### PR TITLE
Add silent option to curl on fetch script

### DIFF
--- a/bin/fetch_ha_env.sh
+++ b/bin/fetch_ha_env.sh
@@ -61,10 +61,10 @@ end
 
 def fetch_and_write_file(filename, remote_url)
   open(filename, 'w') do |f|
-    Open3.popen2e("curl", "-f", remote_url) do |_, stdout_and_err, wait_thr|
+    Open3.popen2e("curl", "-f", "-s", remote_url) do |_, stdout_and_err, wait_thr|
       if wait_thr.value.exitstatus != 0
         abort("Fetch failed")
-      end 
+      end
       stdout_and_err.each do |line|
         f << line
       end

--- a/bin/fetch_ha_env_github.sh
+++ b/bin/fetch_ha_env_github.sh
@@ -23,12 +23,12 @@ end
 
 def fetch_and_write_file(filename, remote_url)
   open(filename, 'w') do |f|
-    Open3.popen2e("curl", "-f", remote_url) do |_, stdout_and_err, wait_thr|
+    Open3.popen2e("curl", "-f", "-s", remote_url) do |_, stdout_and_err, wait_thr|
       if wait_thr.value.exitstatus != 0
         abort("Fetch failed")
-      end 
+      end
       stdout_and_err.each do |line|
-        f << line 
+        f << line
       end
       wait_thr.value
     end


### PR DESCRIPTION
Why:
----
When we pull the scripts without the silent option, the output from the download is included on the response, and it is being copied to the `.env` file.

This Commit:
----
- Add the silent option to the curl script