### PR TITLE
Add submit debug form screen

### DIFF
--- a/example.env.bt
+++ b/example.env.bt
@@ -16,3 +16,6 @@ GAEN_VERIFY_API_TOKEN=
 
 GAEN_AUTHORITY_NAME=The PathCheck Foundation
 AUTHORITY_ADVICE_URL=https://pathcheck.org
+
+DEBUG_API_URL=https://example.com
+DEBUG_API_TOKEN=asdf

--- a/ios/BT/DebugAction.swift
+++ b/ios/BT/DebugAction.swift
@@ -7,5 +7,6 @@
   getAndPostDiagnosisKeys,
   resetExposures,
   toggleENAuthorization,
-  showLastProcessedFilePath
+  showLastProcessedFilePath,
+  fetchDebugLog
 }

--- a/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
+++ b/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
@@ -58,6 +58,14 @@ extension ExposureManager {
     case .showLastProcessedFilePath:
       let path = BTSecureStorage.shared.userState.urlOfMostRecentlyDetectedKeyFile
       resolve(path)
+    case .fetchDebugLog:
+      let sessionInfo = ["Bundle ID: \(String(describing: Bundle.main.bundleIdentifier))",
+        "build: \(String(describing: Bundle.main.infoDictionary?["CFBundleVersion"]))",
+        "version: \(String(describing: Bundle.main.infoDictionary?["CFBundleVersion"]))",
+        "dateLastPerformedFileCapacityReset: \(String(describing: BTSecureStorage.shared.userState.dateLastPerformedFileCapacityReset))",
+      "remainingDailyFileProcessingCapacity: \(BTSecureStorage.shared.userState.remainingDailyFileProcessingCapacity)", "urlOfMostRecentlyDetectedKeyFile: \(BTSecureStorage.shared.userState.urlOfMostRecentlyDetectedKeyFile)",
+        "exposures: \(BTSecureStorage.shared.userState.exposures.map { $0.asDictionary })"]
+      resolve(sessionInfo.joined(separator: ","))
     }
   }
   

--- a/ios/BT/bridge/DebugMenuModule.m
+++ b/ios/BT/bridge/DebugMenuModule.m
@@ -16,6 +16,13 @@ RCT_REMAP_METHOD(fetchDiagnosisKeys,
   [[ExposureManager shared] handleDebugAction:DebugActionFetchDiagnosisKeys resolve:resolve reject:reject];
 }
 
+RCT_REMAP_METHOD(fetchDebugLog,
+                 fetchDebugLogWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [[ExposureManager shared] handleDebugAction:DebugActionFetchDebugLog resolve:resolve reject:reject];
+}
+
 RCT_REMAP_METHOD(detectExposuresNow,
                  detectExposuresNowWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -292,9 +292,9 @@ PODS:
     - React
   - RNCAsyncStorage (1.10.0):
     - React
-  - RNCMaskedView (0.1.5):
+  - RNCMaskedView (0.1.10):
     - React
-  - RNCPushNotificationIOS (1.2.0):
+  - RNCPushNotificationIOS (1.4.0):
     - React
   - RNDateTimePicker (2.3.2):
     - React
@@ -544,8 +544,8 @@ SPEC CHECKSUMS:
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
   RNBackgroundFetch: 388cf1595934d22fed275b8db9b48a28bb4eb7b6
   RNCAsyncStorage: 6d99641f8e6f15d169d695d8ef184bf187903f11
-  RNCMaskedView: dd13f9f7b146a9ad82f9b7eb6c9b5548fcf6e990
-  RNCPushNotificationIOS: 4d9ffd08f00ef6c1029ebbf4d72fc711eca3ff01
+  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
+  RNCPushNotificationIOS: dc1c0c6aa18a128df123598149f42e848d26a4ac
   RNDateTimePicker: 4bd49e09f91ca73d69119a9e1173b0d43b82f5e5
   RNFS: 2bd9eb49dc82fa9676382f0585b992c424cd59df
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
@@ -560,4 +560,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: fbf1dd9aee562d89a1e8e2dba6cd05cf38077e8f
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.9.3

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -116,6 +116,12 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
                 navigation.navigate(Screens.ENLocalDiagnosisKey)
               }}
             />
