### PR TITLE
Fix navigation error when selecting a language

### DIFF
--- a/src/AffectedUserFlow/index.tsx
+++ b/src/AffectedUserFlow/index.tsx
@@ -12,9 +12,16 @@ import PublishConsent from "./PublishConsent/PublishConsentScreen"
 
 import { Icons } from "../assets"
 import { Colors, Spacing } from "../styles"
-import { Screens } from "../navigation"
+import {
+  Screens,
+  AffectedUserFlowScreen,
+  AffectedUserFlowScreens,
+} from "../navigation"
 
-const Stack = createStackNavigator()
+type AffectedUserFlowStackParams = {
+  [key in AffectedUserFlowScreen]: undefined
+}
+const Stack = createStackNavigator<AffectedUserFlowStackParams>()
 
 const ExportStack = (): JSX.Element => {
   const BackButton = () => {
@@ -48,10 +55,10 @@ const ExportStack = (): JSX.Element => {
           headerShown: false,
           gestureEnabled: false,
         }}
-        initialRouteName={Screens.AffectedUserStart}
+        initialRouteName={AffectedUserFlowScreens.AffectedUserStart}
       >
         <Stack.Screen
-          name={Screens.AffectedUserStart}
+          name={AffectedUserFlowScreens.AffectedUserStart}
           component={Start}
           options={{
             headerTransparent: true,
@@ -59,7 +66,7 @@ const ExportStack = (): JSX.Element => {
           }}
         />
         <Stack.Screen
-          name={Screens.AffectedUserCodeInput}
+          name={AffectedUserFlowScreens.AffectedUserCodeInput}
           component={CodeInput}
           options={{
             headerTransparent: true,
@@ -73,7 +80,7 @@ const ExportStack = (): JSX.Element => {
           }}
         />
         <Stack.Screen
-          name={Screens.AffectedUserPublishConsent}
+          name={AffectedUserFlowScreens.AffectedUserPublishConsent}
           component={PublishConsent}
           options={{
             headerTransparent: true,
@@ -87,7 +94,7 @@ const ExportStack = (): JSX.Element => {
           }}
         />
         <Stack.Screen
-          name={Screens.AffectedUserComplete}
+          name={AffectedUserFlowScreens.AffectedUserComplete}
           component={Complete}
           options={{ headerShown: false }}
         />

--- a/src/navigation/ExposureHistoryStack.tsx
+++ b/src/navigation/ExposureHistoryStack.tsx
@@ -7,9 +7,15 @@ import ExposureHistoryScreen from "../ExposureHistory/index"
 import NextSteps from "../ExposureHistory/NextSteps"
 import MoreInfo from "../ExposureHistory/MoreInfo"
 
-import { Screens } from "./index"
+import {
+  ExposureHistoryScreens,
+  ExposureHistoryScreen as Screen,
+} from "./index"
 
-const Stack = createStackNavigator()
+type ExposureHistoryStackParams = {
+  [key in Screen]: undefined
+}
+const Stack = createStackNavigator<ExposureHistoryStackParams>()
 
 const SCREEN_OPTIONS = {
   headerShown: false,
@@ -34,11 +40,17 @@ const ExposureHistoryStack: FunctionComponent = () => {
       }}
     >
       <Stack.Screen
-        name={Screens.ExposureHistory}
+        name={ExposureHistoryScreens.ExposureHistory}
         component={ExposureHistoryScreen}
       />
-      <Stack.Screen name={Screens.NextSteps} component={NextSteps} />
-      <Stack.Screen name={Screens.MoreInfo} component={MoreInfo} />
+      <Stack.Screen
+        name={ExposureHistoryScreens.NextSteps}
+        component={NextSteps}
+      />
+      <Stack.Screen
+        name={ExposureHistoryScreens.MoreInfo}
+        component={MoreInfo}
+      />
     </Stack.Navigator>
   )
 }

--- a/src/navigation/MoreStack.tsx
+++ b/src/navigation/MoreStack.tsx
@@ -13,28 +13,21 @@ import ENLocalDiagnosisKeyScreen from "../More/ENLocalDiagnosisKeyScreen"
 import ExposureListDebugScreen from "../More/ExposureListDebugScreen"
 import LanguageSelection from "../More/LanguageSelection"
 
-import { Screens, Stacks } from "./index"
+import { MoreStackScreens, MoreStackScreen } from "./index"
 
-const Stack = createStackNavigator()
+type MoreStackScreenParams = {
+  [key in MoreStackScreen]: undefined
+}
+const Stack = createStackNavigator<MoreStackScreenParams>()
 
 const SCREEN_OPTIONS = {
   headerShown: false,
 }
 
-type MoreStackRouteName =
-  | "Settings"
-  | "About"
-  | "Licenses"
-  | "ENDebugMenu"
-  | "LanguageSelection"
-  | "AffectedUserFlow"
-  | "ExposureListDebugScreen"
-  | "ENLocalDiagnosisKey"
-
 interface MoreStackRouteState {
   index: number
   key: string
-  routeNames: MoreStackRouteName[]
+  routeNames: MoreStackScreen[]
   routes: MoreStackRoute[]
   stale: boolean
   type: "stack"
@@ -42,7 +35,7 @@ interface MoreStackRouteState {
 
 export interface MoreStackRoute {
   key: string
-  name: "More"
+  name: MoreStackScreen
   params: undefined
   state?: MoreStackRouteState
 }
@@ -52,7 +45,7 @@ export const determineTabBarVisibility = (route: MoreStackRoute): boolean => {
     const routeState = route.state
     const currentRoute = routeState.routes[routeState.index]
     const routeName = currentRoute.name
-    return routeName != Stacks.AffectedUserFlow
+    return routeName != MoreStackScreens.AffectedUserFlow
   } else {
     return true
   }
@@ -61,16 +54,25 @@ export const determineTabBarVisibility = (route: MoreStackRoute): boolean => {
 const MoreStack: FunctionComponent = () => {
   return (
     <Stack.Navigator screenOptions={SCREEN_OPTIONS}>
-      <Stack.Screen name={Screens.Settings} component={SettingsScreen} />
-      <Stack.Screen name={Screens.About} component={AboutScreen} />
-      <Stack.Screen name={Screens.Licenses} component={LicensesScreen} />
-      <Stack.Screen name={Screens.ENDebugMenu} component={ENDebugMenu} />
       <Stack.Screen
-        name={Screens.LanguageSelection}
+        name={MoreStackScreens.Settings}
+        component={SettingsScreen}
+      />
+      <Stack.Screen name={MoreStackScreens.About} component={AboutScreen} />
+      <Stack.Screen
+        name={MoreStackScreens.Licenses}
+        component={LicensesScreen}
+      />
+      <Stack.Screen
+        name={MoreStackScreens.ENDebugMenu}
+        component={ENDebugMenu}
+      />
+      <Stack.Screen
+        name={MoreStackScreens.LanguageSelection}
         component={LanguageSelection}
       />
       <Stack.Screen
-        name={Stacks.AffectedUserFlow}
+        name={MoreStackScreens.AffectedUserFlow}
         component={AffectedUserStack}
         options={{
           ...TransitionPresets.ModalSlideFromBottomIOS,
@@ -78,11 +80,11 @@ const MoreStack: FunctionComponent = () => {
         }}
       />
       <Stack.Screen
-        name={Screens.ExposureListDebugScreen}
+        name={MoreStackScreens.ExposureListDebugScreen}
         component={ExposureListDebugScreen}
       />
       <Stack.Screen
-        name={Screens.ENLocalDiagnosisKey}
+        name={MoreStackScreens.ENLocalDiagnosisKey}
         component={ENLocalDiagnosisKeyScreen}
       />
     </Stack.Navigator>

--- a/src/navigation/OnboardingStack.tsx
+++ b/src/navigation/OnboardingStack.tsx
@@ -8,30 +8,45 @@ import PersonalPrivacy from "../Onboarding/PersonalPrivacy"
 import NotificationDetails from "../Onboarding/NotificationDetails"
 import ShareDiagnosis from "../Onboarding/ShareDiagnosis"
 
-import { Screens } from "./index"
+import { OnboardingScreen, OnboardingScreens } from "./index"
+import LanguageSelection from "../More/LanguageSelection"
 
 const SCREEN_OPTIONS = {
   headerShown: false,
 }
 
-const Stack = createStackNavigator()
+type OnboardingStackParams = {
+  [key in OnboardingScreen]: undefined
+}
+
+const Stack = createStackNavigator<OnboardingStackParams>()
 
 const OnboardingStack: FunctionComponent = () => (
   <Stack.Navigator screenOptions={SCREEN_OPTIONS}>
-    <Stack.Screen name={Screens.Welcome} component={Welcome} />
-    <Stack.Screen name={Screens.PersonalPrivacy} component={PersonalPrivacy} />
+    <Stack.Screen name={OnboardingScreens.Welcome} component={Welcome} />
     <Stack.Screen
-      name={Screens.NotificationDetails}
+      name={OnboardingScreens.PersonalPrivacy}
+      component={PersonalPrivacy}
+    />
+    <Stack.Screen
+      name={OnboardingScreens.NotificationDetails}
       component={NotificationDetails}
     />
-    <Stack.Screen name={Screens.ShareDiagnosis} component={ShareDiagnosis} />
     <Stack.Screen
-      name={Screens.NotificationPermissions}
+      name={OnboardingScreens.ShareDiagnosis}
+      component={ShareDiagnosis}
+    />
+    <Stack.Screen
+      name={OnboardingScreens.NotificationPermissions}
       component={NotificationPermissions}
     />
     <Stack.Screen
-      name={Screens.EnableExposureNotifications}
+      name={OnboardingScreens.EnableExposureNotifications}
       component={EnableExposureNotifications}
+    />
+    <Stack.Screen
+      name={OnboardingScreens.LanguageSelection}
+      component={LanguageSelection}
     />
   </Stack.Navigator>
 )

--- a/src/navigation/SelfAssessmentStack.tsx
+++ b/src/navigation/SelfAssessmentStack.tsx
@@ -6,9 +6,12 @@ import {
 
 import Assessment from "../SelfAssessment/index"
 
-import { Screens } from "./index"
+import { SelfAssessmentScreen, SelfAssessmentScreens } from "./index"
 
-const Stack = createStackNavigator()
+type SelfAssessmentStackParams = {
+  [key in SelfAssessmentScreen]: undefined
+}
+const Stack = createStackNavigator<SelfAssessmentStackParams>()
 
 const fade = ({ current }: StackCardInterpolationProps) => ({
   cardStyle: { opacity: current.progress },
@@ -27,7 +30,10 @@ const SelfAssessmentStack: FunctionComponent = () => (
       gestureEnabled: false,
     }}
   >
-    <Stack.Screen name={Screens.SelfAssessment} component={Assessment} />
+    <Stack.Screen
+      name={SelfAssessmentScreens.SelfAssessment}
+      component={Assessment}
+    />
   </Stack.Navigator>
 )
 

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -12,57 +12,101 @@ export type NavigationProp = NavigationScreenProp<
   NavigationParams
 >
 
-export type Screen =
-  | "NextSteps"
-  | "MoreInfo"
-  | "ENDebugMenu"
-  | "ENLocalDiagnosisKey"
-  | "ExposureListDebugScreen"
-  | "Settings"
-  | "About"
-  | "Licenses"
+export type OnboardingScreen =
   | "Welcome"
   | "PersonalPrivacy"
   | "NotificationDetails"
   | "ShareDiagnosis"
   | "NotificationPermissions"
   | "EnableExposureNotifications"
-  | "SelfAssessment"
   | "LanguageSelection"
-  | "AffectedUserStart"
-  | "AffectedUserCodeInput"
-  | "AffectedUserPublishConsent"
-  | "AffectedUserConfirmUpload"
-  | "AffectedUserExportDone"
-  | "AffectedUserComplete"
-  | "Home"
-  | "ExposureHistory"
 
-export const Screens: { [key in Screen]: Screen } = {
-  NextSteps: "NextSteps",
-  MoreInfo: "MoreInfo",
-  ENDebugMenu: "ENDebugMenu",
-  ENLocalDiagnosisKey: "ENLocalDiagnosisKey",
-  ExposureListDebugScreen: "ExposureListDebugScreen",
-  Settings: "Settings",
-  About: "About",
-  Licenses: "Licenses",
+export const OnboardingScreens: {
+  [key in OnboardingScreen]: OnboardingScreen
+} = {
   Welcome: "Welcome",
   PersonalPrivacy: "PersonalPrivacy",
   NotificationDetails: "NotificationDetails",
   ShareDiagnosis: "ShareDiagnosis",
   NotificationPermissions: "NotificationPermissions",
   EnableExposureNotifications: "EnableExposureNotifications",
-  SelfAssessment: "SelfAssessment",
   LanguageSelection: "LanguageSelection",
+}
+
+export type ExposureHistoryScreen = "ExposureHistory" | "NextSteps" | "MoreInfo"
+
+export const ExposureHistoryScreens: {
+  [key in ExposureHistoryScreen]: ExposureHistoryScreen
+} = {
+  ExposureHistory: "ExposureHistory",
+  NextSteps: "NextSteps",
+  MoreInfo: "MoreInfo",
+}
+
+export type MoreStackScreen =
+  | "Settings"
+  | "About"
+  | "Licenses"
+  | "ENDebugMenu"
+  | "LanguageSelection"
+  | "AffectedUserFlow"
+  | "ExposureListDebugScreen"
+  | "ENLocalDiagnosisKey"
+
+export const MoreStackScreens: {
+  [key in MoreStackScreen]: MoreStackScreen
+} = {
+  Settings: "Settings",
+  About: "About",
+  Licenses: "Licenses",
+  LanguageSelection: "LanguageSelection",
+  ENDebugMenu: "ENDebugMenu",
+  AffectedUserFlow: "AffectedUserFlow",
+  ENLocalDiagnosisKey: "ENLocalDiagnosisKey",
+  ExposureListDebugScreen: "ExposureListDebugScreen",
+}
+
+export type SelfAssessmentScreen = "SelfAssessment"
+
+export const SelfAssessmentScreens: {
+  [key in SelfAssessmentScreen]: SelfAssessmentScreen
+} = {
+  SelfAssessment: "SelfAssessment",
+}
+
+export type AffectedUserFlowScreen =
+  | "AffectedUserStart"
+  | "AffectedUserCodeInput"
+  | "AffectedUserPublishConsent"
+  | "AffectedUserConfirmUpload"
+  | "AffectedUserExportDone"
+  | "AffectedUserComplete"
+
+export const AffectedUserFlowScreens: {
+  [key in AffectedUserFlowScreen]: AffectedUserFlowScreen
+} = {
   AffectedUserStart: "AffectedUserStart",
   AffectedUserCodeInput: "AffectedUserCodeInput",
   AffectedUserPublishConsent: "AffectedUserPublishConsent",
   AffectedUserConfirmUpload: "AffectedUserConfirmUpload",
   AffectedUserExportDone: "AffectedUserExportDone",
   AffectedUserComplete: "AffectedUserComplete",
+}
+export type Screen =
+  | OnboardingScreen
+  | ExposureHistoryScreen
+  | MoreStackScreen
+  | SelfAssessmentScreen
+  | AffectedUserFlowScreen
+  | "Home"
+
+export const Screens: { [key in Screen]: Screen } = {
+  ...OnboardingScreens,
+  ...ExposureHistoryScreens,
+  ...MoreStackScreens,
+  ...SelfAssessmentScreens,
+  ...AffectedUserFlowScreens,
   Home: "Home",
-  ExposureHistory: "ExposureHistory",
 }
 
 export type Stack =


### PR DESCRIPTION
Why:
As a user just downloading the app, I want to be able to select my
preferred language.

This commit:
Fixes a bug where the LanguageSelection screen was removed from the
stack navigator in the OnboardingStack.

Co-Authored-By: Alejandro Dustet <alejandro@thoughtbot.com>

#### Screenshots:

![bienvenido](https://user-images.githubusercontent.com/21161427/87987620-eac22880-caac-11ea-9b17-ea8e5d61d320.gif)


#### How to test:
- Download a fresh version of the app
- You should be able to switch languages from the welcome screen.
