### PR TITLE
Hide Problematic Debug Menu Items 

### DIFF
--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -103,71 +103,67 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
       ) : (
         <ScrollView>
           <View style={styles.section}>
-            {/* <DebugMenuListItem
-              label="Reset Exposures"
-              style={styles.lastListItem}
-              onPress={handleOnPressSimulationButton(
-                BTNativeModule.resetExposures,
-              )}
-            /> */}
-          </View>
-          <View style={styles.section}>
-            {/* <DebugMenuListItem
-              label="Detect Exposures Now"
-              onPress={handleOnPressSimulationButton(
-                BTNativeModule.detectExposuresNow,
-              )}
-            /> */}
             <DebugMenuListItem
               label="Show Last Processed File Path"
               onPress={handleOnPressSimulationButton(
                 BTNativeModule.showLastProcessedFilePath,
               )}
             />
-            {/* <DebugMenuListItem
-              label="Simulate Exposure Detection Error"
-              onPress={handleOnPressSimulationButton(
-                BTNativeModule.simulateExposureDetectionError,
-              )}
-            /> */}
-            {/* <DebugMenuListItem
-              label="Simulate Exposure"
-              onPress={handleOnPressSimulationButton(
-                BTNativeModule.simulateExposure,
-              )}
-            /> */}
             <DebugMenuListItem
               label="Show Exposures"
               onPress={() => {
                 navigation.navigate(Screens.ExposureListDebugScreen)
               }}
             />
-            {/* <DebugMenuListItem
-              label="Show Debug Verification Code"
-              onPress={showDebugVerificationCode}
-            /> */}
-            {/* <DebugMenuListItem
-              label="Toggle Exposure Notifications"
-              onPress={handleOnPressSimulationButton(
-                BTNativeModule.toggleExposureNotifications,
-              )}
-            /> */}
-          </View>
-          <View style={styles.section}>
             <DebugMenuListItem
               label="Show Local Diagnosis Keys"
               onPress={() => {
                 navigation.navigate(Screens.ENLocalDiagnosisKey)
               }}
             />
-            {/* <DebugMenuListItem
-              label="Get and Post Diagnosis Keys"
-              style={styles.lastListItem}
-              onPress={handleOnPressSimulationButton(
-                BTNativeModule.submitExposureKeys,
-              )}
-            /> */}
           </View>
+          {__DEV__ ? (
+            <View style={styles.section}>
+              <DebugMenuListItem
+                label="Simulate Exposure"
+                onPress={handleOnPressSimulationButton(
+                  BTNativeModule.simulateExposure,
+                )}
+              />
+              <DebugMenuListItem
+                label="Toggle Exposure Notifications"
+                onPress={handleOnPressSimulationButton(
+                  BTNativeModule.toggleExposureNotifications,
+                )}
+              />
+              <DebugMenuListItem
+                label="Get and Post Diagnosis Keys"
+                style={styles.lastListItem}
+                onPress={handleOnPressSimulationButton(
+                  BTNativeModule.submitExposureKeys,
+                )}
+              />
+              <DebugMenuListItem
+                label="Detect Exposures Now"
+                onPress={handleOnPressSimulationButton(
+                  BTNativeModule.detectExposuresNow,
+                )}
+              />
+              <DebugMenuListItem
+                label="Reset Exposures"
+                style={styles.lastListItem}
+                onPress={handleOnPressSimulationButton(
+                  BTNativeModule.resetExposures,
+                )}
+              />
+              <DebugMenuListItem
+                label="Simulate Exposure Detection Error"
+                onPress={handleOnPressSimulationButton(
+                  BTNativeModule.simulateExposureDetectionError,
+                )}
+              />
+            </View>
+          ) : null}
         </ScrollView>
       )}
     </NavigationBarWrapper>

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -21,8 +21,6 @@ type ENDebugMenuProps = {
   navigation: NavigationProp
 }
 
-const DEBUG_VERIFICATION_CODE = "123456"
-
 const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
   const [loading, setLoading] = useState(false)
   useEffect(() => {
@@ -76,20 +74,6 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
       }
     }
   }
-
-  const showDebugVerificationCode = () => {
-    Alert.alert(
-      "Debug Verification Code:",
-      DEBUG_VERIFICATION_CODE,
-      [
-        {
-          text: "OK",
-        },
-      ],
-      { cancelable: false },
-    )
-  }
-
   interface DebugMenuListItemProps {
     label: string
     onPress: () => void
@@ -119,55 +103,55 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
       ) : (
         <ScrollView>
           <View style={styles.section}>
-            <DebugMenuListItem
+            {/* <DebugMenuListItem
               label="Reset Exposures"
               style={styles.lastListItem}
               onPress={handleOnPressSimulationButton(
                 BTNativeModule.resetExposures,
               )}
-            />
+            /> */}
           </View>
           <View style={styles.section}>
-            <DebugMenuListItem
+            {/* <DebugMenuListItem
               label="Detect Exposures Now"
               onPress={handleOnPressSimulationButton(
                 BTNativeModule.detectExposuresNow,
               )}
-            />
+            /> */}
             <DebugMenuListItem
               label="Show Last Processed File Path"
               onPress={handleOnPressSimulationButton(
                 BTNativeModule.showLastProcessedFilePath,
               )}
             />
-            <DebugMenuListItem
+            {/* <DebugMenuListItem
               label="Simulate Exposure Detection Error"
               onPress={handleOnPressSimulationButton(
                 BTNativeModule.simulateExposureDetectionError,
               )}
-            />
-            <DebugMenuListItem
+            /> */}
+            {/* <DebugMenuListItem
               label="Simulate Exposure"
               onPress={handleOnPressSimulationButton(
                 BTNativeModule.simulateExposure,
               )}
-            />
+            /> */}
             <DebugMenuListItem
               label="Show Exposures"
               onPress={() => {
                 navigation.navigate(Screens.ExposureListDebugScreen)
               }}
             />
-            <DebugMenuListItem
+            {/* <DebugMenuListItem
               label="Show Debug Verification Code"
               onPress={showDebugVerificationCode}
-            />
-            <DebugMenuListItem
+            /> */}
+            {/* <DebugMenuListItem
               label="Toggle Exposure Notifications"
               onPress={handleOnPressSimulationButton(
                 BTNativeModule.toggleExposureNotifications,
               )}
-            />
+            /> */}
           </View>
           <View style={styles.section}>
             <DebugMenuListItem
@@ -176,13 +160,13 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
                 navigation.navigate(Screens.ENLocalDiagnosisKey)
               }}
             />
-            <DebugMenuListItem
+            {/* <DebugMenuListItem
               label="Get and Post Diagnosis Keys"
               style={styles.lastListItem}
               onPress={handleOnPressSimulationButton(
                 BTNativeModule.submitExposureKeys,
               )}
-            />
+            /> */}
           </View>
         </ScrollView>
       )}


### PR DESCRIPTION
### Why
We'd like to prevent testers from manipulating data and producing confusing behavior from the app

### This Commit
This commit hides debug menu items that manipulate local data or make calls to the GAEN server. It leaves in place only the most necessary buttons that are useful in keeping track of local vs server state.

![Screenshot 2020-07-20 at 12 06 55 PM](https://user-images.githubusercontent.com/2637355/87960699-ae79d280-ca82-11ea-8ab2-60be500d7764.jpeg)
