### PR TITLE
Update splash screen image

### DIFF
--- a/ios/COVIDSafePaths/Base.lproj/LaunchScreen.xib
+++ b/ios/COVIDSafePaths/Base.lproj/LaunchScreen.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,21 +12,12 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bgImage" translatesAutoresizingMaskIntoConstraints="NO" id="q8g-oj-mOm">
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BgImage" translatesAutoresizingMaskIntoConstraints="NO" id="q8g-oj-mOm">
                     <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
-                </imageView>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logoImage" translatesAutoresizingMaskIntoConstraints="NO" id="4lR-aC-tf0">
-                    <rect key="frame" x="108.66666666666669" y="159" width="263" height="162"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="263" id="Fi6-c7-kB3"/>
-                        <constraint firstAttribute="height" constant="162" id="Ptv-Dm-eKH"/>
-                    </constraints>
                 </imageView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="4lR-aC-tf0" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="7Eo-BH-2aa"/>
-                <constraint firstItem="4lR-aC-tf0" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="Vml-xp-im1"/>
                 <constraint firstAttribute="trailing" secondItem="q8g-oj-mOm" secondAttribute="trailing" id="eLU-6Q-dhg"/>
                 <constraint firstItem="q8g-oj-mOm" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="ulo-5x-fqz"/>
                 <constraint firstAttribute="bottom" secondItem="q8g-oj-mOm" secondAttribute="bottom" id="weB-dv-ieB"/>
@@ -39,7 +29,6 @@
         </view>
     </objects>
     <resources>
-        <image name="bgImage" width="375" height="812"/>
-        <image name="logoImage" width="237" height="237"/>
+        <image name="BgImage" width="375" height="812"/>
     </resources>
 </document>


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

Update the splash screen image in Xcode to match the updated and approved mockups.

#### Linked issues:

https://trello.com/c/l201ai4o

#### Screenshots:

<img width="357" alt="Screen Shot 2020-07-23 at 12 19 25 PM" src="https://user-images.githubusercontent.com/2924479/88311466-e5e4bb00-ccde-11ea-8c22-dc1fa1565b6b.png">


#### How to test:

1. Run a fresh install of the app locally.
2. Ensure the splash screen matches the attached screenshot.

Co-authored-by: tparesi <tparesi@gmail.com>
