### PR TITLE
Broadcast enabled status on entering foreground

### DIFF
--- a/ios/AppDelegate.m
+++ b/ios/AppDelegate.m
@@ -44,8 +44,16 @@
   // Schedule background task
   [[ExposureManager shared] scheduleBackgroundTaskIfNeeded];
 
+  // Broadcase EN Status
+  [[ExposureManager shared] broadcastCurrentEnabledStatus];
+
   [RNSplashScreen showSplash:@"LaunchScreen" inRootView:rootView];
   return YES;
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+  [[ExposureManager shared] broadcastCurrentEnabledStatus];
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -245,7 +245,7 @@ PODS:
     - React
   - RNCAsyncStorage (1.10.0):
     - React
-  - RNCMaskedView (0.1.5):
+  - RNCMaskedView (0.1.10):
     - React
   - RNCPushNotificationIOS (1.4.0):
     - React
@@ -472,7 +472,7 @@ SPEC CHECKSUMS:
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
   RNBackgroundFetch: 388cf1595934d22fed275b8db9b48a28bb4eb7b6
   RNCAsyncStorage: 6d99641f8e6f15d169d695d8ef184bf187903f11
-  RNCMaskedView: dd13f9f7b146a9ad82f9b7eb6c9b5548fcf6e990
+  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPushNotificationIOS: dc1c0c6aa18a128df123598149f42e848d26a4ac
   RNDateTimePicker: 4bd49e09f91ca73d69119a9e1173b0d43b82f5e5
   RNFS: 2bd9eb49dc82fa9676382f0585b992c424cd59df

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -108,11 +108,7 @@ const PermissionsProvider: FunctionComponent<PermissionsProviderProps> = ({
   }
 
   const requestENPermission = () => {
-    const handleNativeResponse = (response: string) => {
-      if (response === "success") {
-        setExposureNotificationsPermission(["AUTHORIZED", "ENABLED"])
-      }
-    }
+    const handleNativeResponse = () => {}
     permissionStrategy.request(handleNativeResponse)
   }
 


### PR DESCRIPTION
Why:
We currently have a bug in which the app will not register if it lost
exposure notification permissions if is backgrounded. So we get into a
state where the app says it has permissions when it does not.

This commit:
Add logic to eamit an event of the current status when the app will be
foregrounded and fixes a bug in the event data structure.

Co-Authored-By: johnschoeman <johnschoeman1617@gmail.com>