### PR TITLE
Update ruby version to use a uniform one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,11 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile
 
+      - name: Set up Ruby 2.7
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
       - name: Cache ruby gems
         uses: actions/cache@v1
         with:

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,4 +1,4 @@
-ruby '~> 2.6.3'
+ruby '~> 2.7.1'
 source "https://rubygems.org"
 
 gem "bundler", "=2.1.4"

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -244,7 +244,7 @@ DEPENDENCIES
   fastlane-plugin-load_json
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
Why:
----
The ruby versions for our ios project and the ruby version we are using
for running scripts differ from each other, this causes some
miss-matching on environments and headaches for maintainability.

This Commit:
----
- Update ruby version used on ios project
- Fix same ruby version for our github workflows
