### PR TITLE
(iOS) Remove camera permission entry from info.plist

### DIFF
--- a/ios/BT/Info.plist
+++ b/ios/BT/Info.plist
@@ -42,8 +42,6 @@
 		<key>NSExceptionDomains</key>
 		<dict/>
 	</dict>
-	<key>NSCameraUsageDescription</key>
-	<string>To simulate sharing diagnosis keys between a central server by scanning QR codes.</string>
 	<key>NSMainNibFile</key>
 	<string>LaunchScreen</string>
 	<key>UIAppFonts</key>


### PR DESCRIPTION
### Why
The unnecessary presence of the camera permissions entry in our `Info.plist`  causes a rejection during app review.

### This commit
This commit removes the problematic entry from the app's `Info.plist`.