### PR TITLE
Only allow code submission when en are enabled

### DIFF
--- a/src/AffectedUserFlow/AffectedUserContext.tsx
+++ b/src/AffectedUserFlow/AffectedUserContext.tsx
@@ -4,8 +4,6 @@ type Token = string
 type Key = string
 
 interface AffectedUserContextState {
-  code: string
-  setCode: (code: string) => void
   certificate: Token | null
   hmacKey: Key | null
   setExposureSubmissionCredentials: (certificate: Token, hmacKey: Key) => void
@@ -20,7 +18,6 @@ export const AffectedUserProvider = ({
 }: {
   children: JSX.Element
 }): JSX.Element => {
-  const [code, setCode] = useState("")
   const [hmacKey, setHmacKey] = useState<Key | null>(null)
   const [certificate, setCertificate] = useState<Token | null>(null)
 
@@ -35,8 +32,6 @@ export const AffectedUserProvider = ({
   return (
     <AffectedUserContext.Provider
       value={{
-        code,
-        setCode,
         hmacKey,
         certificate,
         setExposureSubmissionCredentials,

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
@@ -3,27 +3,27 @@ import { cleanup, render, fireEvent, wait } from "@testing-library/react-native"
 import "@testing-library/jest-native/extend-expect"
 import { useNavigation } from "@react-navigation/native"
 
-import CodeInputScreen from "./CodeInput"
-import { AffectedUserProvider } from "./AffectedUserContext"
-import * as API from "./verificationAPI"
-import * as Hmac from "./hmac"
-import { Screens } from "../navigation"
-import { ExposureContext } from "../ExposureContext"
-import { factories } from "../factories"
+import CodeInputForm from "./CodeInputForm"
+import { AffectedUserProvider } from "../AffectedUserContext"
+import * as API from "../verificationAPI"
+import * as Hmac from "../hmac"
+import { Screens } from "../../navigation"
+import { ExposureContext } from "../../ExposureContext"
+import { factories } from "../../factories"
 
 afterEach(cleanup)
 
 jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
-describe("CodeInputScreen", () => {
+describe("CodeInputForm", () => {
   it("initializes with an empty code form", () => {
     const { getByTestId } = render(
       <AffectedUserProvider>
-        <CodeInputScreen />
+        <CodeInputForm />
       </AffectedUserProvider>,
     )
 
-    expect(getByTestId("affected-user-code-input-screen")).not.toBeNull()
+    expect(getByTestId("affected-user-code-input-form")).not.toBeNull()
     expect(getByTestId("code-input")).toHaveTextContent("")
   })
 
@@ -66,7 +66,7 @@ describe("CodeInputScreen", () => {
       const { getByTestId, getByLabelText } = render(
         <ExposureContext.Provider value={exposureContext}>
           <AffectedUserProvider>
-            <CodeInputScreen />
+            <CodeInputForm />
           </AffectedUserProvider>
         </ExposureContext.Provider>,
       )
@@ -94,7 +94,7 @@ describe("CodeInputScreen", () => {
 
       const { getByTestId, getByLabelText, getByText } = render(
         <AffectedUserProvider>
-          <CodeInputScreen />
+          <CodeInputForm />
         </AffectedUserProvider>,
       )
       fireEvent.changeText(getByTestId("code-input"), "12345678")
@@ -115,7 +115,7 @@ describe("CodeInputScreen", () => {
 
       const { getByTestId, getByLabelText, getByText } = render(
         <AffectedUserProvider>
-          <CodeInputScreen />
+          <CodeInputForm />
         </AffectedUserProvider>,
       )
       fireEvent.changeText(getByTestId("code-input"), "12345678")
@@ -138,7 +138,7 @@ describe("CodeInputScreen", () => {
 
       const { getByTestId, getByLabelText, getByText } = render(
         <AffectedUserProvider>
-          <CodeInputScreen />
+          <CodeInputForm />
         </AffectedUserProvider>,
       )
       fireEvent.changeText(getByTestId("code-input"), "12345678")

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -1,6 +1,4 @@
-import React, { useState } from "react"
-import { useNavigation } from "@react-navigation/native"
-import { useTranslation } from "react-i18next"
+import React, { FunctionComponent, useState } from "react"
 import {
   ActivityIndicator,
   Alert,
@@ -12,14 +10,16 @@ import {
   View,
   Keyboard,
 } from "react-native"
-import { SafeAreaView } from "react-native-safe-area-context"
+import { useNavigation } from "@react-navigation/native"
+import { useTranslation } from "react-i18next"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
-import { useAffectedUserContext } from "./AffectedUserContext"
-import * as API from "./verificationAPI"
-import { calculateHmac } from "./hmac"
+import { RTLEnabledText } from "../../components/RTLEnabledText"
+import { useAffectedUserContext } from "../AffectedUserContext"
+import * as API from "../verificationAPI"
+import { calculateHmac } from "../hmac"
+import { useExposureContext } from "../../ExposureContext"
 
-import { Screens, Stacks } from "../navigation"
+import { Screens, Stacks } from "../../navigation"
 import {
   Spacing,
   Buttons,
@@ -28,23 +28,19 @@ import {
   Colors,
   Outlines,
   Typography,
-} from "../styles"
-import { useExposureContext } from "../ExposureContext"
+} from "../../styles"
 
 const defaultErrorMessage = " "
 
-const CodeInputScreen = (): JSX.Element => {
+const CodeInputForm: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
+  const strategy = useExposureContext()
+  const { setExposureSubmissionCredentials } = useAffectedUserContext()
 
-  const {
-    code,
-    setCode,
-    setExposureSubmissionCredentials,
-  } = useAffectedUserContext()
+  const [code, setCode] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState(defaultErrorMessage)
-  const strategy = useExposureContext()
 
   const isIOS = Platform.OS === "ios"
   const codeLength = 8
@@ -118,86 +114,76 @@ const CodeInputScreen = (): JSX.Element => {
   }
 
   const isDisabled = code.length !== codeLength
-
   const buttonStyle = isDisabled ? styles.disabledButton : styles.button
   const buttonTextStyle = isDisabled
     ? styles.disabledButtonText
     : styles.buttonText
 
   return (
-    <View style={styles.backgroundImage}>
-      <SafeAreaView
-        style={{ flex: 1 }}
-        testID={"affected-user-code-input-screen"}
-      >
-        <KeyboardAvoidingView
-          keyboardVerticalOffset={Spacing.tiny}
-          behavior={isIOS ? "padding" : undefined}
-        >
-          <View style={styles.container}>
-            <View>
-              <View style={styles.headerContainer}>
-                <RTLEnabledText style={styles.header}>
-                  {t("export.code_input_title_bluetooth")}
-                </RTLEnabledText>
+    <KeyboardAvoidingView
+      keyboardVerticalOffset={Spacing.tiny}
+      behavior={isIOS ? "padding" : undefined}
+    >
+      <View style={styles.container} testID={"affected-user-code-input-form"}>
+        <View>
+          <View style={styles.headerContainer}>
+            <RTLEnabledText style={styles.header}>
+              {t("export.code_input_title_bluetooth")}
+            </RTLEnabledText>
 
-                <RTLEnabledText style={styles.subheader}>
-                  {t("export.code_input_body_bluetooth")}
-                </RTLEnabledText>
-              </View>
-
-              <View>
-                <TextInput
-                  testID={"code-input"}
-                  value={code}
-                  placeholder={"00000000"}
-                  placeholderTextColor={Colors.placeholderTextColor}
-                  maxLength={codeLength}
-                  style={styles.codeInput}
-                  keyboardType={"number-pad"}
-                  returnKeyType={"done"}
-                  onChangeText={handleOnChangeText}
-                  blurOnSubmit={false}
-                  onSubmitEditing={Keyboard.dismiss}
-                />
-              </View>
-
-              <RTLEnabledText style={styles.errorSubtitle}>
-                {errorMessage}
-              </RTLEnabledText>
-            </View>
-            {isLoading ? <LoadingIndicator /> : null}
-
-            <View>
-              <TouchableOpacity
-                onPress={handleOnPressSubmit}
-                accessible
-                accessibilityLabel={t("common.submit")}
-                accessibilityRole="button"
-                disabled={isDisabled}
-                style={buttonStyle}
-              >
-                <RTLEnabledText style={buttonTextStyle}>
-                  {t("common.submit")}
-                </RTLEnabledText>
-              </TouchableOpacity>
-
-              <TouchableOpacity
-                onPress={handleOnPressCancel}
-                style={styles.secondaryButton}
-              >
-                <RTLEnabledText style={styles.secondaryButtonText}>
-                  {t("export.code_input_button_cancel")}
-                </RTLEnabledText>
-              </TouchableOpacity>
-            </View>
+            <RTLEnabledText style={styles.subheader}>
+              {t("export.code_input_body_bluetooth")}
+            </RTLEnabledText>
           </View>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </View>
+
+          <View>
+            <TextInput
+              testID={"code-input"}
+              value={code}
+              placeholder={"00000000"}
+              placeholderTextColor={Colors.placeholderTextColor}
+              maxLength={codeLength}
+              style={styles.codeInput}
+              keyboardType={"number-pad"}
+              returnKeyType={"done"}
+              onChangeText={handleOnChangeText}
+              blurOnSubmit={false}
+            />
+          </View>
+
+          <RTLEnabledText style={styles.errorSubtitle}>
+            {errorMessage}
+          </RTLEnabledText>
+        </View>
+        {isLoading ? <LoadingIndicator /> : null}
+
+        <View>
+          <TouchableOpacity
+            onPress={handleOnPressSubmit}
+            accessible
+            accessibilityLabel={t("common.submit")}
+            accessibilityRole="button"
+            disabled={isDisabled}
+            style={buttonStyle}
+          >
+            <RTLEnabledText style={buttonTextStyle}>
+              {t("common.submit")}
+            </RTLEnabledText>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            onPress={handleOnPressCancel}
+            style={styles.secondaryButton}
+          >
+            <RTLEnabledText style={styles.secondaryButtonText}>
+              {t("export.code_input_button_cancel")}
+            </RTLEnabledText>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </KeyboardAvoidingView>
   )
 }
-
 const LoadingIndicator = () => {
   return (
     <View style={styles.activityIndicatorContainer}>
@@ -214,18 +200,13 @@ const LoadingIndicator = () => {
 const indicatorWidth = 120
 
 const styles = StyleSheet.create({
-  backgroundImage: {
-    width: "100%",
-    height: "100%",
-    resizeMode: "cover",
-    backgroundColor: Colors.faintGray,
-  },
   container: {
     height: "100%",
     justifyContent: "space-between",
     paddingHorizontal: Spacing.medium,
     paddingTop: Layout.oneTenthHeight,
     backgroundColor: Colors.primaryBackgroundFaintShade,
+    paddingBottom: Spacing.small,
   },
   headerContainer: {
     marginBottom: Spacing.xxxHuge,
@@ -280,4 +261,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default CodeInputScreen
+export default CodeInputForm

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
@@ -1,0 +1,76 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import "@testing-library/jest-native/extend-expect"
+
+import CodeInputScreen from "./CodeInputScreen"
+import { AffectedUserProvider } from "../AffectedUserContext"
+import {
+  PermissionsContext,
+  ENPermissionStatus,
+} from "../../PermissionsContext"
+import { PermissionStatus } from "../../permissionStatus"
+
+jest.mock("@react-navigation/native")
+
+describe("CodeInputScreen", () => {
+  describe("when the user has exposure notifications enabled", () => {
+    it("shows the CodeInputForm", () => {
+      const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
+      const permissionProviderValue = createPermissionProviderValue(
+        enPermissionStatus,
+      )
+
+      const { getByTestId, queryByTestId } = render(
+        <PermissionsContext.Provider value={permissionProviderValue}>
+          <AffectedUserProvider>
+            <CodeInputScreen />
+          </AffectedUserProvider>
+        </PermissionsContext.Provider>,
+      )
+
+      expect(getByTestId("affected-user-code-input-form")).not.toBeNull()
+      expect(
+        queryByTestId("affected-user-enable-expsosure-notifications-screen"),
+      ).toBeNull()
+    })
+  })
+
+  describe("when the user does not have exposure notifications enabled", () => {
+    it("shows the EnableExposureNotifications screen", () => {
+      const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "DISABLED"]
+      const permissionProviderValue = createPermissionProviderValue(
+        enPermissionStatus,
+      )
+
+      const { getByTestId, queryByTestId } = render(
+        <PermissionsContext.Provider value={permissionProviderValue}>
+          <AffectedUserProvider>
+            <CodeInputScreen />
+          </AffectedUserProvider>
+        </PermissionsContext.Provider>,
+      )
+
+      expect(queryByTestId("affected-user-code-input-form")).toBeNull()
+      expect(
+        getByTestId("affected-user-enable-exposure-notifications-screen"),
+      ).not.toBeNull()
+    })
+  })
+})
+
+const createPermissionProviderValue = (
+  enPermissionStatus: ENPermissionStatus,
+) => {
+  return {
+    notification: {
+      status: PermissionStatus.UNKNOWN,
+      check: () => {},
+      request: () => {},
+    },
+    exposureNotifications: {
+      status: enPermissionStatus,
+      check: () => {},
+      request: () => {},
+    },
+  }
+}

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -1,0 +1,38 @@
+import React, { FunctionComponent } from "react"
+import { View, StyleSheet } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
+
+import { usePermissionsContext, ENEnablement } from "../../PermissionsContext"
+import CodeInputForm from "./CodeInputForm"
+import EnableExposureNotifications from "./EnableExposureNotifications"
+
+import { Colors } from "../../styles"
+
+const CodeInputScreen: FunctionComponent = () => {
+  const { exposureNotifications } = usePermissionsContext()
+
+  const hasExposureNotificationsEnabled = (): boolean => {
+    const enabledState: ENEnablement = "ENABLED"
+    return exposureNotifications.status[1] === enabledState
+  }
+  const isEnabled = hasExposureNotificationsEnabled()
+
+  return (
+    <View style={styles.backgroundImage}>
+      <SafeAreaView style={{ flex: 1 }}>
+        {isEnabled ? <CodeInputForm /> : <EnableExposureNotifications />}
+      </SafeAreaView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  backgroundImage: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+    backgroundColor: Colors.faintGray,
+  },
+})
+
+export default CodeInputScreen

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
@@ -1,0 +1,97 @@
+import React, { FunctionComponent } from "react"
+import { TouchableOpacity, Linking, View, StyleSheet } from "react-native"
+import { useTranslation } from "react-i18next"
+import { useNavigation } from "@react-navigation/native"
+
+import { RTLEnabledText } from "../../components/RTLEnabledText"
+
+import { Stacks } from "../../navigation"
+import { Buttons, Colors, Typography, Spacing, Layout } from "../../styles"
+
+const EnableExposureNotifications: FunctionComponent = () => {
+  const { t } = useTranslation()
+  const navigation = useNavigation()
+
+  const handleOnPressOpenSettings = () => {
+    Linking.openSettings()
+  }
+
+  const handleOnPressCancel = () => {
+    navigation.navigate(Stacks.More)
+  }
+
+  return (
+    <View
+      style={styles.container}
+      testID={"affected-user-enable-exposure-notifications-screen"}
+    >
+      <View style={styles.headerContainer}>
+        <RTLEnabledText style={styles.header}>
+          {t("export.enable_exposure_notifications_title")}
+        </RTLEnabledText>
+
+        <RTLEnabledText style={styles.subheader}>
+          {t("export.enable_exposure_notifications_body")}
+        </RTLEnabledText>
+      </View>
+      <View>
+        <TouchableOpacity
+          onPress={handleOnPressOpenSettings}
+          accessible
+          accessibilityLabel={t("common.settings")}
+          accessibilityRole="button"
+          style={styles.button}
+        >
+          <RTLEnabledText style={styles.buttonText}>
+            {t("common.settings")}
+          </RTLEnabledText>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={handleOnPressCancel}
+          style={styles.secondaryButton}
+        >
+          <RTLEnabledText style={styles.secondaryButtonText}>
+            {t("export.code_input_button_cancel")}
+          </RTLEnabledText>
+        </TouchableOpacity>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.primaryBackgroundFaintShade,
+    height: "100%",
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.medium,
+    paddingTop: Layout.oneTenthHeight,
+    paddingBottom: Spacing.small,
+  },
+  headerContainer: {
+    marginBottom: Spacing.xxxHuge,
+  },
+  header: {
+    ...Typography.header2,
+    marginBottom: Spacing.xxSmall,
+  },
+  subheader: {
+    ...Typography.header4,
+    color: Colors.secondaryText,
+  },
+  button: {
+    ...Buttons.primary,
+  },
+  buttonText: {
+    ...Typography.buttonTextPrimary,
+  },
+  secondaryButton: {
+    ...Buttons.secondary,
+  },
+  secondaryButtonText: {
+    ...Typography.buttonTextSecondary,
+  },
+})
+
+export default EnableExposureNotifications

--- a/src/AffectedUserFlow/index.tsx
+++ b/src/AffectedUserFlow/index.tsx
@@ -3,7 +3,7 @@ import { createStackNavigator } from "@react-navigation/stack"
 
 import { AffectedUserProvider } from "./AffectedUserContext"
 import Start from "./Start"
-import CodeInput from "./CodeInput"
+import CodeInput from "./CodeInput/CodeInputScreen"
 import Complete from "./Complete"
 import PublishConsent from "./PublishConsent/PublishConsentScreen"
 

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from "react"
+import React from "react"
 import { StyleSheet, ImageBackground, View } from "react-native"
 import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
 
-import PermissionsContext from "../PermissionsContext"
+import { usePermissionsContext } from "../PermissionsContext"
 import { useStatusBarEffect } from "../navigation"
 import Home from "./Home"
 
@@ -12,7 +12,7 @@ import { Spacing, Layout } from "../styles"
 
 const HomeScreen = (): JSX.Element => {
   useStatusBarEffect("light-content")
-  const { exposureNotifications } = useContext(PermissionsContext)
+  const { exposureNotifications } = usePermissionsContext()
   const { t } = useTranslation()
 
   return (

--- a/src/Onboarding/EnableExposureNotifications.tsx
+++ b/src/Onboarding/EnableExposureNotifications.tsx
@@ -1,8 +1,8 @@
-import React, { useContext } from "react"
+import React from "react"
 import { StyleSheet } from "react-native"
 import { useTranslation } from "react-i18next"
 
-import PermissionsContext from "../PermissionsContext"
+import { usePermissionsContext } from "../PermissionsContext"
 import { useOnboardingContext } from "../OnboardingContext"
 import { useStatusBarEffect } from "../navigation"
 import ExplanationScreen, { IconStyle } from "./ExplanationScreen"
@@ -12,7 +12,7 @@ import { Colors } from "../styles"
 
 const EnableExposureNotifications = (): JSX.Element => {
   const { t } = useTranslation()
-  const { exposureNotifications } = useContext(PermissionsContext)
+  const { exposureNotifications } = usePermissionsContext()
   const { setOnboardingToComplete } = useOnboardingContext()
 
   useStatusBarEffect("dark-content")

--- a/src/Onboarding/NotificationPermissions.tsx
+++ b/src/Onboarding/NotificationPermissions.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from "react"
+import React from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { StyleSheet } from "react-native"
 
-import PermissionsContext from "../PermissionsContext"
+import { usePermissionsContext } from "../PermissionsContext"
 import { Screens } from "../navigation"
 import { useStatusBarEffect } from "../navigation"
 import ExplanationScreen, { IconStyle } from "../Onboarding/ExplanationScreen"
@@ -14,7 +14,7 @@ import { Colors } from "../styles"
 const NotificationsPermissions = (): JSX.Element => {
   const navigation = useNavigation()
   const { t } = useTranslation()
-  const { notification } = useContext(PermissionsContext)
+  const { notification } = usePermissionsContext()
 
   useStatusBarEffect("dark-content")
 

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -3,6 +3,7 @@ import React, {
   createContext,
   useState,
   useEffect,
+  useContext,
   useCallback,
 } from "react"
 
@@ -13,8 +14,8 @@ import {
 import { Platform } from "react-native"
 import { PermissionStatus, statusToEnum } from "./permissionStatus"
 
-type ENEnablement = `DISABLED` | `ENABLED`
-type ENAuthorization = `UNAUTHORIZED` | `AUTHORIZED`
+export type ENAuthorization = `UNAUTHORIZED` | `AUTHORIZED`
+export type ENEnablement = `DISABLED` | `ENABLED`
 import gaenStrategy from "./gaen"
 
 export type ENPermissionStatus = [ENAuthorization, ENEnablement]
@@ -22,7 +23,7 @@ export type ENPermissionStatus = [ENAuthorization, ENEnablement]
 const initialENStatus: ENPermissionStatus = ["UNAUTHORIZED", "DISABLED"]
 const { permissionStrategy } = gaenStrategy
 
-interface PermissionContextState {
+interface PermissionsContextState {
   notification: {
     status: PermissionStatus
     check: () => void
@@ -48,7 +49,7 @@ const initialState = {
   },
 }
 
-const PermissionsContext = createContext<PermissionContextState>(initialState)
+const PermissionsContext = createContext<PermissionsContextState>(initialState)
 
 export interface PermissionStrategy {
   statusSubscription: (
@@ -133,5 +134,12 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
   )
 }
 
-export { PermissionsProvider }
-export default PermissionsContext
+const usePermissionsContext = (): PermissionsContextState => {
+  const context = useContext(PermissionsContext)
+  if (context === undefined) {
+    throw new Error("PermissionsContext must be used with a provider")
+  }
+  return context
+}
+
+export { PermissionsContext, PermissionsProvider, usePermissionsContext }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,6 +51,8 @@
     "code_input_body_bluetooth": "Enter your verification code",
     "code_input_button_cancel": "Cancel",
     "code_input_title_bluetooth": "Verify your diagnosis",
+    "enable_exposure_notifications_title": "Enable exposure notifications to continue",
+    "enable_exposure_notifications_body": "You must enable exposure notifcations to report a positive test result.",
     "complete_body_bluetooth": "By choosing to share your status and anonymously notify others, you’re helping contain the spread of the virus and protect others in your community.",
     "complete_title": "Thanks for keeping your community safe!",
     "consent_button_cancel": "Cancel",


### PR DESCRIPTION
Why:
Currently, if a user has not enabled exposure notifications for the app
it is possible to try to submit the verification code in the affected
user flow, which will necessarily error as the exposure notification api
must be accessible in order to submit exposure keys.

We would like to make it such that a user cannot submit a verification
code unless the en api is enabled. Additionally, if the user starts the
affected user flow without enabled exposure notifications, they should
be prompted to enable exposure notifications.

This commit:
Adds a conditional to the CodeInputScreen to conditionally render either
the CodeInputForm or an EnableExposureNotifications screen that has a
link to the settings for en notifications.

Co-Authored-By johnschoeman <johnschoeman1617@gmail.com>

---

### GIF

![require-en-permissions](https://user-images.githubusercontent.com/16049495/88643528-cc9d8f00-d08f-11ea-957f-959ac59919f7.gif)
