### PR TITLE
Convert AssessmentOption to TypeScript

### DIFF
--- a/src/SelfAssessment/AssessmentOption.spec.tsx
+++ b/src/SelfAssessment/AssessmentOption.spec.tsx
@@ -22,7 +22,9 @@ describe("AssessmentOption", () => {
           label,
           value,
         }}
-        type={SCREEN_TYPE_CHECKBOX}
+        optionType={SCREEN_TYPE_CHECKBOX}
+        isSelected={false}
+        answer={{ index: 1, value }}
       />,
     )
 
@@ -44,7 +46,9 @@ describe("AssessmentOption", () => {
           label,
           value,
         }}
-        type={SCREEN_TYPE_RADIO}
+        isSelected={false}
+        answer={{ index: 1, value }}
+        optionType={SCREEN_TYPE_RADIO}
       />,
     )
 
@@ -65,7 +69,9 @@ describe("AssessmentOption", () => {
             label,
             value: "Value",
           }}
-          type={SCREEN_TYPE_DATE}
+          optionType={SCREEN_TYPE_DATE}
+          isSelected={false}
+          answer={{ index: 1, value: "value" }}
         />,
       )
       expect(getByText("label")).toBeDefined()
@@ -80,7 +86,9 @@ describe("AssessmentOption", () => {
             label: "Label",
             value: "Value",
           }}
-          type={SCREEN_TYPE_DATE}
+          optionType={SCREEN_TYPE_DATE}
+          isSelected={false}
+          answer={{ index: 1, value: "value" }}
         />,
       )
 
@@ -108,7 +116,9 @@ describe("AssessmentOption", () => {
               label: "Label",
               value: "Value",
             }}
-            type={SCREEN_TYPE_DATE}
+            optionType={SCREEN_TYPE_DATE}
+            isSelected={false}
+            answer={{ index: 1, value: "value" }}
           />,
         )
 

--- a/src/SelfAssessment/AssessmentOption.tsx
+++ b/src/SelfAssessment/AssessmentOption.tsx
@@ -1,5 +1,11 @@
 import DateTimePicker from "@react-native-community/datetimepicker"
-import React, { Fragment, useEffect, useMemo, useState } from "react"
+import React, {
+  Fragment,
+  useEffect,
+  useMemo,
+  useState,
+  FunctionComponent,
+} from "react"
 
 import Option from "./Option"
 import { isPlatformAndroid, isPlatformiOS } from "../utils/index"
@@ -9,32 +15,39 @@ import {
   SCREEN_TYPE_RADIO,
 } from "./constants"
 
-/**
- * @typedef { import(".").SurveyAnswers } SurveyAnswers
- * @typedef { import(".").SurveyOption["values"][0] } SurveyOptionValue
- */
+type SelfAssessmentAnswer = {
+  index: number
+  value: string
+}
 
-/** @type {React.FunctionComponent<{
- *   answer?: SurveyAnswers[0][0];
- *   index: number;
- *   onSelect: (value: string) => void;
- *   option: SurveyOptionValue;
- *   selected: boolean;
- *   type: Extract<SurveyScreen, 'Checkbox' | 'Date' | 'Radio'>
- * }>} */
-export const AssessmentOption = ({
+type SelfAssessmentOption = {
+  description?: string
+  label: string
+  value: string
+}
+
+interface AssessmentOptionProps {
+  answer: SelfAssessmentAnswer
+  index: number
+  onSelect: (value: string) => void
+  option: SelfAssessmentOption
+  isSelected: boolean
+  optionType: string
+}
+
+const AssessmentOption: FunctionComponent<AssessmentOptionProps> = ({
   answer,
   index,
   onSelect,
   option,
   isSelected,
-  type,
+  optionType,
 }) => {
   // The API doesn't have a defined way to know a specific option is a date,
   // we just assume the first option is the date picker when type is SCREEN_TYPE_DATE
-  const isDateOption = type === SCREEN_TYPE_DATE && index === 0
+  const isDateOption = optionType === SCREEN_TYPE_DATE && index === 0
   const typeArray = [SCREEN_TYPE_CHECKBOX, SCREEN_TYPE_RADIO, SCREEN_TYPE_DATE]
-  const isValidType = typeArray.includes(type)
+  const isValidType = typeArray.includes(optionType)
   const [showDatePicker, setShowDatePicker] = useState(false)
 
   const [date, setDate] = useState(() =>
@@ -56,7 +69,7 @@ export const AssessmentOption = ({
 
   const handleOnPress = () => {
     if (isDateOption) {
-      let date = new Date()
+      const date = new Date()
       setDate(date)
       setShowDatePicker(true)
       if (isPlatformiOS()) onSelect(date.toDateString())
@@ -65,7 +78,7 @@ export const AssessmentOption = ({
     onSelect(option.value)
   }
 
-  const handleDateTimePickerSelect = (e, date) => {
+  const handleDateTimePickerSelect = (_event: Event, date?: Date) => {
     if (date) {
       if (isPlatformAndroid()) setShowDatePicker(false)
       onSelect(date.toDateString())
@@ -80,9 +93,8 @@ export const AssessmentOption = ({
         testID="option"
         isValidType={isValidType}
         isSelected={isSelected}
-        inputType={type}
+        inputType={optionType}
         title={label}
-        description={option.description}
       />
       {showDatePicker && (
         <DateTimePicker
@@ -92,9 +104,11 @@ export const AssessmentOption = ({
           onChange={handleDateTimePickerSelect}
           timeZoneOffsetInMinutes={0}
           testID="datepicker"
-          value={date}
+          value={date || new Date()}
         />
       )}
     </Fragment>
   )
 }
+
+export { AssessmentOption }

--- a/src/SelfAssessment/AssessmentQuestion.js
+++ b/src/SelfAssessment/AssessmentQuestion.js
@@ -71,7 +71,7 @@ export const AssessmentQuestion = ({ onNext, onChange, option, question }) => {
         onSelect={(value) => onSelectHandler(value, index)}
         option={option}
         isSelected={selectedValues.some((v) => v.index === index)}
-        type={question.screen_type}
+        optionType={question.screen_type}
       />
     ))
 

--- a/src/SelfAssessment/Option.tsx
+++ b/src/SelfAssessment/Option.tsx
@@ -18,6 +18,7 @@ interface OptionProps {
   inputType: string
   title: string
   onPress: () => void
+  testID?: string
 }
 
 const Option: FunctionComponent<OptionProps> = ({
@@ -26,9 +27,10 @@ const Option: FunctionComponent<OptionProps> = ({
   inputType,
   title,
   onPress,
+  testID,
 }) => {
   return (
-    <TouchableOpacity onPress={onPress} testID="option">
+    <TouchableOpacity onPress={onPress} testID={testID || "option"}>
       <View style={[styles.container, isSelected && styles.containerSelected]}>
         <OptionSelect
           wrapperStyle={styles.primary}


### PR DESCRIPTION
Why:
----
We would like to have all of our files using typescript.

This Commit:
----
- Convert the AssessmentOption file to TypeScript

Reviewers:
----
This is a major effort around converting the files into TypeScript, this is one commit of many, we are focusing first on having an integrated type system and then we can tackle the behavior of these components.