### PR TITLE
Update storage utility helpers

### DIFF
--- a/src/OnboardingContext.tsx
+++ b/src/OnboardingContext.tsx
@@ -7,10 +7,8 @@ import React, {
 
 import { StorageUtils } from "./utils"
 
-const ONBOARDING_COMPLETE = "ONBOARDING_COMPLETE"
-
 export const isOnboardingComplete = async (): Promise<boolean> => {
-  return Boolean(await StorageUtils.getStoreData(ONBOARDING_COMPLETE))
+  return await StorageUtils.getIsOnboardingComplete()
 }
 
 interface OnboardingContextState {
@@ -33,7 +31,7 @@ export const OnboardingProvider: FunctionComponent<OnboardingProviderProps> = ({
   const [isComplete, setIsComplete] = useState<boolean>(onboardingIsComplete)
 
   const setOnboardingIsComplete = () => {
-    StorageUtils.setStoreData(ONBOARDING_COMPLETE, "true")
+    StorageUtils.setIsOnboardingComplete()
     setIsComplete(true)
   }
 

--- a/src/locales/languages.ts
+++ b/src/locales/languages.ts
@@ -30,8 +30,6 @@ import tl from "./tl.json"
 import vi from "./vi.json"
 import zh_Hant from "./zh_Hant.json"
 
-const LANG_OVERRIDE = "LANG_OVERRIDE"
-
 // Refer this for checking the codes and creating new folders https://developer.chrome.com/webstore/i18n
 
 // Adding/updating a language:
@@ -41,11 +39,6 @@ const LANG_OVERRIDE = "LANG_OVERRIDE"
 //
 
 type Locale = string
-
-/** Fetch the user language override, if any */
-export async function getUserLocaleOverride(): Promise<Locale> {
-  return (await StorageUtils.getStoreData(LANG_OVERRIDE)) as Locale
-}
 
 export function getLanguageFromLocale(locale: Locale): Locale {
   const [languageCode] = toIETFLanguageTag(locale).split("-")
@@ -75,7 +68,7 @@ export function useLanguageDirection(): TextDirection {
 
 export async function setUserLocaleOverride(locale: Locale): Promise<void> {
   await setLocale(locale)
-  await StorageUtils.setStoreData(LANG_OVERRIDE, locale)
+  await StorageUtils.setUserLocaleOverride(locale)
 }
 
 /* eslint-disable no-underscore-dangle */
@@ -196,8 +189,11 @@ export function supportedDeviceLanguageOrEnglish(): Locale {
 // detect and set device locale, must go after i18next.init()
 setLocale(supportedDeviceLanguageOrEnglish())
 
+const getUserLocale = async (): Promise<string | null> => {
+  return await StorageUtils.getUserLocaleOverride()
+}
 // detect user override
-getUserLocaleOverride().then((locale) => {
+getUserLocale().then((locale) => {
   if (locale) {
     setLocale(locale)
   }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,37 +1,37 @@
 import AsyncStorage from "@react-native-community/async-storage"
 
-export async function getStoreData(
-  key: string,
-  isString = true,
-): Promise<Record<string, string> | string | null> {
+async function getStoreData(key: string): Promise<string | null> {
   try {
-    const data = await AsyncStorage.getItem(key)
-
-    if (isString) {
-      return data
-    }
-
-    if (data) {
-      return JSON.parse(data)
-    }
-    return null
+    return await AsyncStorage.getItem(key)
   } catch (error) {
     console.log(error.message)
     return null
   }
 }
 
-export async function setStoreData(
-  key: string,
-  item: Record<string, string> | string,
-): Promise<void> {
+async function setStoreData(key: string, item: string): Promise<void> {
   try {
-    if (typeof item !== "string") {
-      item = JSON.stringify(item)
-    }
-
     return await AsyncStorage.setItem(key, item)
   } catch (error) {
     console.log(error.message)
   }
+}
+
+const LANG_OVERRIDE = "LANG_OVERRIDE"
+export async function getUserLocaleOverride(): Promise<string | null> {
+  return await getStoreData(LANG_OVERRIDE)
+}
+
+export async function setUserLocaleOverride(locale: string): Promise<void> {
+  return await setStoreData(LANG_OVERRIDE, locale)
+}
+
+const ONBOARDING_COMPLETE = "ONBOARDING_COMPLETE"
+export async function getIsOnboardingComplete(): Promise<boolean> {
+  const onBoardingComplete = await getStoreData(ONBOARDING_COMPLETE)
+  return onBoardingComplete === ONBOARDING_COMPLETE
+}
+
+export async function setIsOnboardingComplete(): Promise<void> {
+  return setStoreData(ONBOARDING_COMPLETE, ONBOARDING_COMPLETE)
 }


### PR DESCRIPTION
#### Description:

The current getStoreData and setSetStoreData utilities are very generic
so that they can be used for all data types. Since we recently updated the type
annotations of these functions to return a union type instead of `any` (#4),
we had to do some type gymnastics to make the type signatures align for
more specific use cases, such as storing boolean, string, or null
values.

This commit:
Updates the getStoreData and setStoreData functions to have less
responsibility and not be exported from the utils file in favor of more
specific getters and setters. This has the benefit of being more
explicit about what types are returned from this function, how those
type are encoded, and removes the possibility of storing arbitrary data.
It also consolidates the constants used as async storage keys into one
place, which can serve as a source of truth of what data we are storing
to the device.

Co-Authored-By: Alejandro Dustet <alejandro@thoughtbot.com>

#### How to test:

- The app builds and tests pass

