### PR TITLE
Fix build regressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,17 +2,13 @@
  * @format
  */
 
-import NetInfo from '@react-native-community/netinfo';
-import { AppRegistry } from 'react-native';
+import NetInfo from "@react-native-community/netinfo"
+import { AppRegistry } from "react-native"
 
-import App from './App';
-import { name as appName } from './app.json';
+import App from "./App"
+import { name as appName } from "./app.json"
 
-AppRegistry.registerComponent(appName, () => App);
-
-if (__DEV__) {
-  import('./reactotron.config');
-}
+AppRegistry.registerComponent(appName, () => App)
 
 NetInfo.configure({
   // interval to check for internet reachability if was reachable
@@ -21,4 +17,4 @@ NetInfo.configure({
   reachabilityShortTimeout: 60 * 1000, // 60s
   // internet reachability request timeout
   reachabilityRequestTimeout: 5 * 1000, // 5s
-});
+})


### PR DESCRIPTION
Why:
A previous commit removed unused things, but not all so the build step
was broken.

This commit:
Fully removes reactotron.