+            <DebugMenuListItem
+              label="Submit Debug Log"
+              onPress={() => {
+                navigation.navigate(Screens.ENSubmitDebugForm)
+              }}
+            />
           </View>
           {__DEV__ ? (
             <View style={styles.section}>

--- a/src/More/ENSubmitDebugForm.tsx
+++ b/src/More/ENSubmitDebugForm.tsx
@@ -1,0 +1,239 @@
+import React, { useState, FunctionComponent } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  StyleSheet,
+  Platform,
+  TouchableOpacity,
+  TextInput,
+  View,
+  Keyboard,
+} from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
+
+import { RTLEnabledText } from "../components/RTLEnabledText"
+import { NativeModule } from "../gaen"
+import * as API from "./debugAPI"
+
+import {
+  Spacing,
+  Buttons,
+  Layout,
+  Forms,
+  Colors,
+  Outlines,
+  Typography,
+} from "../styles"
+
+const defaultErrorMessage = " "
+
+const CodeInputScreen: FunctionComponent = () => {
+  const { t } = useTranslation()
+
+  const [email, setEmail] = useState("")
+  const [description, setDescription] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState(defaultErrorMessage)
+
+  const isIOS = Platform.OS === "ios"
+
+  const handleOnChangeEmail = (email: string) => {
+    setErrorMessage("")
+    setEmail(email)
+  }
+
+  const handleOnChangeDescription = (description: string) => {
+    setErrorMessage("")
+    setDescription(description)
+  }
+
+  const handleOnPressSubmit = async () => {
+    setIsLoading(true)
+    setErrorMessage(defaultErrorMessage)
+    try {
+      const payload = await NativeModule.fetchDebugLog()
+      const response = await API.postDebugLog({ email, description, payload })
+
+      if (response.kind === "success") {
+        Alert.alert(t("common.success"))
+      } else {
+        setErrorMessage(showError(response.error))
+      }
+      setIsLoading(false)
+    } catch (e) {
+      Alert.alert(t("common.something_went_wrong"), e.message)
+      setIsLoading(false)
+    }
+  }
+
+  const showError = (error: API.SubmitLogsError): string => {
+    switch (error) {
+      default: {
+        return t("common.something_went_wrong")
+      }
+    }
+  }
+
+  return (
+    <View style={styles.backgroundImage}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <KeyboardAvoidingView
+          keyboardVerticalOffset={Spacing.tiny}
+          behavior={isIOS ? "padding" : undefined}
+        >
+          <View style={styles.container}>
+            <View>
+              <View style={styles.headerContainer}>
+                <RTLEnabledText style={styles.header}>
+                  {t("more.debug.submit_your_debug_log")}
+                </RTLEnabledText>
+              </View>
+
+              <View style={styles.inputContainer}>
+                <RTLEnabledText style={styles.inputLabel}>
+                  {t("label.email_optional")}
+                </RTLEnabledText>
+                <TextInput
+                  value={email}
+                  placeholder={"email@example.com"}
+                  placeholderTextColor={Colors.placeholderTextColor}
+                  style={styles.textInput}
+                  keyboardType={"email-address"}
+                  returnKeyType={"done"}
+                  onChangeText={handleOnChangeEmail}
+                  blurOnSubmit={false}
+                  onSubmitEditing={Keyboard.dismiss}
+                  autoCapitalize={"none"}
+                />
+              </View>
+
+              <View style={styles.inputContainer}>
+                <RTLEnabledText style={styles.inputLabel}>
+                  {t("label.description_optional")}
+                </RTLEnabledText>
+                <TextInput
+                  value={description}
+                  style={styles.descriptionInput}
+                  keyboardType={"default"}
+                  returnKeyType={"done"}
+                  onChangeText={handleOnChangeDescription}
+                  blurOnSubmit={false}
+                  onSubmitEditing={Keyboard.dismiss}
+                  multiline
+                />
+              </View>
+
+              <RTLEnabledText style={styles.errorSubtitle}>
+                {errorMessage}
+              </RTLEnabledText>
+            </View>
+            {isLoading ? <LoadingIndicator /> : null}
+
+            <View>
+              <TouchableOpacity
+                onPress={handleOnPressSubmit}
+                accessible
+                accessibilityLabel={t("common.submit")}
+                accessibilityRole="button"
+                style={styles.button}
+              >
+                <RTLEnabledText style={styles.buttonText}>
+                  {t("common.submit")}
+                </RTLEnabledText>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </View>
+  )
+}
+
+const LoadingIndicator = () => {
+  return (
+    <View style={styles.activityIndicatorContainer}>
+      <ActivityIndicator
+        size={"large"}
+        color={Colors.darkGray}
+        style={styles.activityIndicator}
+        testID={"loading-indicator"}
+      />
+    </View>
+  )
+}
+
+const indicatorWidth = 120
+
+const styles = StyleSheet.create({
+  backgroundImage: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+    backgroundColor: Colors.faintGray,
+  },
+  container: {
+    height: "100%",
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.medium,
+    paddingTop: Spacing.large,
+    backgroundColor: Colors.primaryBackgroundFaintShade,
+  },
+  headerContainer: {
+    marginBottom: Spacing.small,
+  },
+  header: {
+    ...Typography.header2,
+    marginBottom: Spacing.xxSmall,
+  },
+  subheader: {
+    ...Typography.header4,
+    color: Colors.secondaryText,
+  },
+  errorSubtitle: {
+    ...Typography.header4,
+    color: Colors.errorText,
+    paddingTop: Spacing.xxSmall,
+  },
+  inputContainer: {
+    marginTop: Spacing.large,
+  },
+  inputLabel: {
+    ...Typography.description,
+    paddingBottom: Spacing.xxSmall,
+  },
+  textInput: {
+    ...Typography.secondaryTextInput,
+    ...Outlines.textInput,
+    padding: Spacing.xSmall,
+    borderColor: Colors.formInputBorder,
+  },
+  descriptionInput: {
+    ...Forms.textInputFormField,
+    ...Typography.secondaryTextInput,
+    minHeight: 4 * Typography.largeLineHeight,
+  },
+  activityIndicatorContainer: {
+    position: "absolute",
+    zIndex: Layout.level1,
+    left: Layout.halfWidth,
+    top: Layout.halfHeight,
+    marginLeft: -(indicatorWidth / 2),
+    marginTop: -(indicatorWidth / 2),
+  },
+  activityIndicator: {
+    width: indicatorWidth,
+    height: indicatorWidth,
+    backgroundColor: Colors.transparentDarkGray,
+    borderRadius: Outlines.baseBorderRadius,
+  },
+  button: {
+    ...Buttons.primary,
+  },
+  buttonText: {
+    ...Typography.buttonTextPrimary,
+  },
+})
+
+export default CodeInputScreen

