### PR TITLE
(iOS) Debug Menu Updates

### DIFF
--- a/ios/BT/bridge/DebugMenuModule.m
+++ b/ios/BT/bridge/DebugMenuModule.m
@@ -18,7 +18,7 @@ RCT_REMAP_METHOD(fetchDiagnosisKeys,
 
 RCT_EXPORT_METHOD(forceAppCrash)
 {
-  NSAssert(NO, @"Forced Crash (Debug)");
+  @throw [NSException exceptionWithName:NSGenericException reason:@"Forced Crash (Debug)" userInfo:nil];
 }
 
 RCT_REMAP_METHOD(fetchDebugLog,
@@ -71,14 +71,6 @@ RCT_REMAP_METHOD(resetExposures,
 {
   [[ExposureManager shared] handleDebugAction:DebugActionResetExposures resolve:resolve reject:reject];
 }
-
-RCT_REMAP_METHOD(submitExposureKeys,
-                 submitExposureKeysResolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject)
-{
-  [[ExposureManager shared] handleDebugAction:DebugActionGetAndPostDiagnosisKeys resolve:resolve reject:reject];
-}
-
 
 RCT_REMAP_METHOD(showLastProcessedFilePath,
                  showLastProcessedFilePathResolver:(RCTPromiseResolveBlock)resolve

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -144,13 +144,6 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
                 )}
               />
               <DebugMenuListItem
-                label="Get and Post Diagnosis Keys"
-                style={styles.lastListItem}
-                onPress={handleOnPressSimulationButton(
-                  NativeModule.submitExposureKeys,
-                )}
-              />
-              <DebugMenuListItem
                 label="Detect Exposures Now"
                 onPress={handleOnPressSimulationButton(
                   NativeModule.detectExposuresNow,

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -167,10 +167,6 @@ export const toggleExposureNotifications = async (): Promise<"success"> => {
   return debugModule.toggleExposureNotifications()
 }
 
-export const submitExposureKeys = async (): Promise<"success"> => {
-  return debugModule.submitExposureKeys()
-}
-
 export const simulateExposureDetectionError = async (): Promise<"success"> => {
   return debugModule.simulateExposureDetectionError()
 }


### PR DESCRIPTION
### Why
We'd like to remove debug menu buttons that will cease to work when the gaen server verifies key submission requests

### This Commit
This commit removes the existing key submission button from the debug menu, and also updates the underlying method for forcing a crash on iOS