### PR TITLE
(iOS) Add debug button to force app crash.

### DIFF
--- a/ios/BT/bridge/DebugMenuModule.m
+++ b/ios/BT/bridge/DebugMenuModule.m
@@ -16,6 +16,11 @@ RCT_REMAP_METHOD(fetchDiagnosisKeys,
   [[ExposureManager shared] handleDebugAction:DebugActionFetchDiagnosisKeys resolve:resolve reject:reject];
 }
 
+RCT_EXPORT_METHOD(forceAppCrash)
+{
+  NSAssert(NO, @"Forced Crash (Debug)");
+}
+
 RCT_REMAP_METHOD(fetchDebugLog,
                  fetchDebugLogWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -117,6 +117,12 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
               }}
             />
             <DebugMenuListItem
+              label="Force App Crash"
+              onPress={() => {
+                NativeModule.forceAppCrash()
+              }}
+            />
+            <DebugMenuListItem
               label="Submit Debug Log"
               onPress={() => {
                 navigation.navigate(Screens.ENSubmitDebugForm)

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -132,6 +132,10 @@ export const fetchDebugLog = async (): Promise<string> => {
   return debugModule.fetchDebugLog()
 }
 
+export const forceAppCrash = async (): Promise<void> => {
+  return debugModule.forceAppCrash()
+}
+
 export const fetchDiagnosisKeys = async (): Promise<ENDiagnosisKey[]> => {
   return debugModule.fetchDiagnosisKeys()
 }


### PR DESCRIPTION
### Why
We'd like to verify that crashes are getting logged

### This Commit
This commit adds a debug button to force an app crash on iOS