### PR TITLE
Display application name, version on about screen

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -298,6 +298,8 @@ PODS:
     - React
   - RNDateTimePicker (2.3.2):
     - React
+  - RNDeviceInfo (5.6.3):
+    - React
   - RNFS (2.16.6):
     - React
   - RNGestureHandler (1.6.1):
@@ -367,6 +369,7 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
+  - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
@@ -475,6 +478,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/push-notification-ios"
   RNDateTimePicker:
     :path: "../node_modules/@react-native-community/datetimepicker"
+  RNDeviceInfo:
+    :path: "../node_modules/react-native-device-info"
   RNFS:
     :path: "../node_modules/react-native-fs"
   RNGestureHandler:
@@ -547,6 +552,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPushNotificationIOS: dc1c0c6aa18a128df123598149f42e848d26a4ac
   RNDateTimePicker: 4bd49e09f91ca73d69119a9e1173b0d43b82f5e5
+  RNDeviceInfo: 5be12a5bfbb8da3528c43ee4373abd9c30d04616
   RNFS: 2bd9eb49dc82fa9676382f0585b992c424cd59df
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-native": "0.61.5",
     "react-native-background-fetch": "^3.0.4",
     "react-native-config": "^1.2.1",
+    "react-native-device-info": "^5.6.3",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-linear-gradient": "^2.5.6",

--- a/src/More/About.spec.tsx
+++ b/src/More/About.spec.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import { Linking } from "react-native"
+import { render, fireEvent } from "@testing-library/react-native"
+import {
+  getApplicationName,
+  getVersion,
+  getBuildNumber,
+} from "react-native-device-info"
+
+import AboutScreen from "./About"
+
+jest.mock("react-native-device-info", () => {
+  return {
+    getApplicationName: jest.fn(),
+    getBuildNumber: jest.fn(),
+    getVersion: jest.fn(),
+  }
+})
+
+describe("About", () => {
+  it("shows the name of the application", () => {
+    const applicationName = "application name"
+
+    ;(getApplicationName as jest.Mock).mockReturnValueOnce(applicationName)
+
+    const { getByText } = render(<AboutScreen />)
+
+    expect(getByText(applicationName)).toBeDefined()
+  })
+
+  it("shows the build and version number of the application", () => {
+    const buildNumber = 8
+    const versionNumber = 0.18
+
+    ;(getBuildNumber as jest.Mock).mockReturnValueOnce(buildNumber)
+    ;(getVersion as jest.Mock).mockReturnValueOnce(versionNumber)
+
+    const { getByText } = render(<AboutScreen />)
+
+    expect(getByText("Version:")).toBeDefined()
+    expect(getByText(`${versionNumber} (${buildNumber})`)).toBeDefined()
+  })
+
+  it("navigates to the pathcheck organization when tapped on the url", () => {
+    const openURLSpy = jest.spyOn(Linking, "openURL")
+
+    const { getByText } = render(<AboutScreen />)
+
+    fireEvent.press(getByText("pathcheck.org"))
+
+    expect(openURLSpy).toHaveBeenCalledWith("https://pathcheck.org/")
+  })
+
+  it("shows the OS name and version", () => {
+    const mockOsName = "osName"
+    const mockOsVersion = "osVersion"
+    jest.mock("react-native/Libraries/Utilities/Platform", () => {
+      return { OS: mockOsName, Version: mockOsVersion }
+    })
+
+    const { getByText } = render(<AboutScreen />)
+
+    expect(getByText(`${mockOsName} v${mockOsVersion}`)).toBeDefined()
+  })
+})

--- a/src/More/About.tsx
+++ b/src/More/About.tsx
@@ -8,14 +8,20 @@ import {
   Text,
   View,
 } from "react-native"
+import {
+  getApplicationName,
+  getBuildNumber,
+  getVersion,
+} from "react-native-device-info"
 
-import packageJson from "../../package.json"
 import { RTLEnabledText } from "../components/RTLEnabledText"
 
 import { Colors, Spacing, Typography } from "../styles"
 
 export const AboutScreen: FunctionComponent = () => {
   const { t } = useTranslation()
+
+  const versionInfo = `${getVersion()} (${getBuildNumber()})`
 
   return (
     <ScrollView
@@ -24,7 +30,7 @@ export const AboutScreen: FunctionComponent = () => {
     >
       <View>
         <RTLEnabledText style={styles.headerContent}>
-          {t("label.about_header_bluetooth")}
+          {getApplicationName()}
         </RTLEnabledText>
       </View>
       <RTLEnabledText style={styles.aboutContent}>
@@ -36,7 +42,7 @@ export const AboutScreen: FunctionComponent = () => {
           Linking.openURL("https://pathcheck.org/")
         }}
       >
-        <Text>{"pathcheck.org"}</Text>
+        <Text>pathcheck.org</Text>
       </RTLEnabledText>
 
       <View style={styles.rowContainer}>
@@ -46,7 +52,7 @@ export const AboutScreen: FunctionComponent = () => {
           </RTLEnabledText>
 
           <RTLEnabledText style={styles.aboutSectionParaContent}>
-            {packageJson.version}
+            {versionInfo}
           </RTLEnabledText>
         </View>
         <View style={styles.row}>
@@ -67,6 +73,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.primaryBackground,
     paddingHorizontal: Spacing.medium,
     paddingTop: Spacing.huge,
+    flex: 1,
   },
   headerContent: {
     ...Typography.header2,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -117,7 +117,6 @@
     }
   },
   "label": {
-    "about_header_bluetooth": "PathCheck BT",
     "about_para": "The PathCheck app is made available by the PathCheck Foundation, a non-profit organization that is committed to providing free software to help stop the spread of COVID-19 and protect the privacy of individuals. \n\nFor more information, visit",
     "assessment_icon": "Clipboard icon with checkmark inside",
     "bell_icon": "Bell icon",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6755,6 +6755,11 @@ react-native-config@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.2.1.tgz#f80454fc58ea89b549819ccb4bdab26518a9f0db"
   integrity sha512-u7MDku3fUUKAtxfUFLLwnj4htBYO840EBGdlDB9ry/eX1TY+asHwULaUkAj9x+pJo4vSpIp8GtYxxi8dLzDtJw==
 
+react-native-device-info@^5.6.3:
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-5.6.3.tgz#8b964866fc538bcfb82e25ad88f872139d7a591d"
+  integrity sha512-fmaXRjG0NW9FAOdOD86cmjgoxA/2I0lBq1NZmxQ2sgElyRjLxZLtuJn/QpP8hmFeTlKFDSZpSDvEnB+UUihcmw==
+
 react-native-fs@^2.16.6:
   version "2.16.6"
   resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.16.6.tgz#2901789a43210a35a0ef0a098019bbef3af395fd"


### PR DESCRIPTION
Why:
----
When a user navigates to the `About` screen, they should see the correct application name based on the build as-well-as the information of the version and the number of the build.

This Commit:
----
- Install react-native-device-info library
- Display the application name and the version and build from the device information
- Add tests for the about screen

<img width="424" alt="Screen Shot 2020-07-27 at 10 20 52 AM" src="https://user-images.githubusercontent.com/2413802/88557981-edff6c00-cff8-11ea-9a5b-592be0c2bc89.png">
