### PR TITLE
Update dev setup script for env and ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up Ruby 2.6
+      - name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
 
       - name: Install bundler for ruby package management
         run: gem install bundler -v "$(grep -A 1 "BUNDLED WITH" ./Gemfile.lock | tail -n 1)"

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ This project is using [eslint](https://eslint.org/docs/user-guide/getting-starte
 We have linting checks on CI, please make sure to include the checks locally in
 your IDE.
 
+#### Ruby
+
+We use ruby for bin scripts, cocoapods, and fastlane.
+We recommended [asdf](https://asdf-vm.com/#/) as version manager for ruby.
+
 ## Testing
 
 Tests are ran automatically through Github actions - PRs are not able to be merged if there are tests that are failing.

--- a/android/Gemfile
+++ b/android/Gemfile
@@ -1,4 +1,4 @@
-ruby '~> 2.6.3'
+ruby '2.7.1'
 source "https://rubygems.org"
 
 gem "bundler", "=2.1.4"

--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -181,7 +181,7 @@ DEPENDENCIES
   fastlane-plugin-load_json
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.4

--- a/bin/dev_setup.sh
+++ b/bin/dev_setup.sh
@@ -95,6 +95,18 @@ function get_YN() { # helper function for interactive questions
 ###############################################################################
 ## Main setup
 
+printf "Setting up configurable environment variables...\n"
+printf "$spacer"
+if [ ! -f .env ]; then
+  cp example.env .env
+fi
+
+printf "$spacer"
+if [ ! -f .env.bt ]; then
+  cp example.env.bt .env.bt
+  cp example.env.bt .env.bt.release
+fi
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
   if ! found_exe brew; then
     echo "${YELLOW}Homebrew is required to install dependencies: https://docs.brew.sh/Installation${RESET}"


### PR DESCRIPTION
Why:
We would like the dev setup script to automatically copy .env and
.env.bt if the root directory doesnt already have those files. Also we
would like for android and github actions to be using the most recent
version of ruby, 2.7.1