--- a/src/More/debugAPI.ts
+++ b/src/More/debugAPI.ts
@@ -1,0 +1,70 @@
+import env from "react-native-config"
+
+const baseUrl = env.DEBUG_API_URL
+const submitLogsUrl = `${baseUrl}/api/v1/submit_logs`
+
+const defaultHeaders = {
+  "content-type": "application/json",
+  Authorization: `Bearer ${env.DEBUG_API_TOKEN}`,
+}
+
+export type Token = string
+
+interface NetworkSuccess<T> {
+  kind: "success"
+  body: T
+}
+interface NetworkFailure<U> {
+  kind: "failure"
+  error: U
+}
+
+export type NetworkResponse<T, U = "Unknown"> =
+  | NetworkSuccess<T>
+  | NetworkFailure<U>
+
+type SubmitLogsSuccess = "success"
+export type SubmitLogsError = "Unknown"
+
+type SubmitLogsRequest = {
+  email: string
+  payload: string
+  description?: string
+}
+
+export const postDebugLog = async ({
+  email,
+  payload,
+  description = "",
+}: SubmitLogsRequest): Promise<
+  NetworkResponse<SubmitLogsSuccess, SubmitLogsError>
+> => {
+  const body = JSON.stringify({
+    log: {
+      email,
+      payload,
+      description,
+    },
+  })
+  const requestOptions = {
+    method: "POST",
+    headers: defaultHeaders,
+    body,
+  }
+
+  try {
+    const response = await fetch(submitLogsUrl, requestOptions)
+    const json = await response.json()
+    if (response.ok) {
+      return { kind: "success", body: json.body }
+    } else {
+      switch (json.error) {
+        default:
+          return { kind: "failure", error: "Unknown" }
+      }
+    }
+  } catch (e) {
+    console.log(e)
+    return { kind: "failure", error: "Unknown" }
+  }
+}

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -128,6 +128,10 @@ export const submitDiagnosisKeys = async (
 // Debug Module
 const debugModule = NativeModules.DebugMenuModule
 
+export const fetchDebugLog = async (): Promise<string> => {
+  return debugModule.fetchDebugLog()
+}
+
 export const fetchDiagnosisKeys = async (): Promise<ENDiagnosisKey[]> => {
   return debugModule.fetchDiagnosisKeys()
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -44,7 +44,8 @@
     "settings": "Open Settings",
     "something_went_wrong": "Something went wrong",
     "start": "Start",
-    "submit": "Submit"
+    "submit": "Submit",
+    "success": "Success"
   },
   "export": {
     "code_input_body_bluetooth": "Enter your verification code",
@@ -122,6 +123,8 @@
     "calendar_icon": "Calendar icon",
     "check_icon": "Checkmark icon",
     "close_icon": "Close icon",
+    "description_optional": "Description (Optional)",
+    "email_optional": "Email (Optional)",
     "exposure_icon": "Circle icon with eight dots surrounding it",
     "heart_icon": "Heart icon with cross inside",
     "home_icon": "Home icon",
@@ -148,6 +151,11 @@
     "question_icon": "Question mark icon",
     "unknown": "unknown"
   },
+  "more": {
+    "debug": {
+      "submit_your_debug_log": "Submit your debug log"
+    }
+  },
   "navigation": {
     "history": "History",
     "home": "Home",
@@ -165,6 +173,7 @@
   "screen_titles": {
     "about": "About",
     "debug": "Debug",
+    "debug_form": "Debug Form",
     "exposure_history": "Exposure History",
     "legal": "Legal",
     "select_language": "Select Language"

--- a/src/navigation/MoreStack.tsx
+++ b/src/navigation/MoreStack.tsx
@@ -10,6 +10,7 @@ import AboutScreen from "./../More/About"
 import LicensesScreen from "./../More/Licenses"
 import ENDebugMenu from "./../More/ENDebugMenu"
 import ENLocalDiagnosisKeyScreen from "./../More/ENLocalDiagnosisKeyScreen"
+import ENSubmitDebugForm from "./../More/ENSubmitDebugForm"
 import ExposureListDebugScreen from "./../More/ExposureListDebugScreen"
 import LanguageSelection from "../More/LanguageSelection"
 
@@ -59,6 +60,11 @@ const MoreStack: FunctionComponent = () => {
       <Stack.Screen
         name={MoreStackScreens.ENLocalDiagnosisKey}
         component={ENLocalDiagnosisKeyScreen}
+      />
+      <Stack.Screen
+        name={MoreStackScreens.ENSubmitDebugForm}
+        component={ENSubmitDebugForm}
+        options={{ headerTitle: t("screen_titles.debug_form") }}
       />
     </Stack.Navigator>
   )

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -48,6 +48,7 @@ export type MoreStackScreen =
   | "About"
   | "Licenses"
   | "ENDebugMenu"
+  | "ENSubmitDebugForm"
   | "LanguageSelection"
   | "AffectedUserFlow"
   | "ExposureListDebugScreen"
@@ -61,6 +62,7 @@ export const MoreStackScreens: {
   Licenses: "Licenses",
   LanguageSelection: "LanguageSelection",
   ENDebugMenu: "ENDebugMenu",
+  ENSubmitDebugForm: "ENSubmitDebugForm",
   AffectedUserFlow: "AffectedUserFlow",
   ENLocalDiagnosisKey: "ENLocalDiagnosisKey",
   ExposureListDebugScreen: "ExposureListDebugScreen",

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -215,6 +215,12 @@ export const primaryTextInput: TextStyle = {
   color: Colors.primaryText,
 }
 
+export const secondaryTextInput: TextStyle = {
+  fontSize: medium,
+  lineHeight: large,
+  color: Colors.primaryText,
+}
+
 // Navigation
 export const navHeader: TextStyle = {
   ...largeFont,


### PR DESCRIPTION
Why:
We would like for our users and testers to be able to submit their
exposure history debug logs.

This commit:
Adds a simple form with optional inputs for email and a description with
the exposure notifications diagnostics logs which when submitted will
post to an web api in which we will store the debug info.

Co-Authored-By: Alejandro Dustet <alejandro@thoughtbot.com>
Co-Authored-By: Matt Buckley <matt@nicethings.io>
Co-Authored-By: Ferrumofomega <sam@pathcheck.org>

<img width="545" alt="Screen Shot 2020-07-24 at 6 18 23 PM" src="https://user-images.githubusercontent.com/16049495/88439758-1f4e2100-cdda-11ea-9482-45b7d5cfacfc.png">

