### PR TITLE
Add an await to the call to StorageUtils.getStoreData for Onboarding

### DIFF
--- a/src/OnboardingContext.tsx
+++ b/src/OnboardingContext.tsx
@@ -10,7 +10,7 @@ import { StorageUtils } from "./utils"
 const ONBOARDING_COMPLETE = "ONBOARDING_COMPLETE"
 
 export const isOnboardingComplete = async (): Promise<boolean> => {
-  return Boolean(StorageUtils.getStoreData(ONBOARDING_COMPLETE))
+  return Boolean(await StorageUtils.getStoreData(ONBOARDING_COMPLETE))
 }
 
 interface OnboardingContextState {


### PR DESCRIPTION
#### Description:

The call to local storage was not being awaited, so always returning true. This adds an await to that async call.
