### PR TITLE
Add script to update display names before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Generating a release build is an optional step in the development process.
 
 - [Android instructions](https://reactnative.dev/docs/signed-apk-android)
 
+**Note:** Members of the `Path-Check` org should update the environment variables of the release build corresponding with the health authority, for this we need to execute the script `bin/set_ha.sh ${HA_LABEL}` where HA_LABEL is the corresponding health authority label. This will setup the values for the display name of the applications and will ensure that we are working with the latest configuration.
+
 ### Debugging
 
 [react-native-debugger](https://github.com/jhen0409/react-native-debugger) is recommended. This tool will provide visibility of the JSX hierarchy, breakpoint usage, monitoring of network calls, and other common debugging tasks.

--- a/bin/fetch_ha_env.sh
+++ b/bin/fetch_ha_env.sh
@@ -28,13 +28,13 @@ def fetch_env
   if !valid_token(token) then
     puts "No valid github token set"
     puts "Set a valid token in your .env file"
-    exit
+    exit 1
   end
 
   if !HA_LABEL then
     puts "No HA label provided"
     puts "provide a label as a parameter e.g. $ bin/fetch_ha_env.sh pc"
-    exit
+    exit 1
   end
 
   puts "...fetching .env for #{HA_LABEL}"
@@ -63,7 +63,7 @@ def fetch_and_write_file(filename, remote_url)
   open(filename, 'w') do |f|
     Open3.popen2e("curl", "-s", remote_url) do |_, stdout_and_err, wait_thr|
       stdout_and_err.each do |line|
-        f << line 
+        f << line
       end
       wait_thr.value
     end
@@ -71,7 +71,7 @@ def fetch_and_write_file(filename, remote_url)
   print "."
 end
 
-def valid_token(token) 
+def valid_token(token)
   token.length == 40
 end
 

--- a/bin/set_display_names.sh
+++ b/bin/set_display_names.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+#
+# Update the applications display name based on the release env file
+#
+# Usage
+#
+#   bin/set_display_names <?env>
+#
+# Example
+#
+#   bin/fetch_env
+#
+# Requirements
+#
+# 1. An .env.bt.release file in the root folder or an existing environment file
+# in the route of the argument
+
+require 'dotenv'
+require 'open3'
+
+# Constants
+ENV_FILE = ARGV[0] || ".env.bt.release"
+DISPLAY_NAME_KEY = "DISPLAY_NAME"
+PLIST_PATH = "./ios/BT/Info.plist"
+ANDROID_STRINGS_PATH="./android/app/src/bt/res/values/strings.xml"
+SEPARATOR = "##################################################################"
+
+def get_current_ios_name
+  output, error, status = Open3.capture3(
+    "/usr/libexec/PlistBuddy -c \"Print :CFBundleDisplayName\" \"#{PLIST_PATH}\""
+  )
+  if status.success?
+    output.gsub(/\R+/, "")
+  else
+    puts "Could not read ios current name from file #{PLIST_PATH}, error: #{error}"
+    exit 1
+  end
+end
+
+def update_ios_display_name(new_name)
+  puts "Updating ios display name from #{get_current_ios_name} to #{new_name}"
+  output, error, status = Open3.capture3(
+    "/usr/libexec/PlistBuddy -c \"Set :CFBundleDisplayName #{new_name}\" \"#{PLIST_PATH}\""
+  )
+  return if status.success?
+  puts "Failed to update the name of the ios app with error: #{output}"
+  exit 1
+end
+
+def get_current_android_name
+  output, error, status = Open3.capture3(
+    "xmllint --xpath \"/resources/string[@name='app_name']/text()\" #{ANDROID_STRINGS_PATH}"
+  )
+  if status.success?
+    output
+  else
+    puts "Could not read android current name from file #{ANDROID_STRINGS_PATH}, error: #{error}"
+    exit 1
+  end
+end
+
+def update_android_display_name(new_name)
+  puts "Updating android display name from #{get_current_android_name} to #{new_name}"
+  _output, error, status = Open3.capture3(
+"xmllint --shell #{ANDROID_STRINGS_PATH} << EOF
+cd /resources/string[@name='app_name']
+set #{new_name}
+save
+EOF
+"
+  )
+  return if status.success?
+  puts "Failed to update the name of the android app with error: #{error}"
+  exit 1
+end
+
+def update_application_display_name
+  environment = Dotenv.parse(File.open(ENV_FILE))
+  display_name = environment.fetch(DISPLAY_NAME_KEY, false)
+
+  if display_name
+    update_ios_display_name(display_name)
+    update_android_display_name(display_name)
+    puts SEPARATOR
+    puts "All done!"
+  else
+    puts "#{DISPLAY_NAME_KEY} not provided on #{ENV_FILE}"
+  end
+end
+
+if File.exist?(ENV_FILE)
+  update_application_display_name
+else
+  puts "#{ENV_FILE} not found on the root folder, environment file is needed"
+end

--- a/bin/set_ha.sh
+++ b/bin/set_ha.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+#
+# Fetch the HA data and sets the display names on the ios and android builds
+#
+# Usage
+#
+#   bin/fetch_env <health-authority-label>
+#
+# Example
+#
+#   bin/set_ha pc
+#
+# Requirements
+#
+# 1. Remote access to the environment repo
+# 2. A github personal access token saved in `.env`:
+#    https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
+
+require 'open3'
+
+HA_LABEL = ARGV[0]
+
+fetching_env_succeeded = system("./bin/fetch_ha_env.sh #{HA_LABEL}")
+
+fetching_env_succeeded && system("./bin/set_display_names.sh")


### PR DESCRIPTION
Why:
----
Each HA will have a unique display name they want shown on the application that gets released to the final user. We need a way to update this properties before cutting a production build

This Commit:
----
- Add a script that uses the libraries `PlistBuddy` and `xmllint` to edit the `Info.plist` for the iOS application and the `strings.xml` for the android application

How to test:
----
- After executing the `fetch_ha_env` script run `./set_display_name.sh` and verify that the names have been updated for both applications.

