### PR TITLE
Convert SelfAssessment/Info to TypeScript

### DIFF
--- a/src/SelfAssessment/Agreement.js
+++ b/src/SelfAssessment/Agreement.js
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { InfoText } from "./InfoText"
 import { Button } from "../components/Button"
-import { Info } from "./Info"
+import { AssessmentLayout } from "./AssessmentLayout"
 import { RTLEnabledText } from "../components/RTLEnabledText"
 
 import { Colors, Typography } from "../styles"
@@ -17,7 +17,7 @@ export const Agreement = ({ navigation }) => {
   const handleAgreementPress = () => navigation.push("EmergencyAssessment")
 
   return (
-    <Info
+    <AssessmentLayout
       backgroundColor={Colors.invertedPrimaryBackground}
       icon={Icons.SelfAssessment}
       footer={
@@ -32,7 +32,7 @@ export const Agreement = ({ navigation }) => {
         title={t("assessment.agreement_title")}
         description={t("assessment.agreement_description")}
       />
-    </Info>
+    </AssessmentLayout>
   )
 }
 

--- a/src/SelfAssessment/AssessmentLayout.spec.tsx
+++ b/src/SelfAssessment/AssessmentLayout.spec.tsx
@@ -2,20 +2,26 @@ import { render } from "@testing-library/react-native"
 import React from "react"
 import { View } from "react-native"
 
-import { Info } from "./Info"
+import { AssessmentLayout } from "./AssessmentLayout"
 
-describe("Info", () => {
+describe("AssessmentLayout", () => {
   it("renders it's children component", () => {
     const { getByTestId } = render(
-      <Info>
+      <AssessmentLayout backgroundColor="color" footer="ReactNode" icon="icon">
         <View testID="children" />
-      </Info>,
+      </AssessmentLayout>,
     )
     expect(getByTestId("children")).toBeTruthy()
   })
 
   it("renders the footer component", () => {
-    const { getByTestId } = render(<Info footer={<View testID="footer" />} />)
+    const { getByTestId } = render(
+      <AssessmentLayout
+        footer={<View testID="footer" />}
+        backgroundColor="color"
+        icon="icon"
+      />,
+    )
     expect(getByTestId("footer")).toBeTruthy()
   })
 })

--- a/src/SelfAssessment/AssessmentLayout.tsx
+++ b/src/SelfAssessment/AssessmentLayout.tsx
@@ -1,29 +1,28 @@
-import React from "react"
+import React, { FunctionComponent, ReactNode } from "react"
 import {
   ImageBackground,
   SafeAreaView,
   ScrollView,
   StyleSheet,
   View,
+  ViewStyle,
+  ImageSourcePropType,
 } from "react-native"
 import { SvgXml } from "react-native-svg"
 
-/**
- * @typedef { import("react").ReactNode } ReactNode
- */
+const NO_IMAGE_BACKGROUND = 0
 
-/** @type {React.FunctionComponent<{
- *   ctaAction?: () => void;
- *   ctaColor?: string;
- *   ctaTitle?: string;
- *   description?: ReactNode;
- *   footer?: ReactNode;
- *   image: string;
- *   title: string;
- * }>} */
-export const Info = ({
+type AssessmentLayoutProps = {
+  backgroundColor: string
+  backgroundImage?: ImageSourcePropType
+  scrollStyle?: ViewStyle
+  footer: ReactNode
+  icon: string
+}
+
+const AssessmentLayout: FunctionComponent<AssessmentLayoutProps> = ({
   backgroundColor,
-  backgroundImage,
+  backgroundImage = NO_IMAGE_BACKGROUND,
   children,
   scrollStyle,
   footer,
@@ -31,8 +30,10 @@ export const Info = ({
 }) => {
   return (
     <SafeAreaView
-      backgroundColor={backgroundColor}
-      style={assessmentStyles.container}
+      style={{
+        ...assessmentStyles.container,
+        backgroundColor: backgroundColor,
+      }}
     >
       <ImageBackground
         source={backgroundImage}
@@ -72,3 +73,5 @@ export const assessmentStyles = StyleSheet.create({
     padding: 20,
   },
 })
+
+export { AssessmentLayout }

--- a/src/SelfAssessment/AssessmentStart.js
+++ b/src/SelfAssessment/AssessmentStart.js
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { InfoText } from "./InfoText"
 import { Button } from "../components/Button"
-import { Info } from "./Info"
+import { AssessmentLayout } from "./AssessmentLayout"
 
 import { Colors } from "../styles"
 import { Icons, Images } from "../assets"
@@ -16,7 +16,7 @@ export const AssessmentStart = ({ navigation }) => {
   const handleButtonPress = () => navigation.push("Agreement")
 
   return (
-    <Info
+    <AssessmentLayout
       backgroundColor={Colors.surveyPrimaryBackground}
       backgroundImage={Images.EmptyPathBackground}
       icon={Icons.SelfAssessment}
@@ -33,7 +33,7 @@ export const AssessmentStart = ({ navigation }) => {
         title={t("assessment.start_title")}
         description={t("assessment.start_description")}
       />
-    </Info>
+    </AssessmentLayout>
   )
 }
 

--- a/src/SelfAssessment/EmergencyAssessment.js
+++ b/src/SelfAssessment/EmergencyAssessment.js
@@ -7,7 +7,7 @@ import {
   SCREEN_TYPE_RADIO,
   SCREEN_TYPE_EMERGENCY,
 } from "./constants"
-import { Info } from "./Info"
+import { AssessmentLayout } from "./AssessmentLayout"
 import { InfoText } from "./InfoText"
 import { RTLEnabledText } from "../components/RTLEnabledText"
 
@@ -29,7 +29,7 @@ export const EmergencyAssessment = ({ navigation }) => {
   }
 
   return (
-    <Info
+    <AssessmentLayout
       backgroundColor={Colors.surveyPrimaryBackground}
       footer={
         <ChoiceButtons
@@ -43,7 +43,7 @@ export const EmergencyAssessment = ({ navigation }) => {
         title={t("assessment.agree_question_text")}
         description={t("assessment.agree_question_description")}
       />
-    </Info>
+    </AssessmentLayout>
   )
 }
 

--- a/src/SelfAssessment/endScreens/AssessmentComplete.js
+++ b/src/SelfAssessment/endScreens/AssessmentComplete.js
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { Icons, Images } from "../../assets"
 import { AssessmentNavigationContext } from "../Context"
-import { Info } from "../Info"
+import { AssessmentLayout } from "../AssessmentLayout"
 import { InfoText } from "../InfoText"
 import { Button } from "../../components/Button"
 
@@ -16,7 +16,7 @@ export const AssessmentComplete = () => {
   const { dismiss } = useContext(AssessmentNavigationContext)
 
   return (
-    <Info
+    <AssessmentLayout
       backgroundColor={Colors.primaryBackgroundFaintShade}
       backgroundImage={Images.EmptyPathBackground}
       icon={Icons.SelfAssessment}
@@ -34,7 +34,7 @@ export const AssessmentComplete = () => {
         title={t("assessment.complete_title")}
         description={t("assessment.complete_description")}
       />
-    </Info>
+    </AssessmentLayout>
   )
 }
 

--- a/src/SelfAssessment/endScreens/Caregiver.js
+++ b/src/SelfAssessment/endScreens/Caregiver.js
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { StyleSheet } from "react-native"
 
 import { AssessmentNavigationContext } from "../Context"
-import { Info } from "../Info"
+import { AssessmentLayout } from "../AssessmentLayout"
 import { InfoText } from "../InfoText"
 import { Button } from "../../components/Button"
 
@@ -18,7 +18,7 @@ export const Caregiver = ({ navigation }) => {
   const handleButtonPress = () => navigation.push(completeRoute)
 
   return (
-    <Info
+    <AssessmentLayout
       backgroundColor={Colors.primaryBackgroundFaintShade}
       backgroundImage={Images.IsolatePathBackground}
       icon={Icons.Isolate}
@@ -36,7 +36,7 @@ export const Caregiver = ({ navigation }) => {
         title={t("assessment.caregiver_title")}
         description={t("assessment.caregiver_description")}
       />
-    </Info>
+    </AssessmentLayout>
   )
 }
 

--- a/src/SelfAssessment/endScreens/Distancing.js
+++ b/src/SelfAssessment/endScreens/Distancing.js
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { StyleSheet } from "react-native"
 
 import { AssessmentNavigationContext } from "../Context"
-import { Info } from "../Info"
+import { AssessmentLayout } from "../AssessmentLayout"
 import { InfoText } from "../InfoText"
 import { Button } from "../../components/Button"
 
@@ -18,7 +18,7 @@ export const Distancing = ({ navigation }) => {
   const handleButtonPress = () => navigation.push(completeRoute)
 
   return (
-    <Info
+    <AssessmentLayout
       backgroundColor={Colors.primaryBackgroundFaintShade}
       backgroundImage={Images.IsolatePathBackground}
       icon={Icons.Isolate}
@@ -36,7 +36,7 @@ export const Distancing = ({ navigation }) => {
         title={t("assessment.distancing_title")}
         description={t("assessment.distancing_description")}
       />
-    </Info>
+    </AssessmentLayout>
   )
 }
 

--- a/src/SelfAssessment/endScreens/Emergency.js
+++ b/src/SelfAssessment/endScreens/Emergency.js
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Linking, StyleSheet } from "react-native"
 
 import { Button } from "../../components/Button"
-import { Info } from "../Info"
+import { AssessmentLayout } from "../AssessmentLayout"
 import { InfoText } from "../InfoText"
 
 import { Icons } from "../../assets"
@@ -17,7 +17,7 @@ export const Emergency = () => {
   const handleOnPress = () => Linking.openURL("tel://911")
 
   return (
-    <Info
+    <AssessmentLayout
       backgroundColor={Colors.primaryBackgroundFaintShade}
       icon={Icons.SelfAssessment} // TODO: Placeholder, replace when we get icon
       scrollStyle={styles.containerItemsAlignment}
@@ -35,7 +35,7 @@ export const Emergency = () => {
         title={t("assessment.emergency_title")}
         description={t("assessment.emergency_description")}
       />
-    </Info>
+    </AssessmentLayout>
   )
 }
 

--- a/src/SelfAssessment/endScreens/Isolate.js
+++ b/src/SelfAssessment/endScreens/Isolate.js
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { StyleSheet } from "react-native"
 
 import { AssessmentNavigationContext } from "../Context"
-import { Info } from "../Info"
+import { AssessmentLayout } from "../AssessmentLayout"
 import { InfoText } from "../InfoText"
 import { Button } from "../../components/Button"
 
@@ -18,7 +18,7 @@ export const Isolate = ({ navigation }) => {
   const handleButtonPress = () => navigation.push(completeRoute)
 
   return (
-    <Info
+    <AssessmentLayout
       backgroundColor={Colors.primaryBackgroundFaintShade}
       backgroundImage={Images.IsolatePathBackground}
       icon={Icons.Isolate}
@@ -36,7 +36,7 @@ export const Isolate = ({ navigation }) => {
         title={t("assessment.isolate_title")}
         description={t("assessment.isolate_description")}
       />
-    </Info>
+    </AssessmentLayout>
   )
 }
 

--- a/src/SelfAssessment/endScreens/Share.js
+++ b/src/SelfAssessment/endScreens/Share.js
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import env from "react-native-config"
 import { StyleSheet } from "react-native"
 
-import { Info } from "../Info"
+import { AssessmentLayout } from "../AssessmentLayout"
 import { InfoText } from "../InfoText"
 import { Button } from "../../components/Button"
 
@@ -20,7 +20,7 @@ export const Share = ({ navigation }) => {
   const handleButtonPress = () => navigation.push("AssessmentComplete")
 
   return (
-    <Info
+    <AssessmentLayout
       icon={Icons.AnonymizedDataInverted}
       backgroundColor={Colors.invertedSecondaryBackground}
       footer={
@@ -37,7 +37,7 @@ export const Share = ({ navigation }) => {
         title={t("assessment.share_title")}
         description={t("assessment.share_description", { authority })}
       />
-    </Info>
+    </AssessmentLayout>
   )
 }
 


### PR DESCRIPTION
Why:
----
We would like to have all of our files using typescript.

This Commit:
----
- Convert the SelfAssessment/Info file to TypeScript
- Rename `Info` to `AssessmentLayout` since it reflects more closely what the file is doing

Reviewers:
----
This is a major effort around converting the files into TypeScript, this is one commit of many, we are focusing first on having an integrated type system and then we can tackle the behavior of these components.
