### PR TITLE
Bump minSdkVersion to 23

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         compileSdkVersion = 28
         buildToolsVersion = "28.0.3"
         targetSdkVersion = 28
-        minSdkVersion = 21
+        minSdkVersion = 23
         supportLibVersion = "28.0.0"
         googlePlayServicesVersion = "11+"
         firebaseVersion = "11+"


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

The minimum version supported by GAEN API is 23.
Source: https://developers.google.com/android/exposure-notifications/exposure-notifications-api