### PR TITLE
Fix behavior leaving a string instead of a boolean

### DIFF
--- a/src/ExposureHistory/ExposureDatumDetail.tsx
+++ b/src/ExposureHistory/ExposureDatumDetail.tsx
@@ -42,8 +42,9 @@ const PossibleExposureDetail = ({
   const exposureDurationText = DateTimeUtils.durationToString(duration)
   const navigation = useNavigation()
   const { t } = useTranslation()
-  const displayNextSteps =
-    env.DISPLAY_SELF_ASSESSMENT === "true" || env.AUTHORITY_ADVICE_URL
+  const displayNextSteps = Boolean(
+    env.DISPLAY_SELF_ASSESSMENT === "true" || env.AUTHORITY_ADVICE_URL,
+  )
   const exposureDate = dayjs(date).format("dddd, MMM DD")
   const exposureTime = t("exposure_datum.possible.duration", {
     duration: exposureDurationText,

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -22,8 +22,9 @@ const SCREEN_OPTIONS = {
 
 const MainNavigator: FunctionComponent = () => {
   const { onboardingIsComplete } = useOnboardingContext()
-  const displayNextSteps =
-    env.DISPLAY_SELF_ASSESSMENT === "true" || env.AUTHORITY_ADVICE_URL
+  const displayNextSteps = Boolean(
+    env.DISPLAY_SELF_ASSESSMENT === "true" || env.AUTHORITY_ADVICE_URL,
+  )
 
   return (
     <NavigationContainer>


### PR DESCRIPTION
Why:
----
When we render the navigators, the logic gate is being run against a variable that can be assigned as a string if both environment variables are present. We need to treat it as a boolean check to avoid rendering errors on the Navigator component.

This Commit:
----
- Casts environment variables check to determine whether to display the self assessment as boolean