### PR TITLE
Update pull and push scripts for lokalise

### DIFF
--- a/ios/en.lproj/InfoPlist.strings
+++ b/ios/en.lproj/InfoPlist.strings
@@ -1,5 +1,1 @@
 "NSHumanReadableCopyright" = "Copyright © 2020 Path Check Inc. All rights reserved.";
-"NSLocationAlwaysAndWhenInUseUsageDescription" = "Your location history will be saved on your device, and only shared with others if you choose to do so.";
-"NSLocationAlwaysUsageDescription" = "Your location history will be saved on your device, and only shared with others if you choose to do so.";
-"NSLocationWhenInUseUsageDescription" = "Your location history will be saved on your device, and only shared with others if you choose to do so.";
-"NSMotionUsageDescription" = "We use your accelerometer for accurate location history.";

--- a/ios/en.lproj/Localizable.strings
+++ b/ios/en.lproj/Localizable.strings
@@ -1,4 +1,0 @@
-/* Body text of notification when app is closed on iOS */
-"ios.app_closed_alert_text" = "PathCheck is securely storing your GPS coordinates once every five minutes on this device.";
-/* Title of notification when app is closed on iOS */
-"ios.app_closed_alert_title" = "PathCheck was closed";

--- a/src/SelfAssessment/endScreens/AssessmentComplete.spec.js
+++ b/src/SelfAssessment/endScreens/AssessmentComplete.spec.js
@@ -21,7 +21,7 @@ describe("AssessmentComplete", () => {
     expect(getByText("Thanks for keeping your community safe!")).toBeDefined()
     expect(
       getByText(
-        "By sharing your health status and location history anonymously with your community, you are being proactive about fighting the spread of COVID-19.",
+        "By sharing your health status and exposure history anonymously with your community, you are being proactive about fighting the spread of COVID-19.",
       ),
     ).toBeDefined()
   })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -15,7 +15,7 @@
     "caregiver_description": "Notify a healthcare provider in your long-term care facility. Living in a long-term care facility or nursing home may put you at risk for severe illness.\n\nTell a caregiver at the facility that you are sick and need to see a medical provider as soon as possible.",
     "caregiver_title": "Notify Caregiver",
     "complete_cta": "Done",
-    "complete_description": "By sharing your health status and location history anonymously with your community, you are being proactive about fighting the spread of COVID-19.",
+    "complete_description": "By sharing your health status and exposure history anonymously with your community, you are being proactive about fighting the spread of COVID-19.",
     "complete_title": "Thanks for keeping your community safe!",
     "distancing_cta": "Next",
     "distancing_description": "Please follow your local, state, or national guidelines for social distancing and Personal Protection Equipment (PPE) like masks and/or gloves. No additional action is needed at this time.",

--- a/src/locales/pull.sh
+++ b/src/locales/pull.sh
@@ -4,7 +4,10 @@ set -e
 # Usage:
 #   - Create a READ ONLY a token at https://app.lokalise.com/profile
 #   - Run the command from the root of the project with:
-#     LOKALISE_TOKEN=<token> yarn i18n:pull
+#     LOKALISE_READ_TOKEN=<token> yarn i18n:pull
+#   - To specify which languages do pull add the LANGUAGES with comma separated
+#     locale strings:
+#     LANGUAGES=en,es_PR,el yarn i18n:pull
 
 function found_exe() {
   hash "$1" 2>/dev/null
@@ -25,6 +28,12 @@ if ! found_exe lokalise2; then
   fi
 fi
 
+if [ -z "$LANGUAGES" ]; then
+  LANGUAGES_FILTER=""
+else
+  LANGUAGES_FILTER="--filter-langs $LANGUAGES"
+fi
+
 echo "Downloading iOS *.strings"
 lokalise2 file download \
   --add-newline-eof \
@@ -36,7 +45,8 @@ lokalise2 file download \
   --unzip-to=ios \
   --export-sort=a_z \
   --config .lokalise.yml \
-  --token=$LOKALISE_READ_TOKEN
+  --token=$LOKALISE_READ_TOKEN \
+  $LANGUAGES_FILTER
 
 echo "Downloading Android strings.xml"
 lokalise2 file download \
@@ -48,7 +58,8 @@ lokalise2 file download \
   --unzip-to=android/app/src/bt/res \
   --export-sort=a_z \
   --config .lokalise.yml \
-  --token=$LOKALISE_READ_TOKEN
+  --token=$LOKALISE_READ_TOKEN \
+  $LANGUAGES_FILTER
 
 echo "Downloading i18next *.json files"
 lokalise2 file download \
@@ -62,8 +73,9 @@ lokalise2 file download \
   --replace-breaks=false \
   --bundle-structure "locales/%LANG_ISO%.json" \
   --original-filenames=false \
-  --unzip-to=app \
+  --unzip-to=src \
   --indentation=2sp \
   --json-unescaped-slashes \
   --config .lokalise.yml \
-  --token=$LOKALISE_READ_TOKEN
+  --token=$LOKALISE_READ_TOKEN \
+  $LANGUAGES_FILTER

--- a/src/locales/push.sh
+++ b/src/locales/push.sh
@@ -4,7 +4,8 @@ set -e
 # Usage:
 #   - Create a READ/WRITE token at https://app.lokalise.com/profile
 #   - Run the command from the root of the project with:
-#     LOKALISE_TOKEN=<token> yarn i18n:push
+#     LOKALISE_READ_WRITE_TOKEN=<token> yarn i18n:push
+
 
 function found_exe() {
   hash "$1" 2>/dev/null
@@ -28,7 +29,7 @@ fi
 
 echo "Uploading English base files"
 lokalise2 file upload \
-  --file=app/locales/en.json,ios/en.lproj/InfoPlist.strings,ios/en.lproj/Localizable.strings,android/app/src/gps/res/values/strings.xml,android/app/src/bt/res/values/strings.xml \
+  --file=src/locales/en.json,ios/en.lproj/InfoPlist.strings,ios/en.lproj/Localizable.strings,android/app/src/bt/res/values/strings.xml \
   --lang-iso=en \
   --cleanup-mode \
   --replace-modified \


### PR DESCRIPTION
Why:
----
The push and pull actions for lokalise are not working as expected

This Commit:
----
- Remove location permission strings for iOS
- Extract to `src` not `app`
- Do not search under the `gps` flavor of android to upload files
- Update README portion of scripts with new env variables names
- Change some translations that mention location
- Add option to pull script to include just a set of languages
- Removed unused strings on iOS
- Upload translations from the src folder
- Ran push and updated master translations file on lokalise

Caveat:
----
This Commit does not include the result of running and commiting the `pull` script since it brings several files into the `iOS` and `android` projects that might not be necessary. There are more arguments like the languages to include in the pull we might add to the script.
