### PR TITLE
Add Small style additions to No Exposures Page

### DIFF
--- a/src/ExposureHistory/History/NoExposures.tsx
+++ b/src/ExposureHistory/History/NoExposures.tsx
@@ -15,63 +15,73 @@ const {
 const NoExposures: FunctionComponent = () => {
   const { t } = useTranslation()
   return (
-    <>
-      <View style={style.container}>
-        <RTLEnabledText style={style.headerText}>
+    <View>
+      <View style={styles.noExposureCard}>
+        <RTLEnabledText style={styles.headerText}>
           {t("exposure_history.no_exposure_reports")}
         </RTLEnabledText>
-        <RTLEnabledText style={style.subheaderText}>
+        <RTLEnabledText style={styles.subheaderText}>
           {t("exposure_history.no_exposure_reports_over_past")}
         </RTLEnabledText>
       </View>
-      <View style={style.card}>
-        <RTLEnabledText style={style.cardHeaderText}>
-          {t("exposure_history.protect_yourself_and_others")}
-        </RTLEnabledText>
-        {Boolean(healthAuthorityLink) && (
-          <>
-            <RTLEnabledText style={style.cardSubheaderText}>
-              {t("exposure_history.review_guidance_from_ha", {
-                healthAuthorityName,
-              })}
+      <HealthGuidelines />
+    </View>
+  )
+}
+
+const HealthGuidelines: FunctionComponent = () => {
+  const { t } = useTranslation()
+  const handleOnPressHALink = () => {
+    Linking.openURL(healthAuthorityLink)
+  }
+
+  return (
+    <View style={styles.card}>
+      <RTLEnabledText style={styles.cardHeaderText}>
+        {t("exposure_history.protect_yourself_and_others")}
+      </RTLEnabledText>
+      {Boolean(healthAuthorityLink) && (
+        <>
+          <RTLEnabledText style={styles.cardSubheaderText}>
+            {t("exposure_history.review_guidance_from_ha", {
+              healthAuthorityName,
+            })}
+          </RTLEnabledText>
+          <TouchableOpacity
+            onPress={handleOnPressHALink}
+            style={styles.learnMoreCtaContainer}
+          >
+            <RTLEnabledText style={styles.learnMoreCta}>
+              {t("exposure_history.learn_more")}
             </RTLEnabledText>
-            <TouchableOpacity
-              onPress={() => Linking.openURL(healthAuthorityLink)}
-            >
-              <RTLEnabledText style={style.learnMoreCta}>
-                <>
-                  {t("exposure_history.learn_more")}
-                  <SvgXml
-                    xml={Icons.Arrow}
-                    fill={Colors.primaryViolet}
-                    style={style.ctaArrow}
-                  />
-                </>
-              </RTLEnabledText>
-            </TouchableOpacity>
-            <RTLEnabledText style={style.listHeading}>
-              {t("exposure_history.health_guidelines.title")}
-            </RTLEnabledText>
-          </>
-        )}
-        <HealthGuidelineItem
-          icon={Icons.WashHands}
-          text={t("exposure_history.health_guidelines.wash_your_hands")}
-        />
-        <HealthGuidelineItem
-          icon={Icons.House}
-          text={t("exposure_history.health_guidelines.stay_home")}
-        />
-        <HealthGuidelineItem
-          icon={Icons.Mask}
-          text={t("exposure_history.health_guidelines.wear_a_mask")}
-        />
-        <HealthGuidelineItem
-          icon={Icons.SixFeet}
-          text={t("exposure_history.health_guidelines.six_feet_apart")}
-        />
-      </View>
-    </>
+            <SvgXml
+              xml={Icons.Arrow}
+              fill={Colors.primaryViolet}
+              style={styles.ctaArrow}
+            />
+          </TouchableOpacity>
+          <RTLEnabledText style={styles.listHeading}>
+            {t("exposure_history.health_guidelines.title")}
+          </RTLEnabledText>
+        </>
+      )}
+      <HealthGuidelineItem
+        icon={Icons.WashHands}
+        text={t("exposure_history.health_guidelines.wash_your_hands")}
+      />
+      <HealthGuidelineItem
+        icon={Icons.House}
+        text={t("exposure_history.health_guidelines.stay_home")}
+      />
+      <HealthGuidelineItem
+        icon={Icons.Mask}
+        text={t("exposure_history.health_guidelines.wear_a_mask")}
+      />
+      <HealthGuidelineItem
+        icon={Icons.SixFeet}
+        text={t("exposure_history.health_guidelines.six_feet_apart")}
+      />
+    </View>
   )
 }
 
@@ -84,20 +94,17 @@ const HealthGuidelineItem: FunctionComponent<HealthGuidelineItemProps> = ({
   icon,
 }) => {
   return (
-    <View style={style.listItem}>
-      <SvgXml
-        xml={icon}
-        fill={Colors.primaryViolet}
-        style={style.listItemIcon}
-      />
-      <RTLEnabledText>{text}</RTLEnabledText>
+    <View style={styles.listItem}>
+      <View style={styles.listItemIconContainer}>
+        <SvgXml xml={icon} fill={Colors.primaryViolet} />
+      </View>
+      <RTLEnabledText style={styles.listItemText}>{text}</RTLEnabledText>
     </View>
   )
 }
 
-const style = StyleSheet.create({
-  container: {
-    flex: 1,
+const styles = StyleSheet.create({
+  noExposureCard: {
     backgroundColor: Colors.primaryViolet,
     ...Outlines.roundedBorder,
     borderColor: Colors.primaryViolet,
@@ -106,7 +113,7 @@ const style = StyleSheet.create({
   headerText: {
     ...Typography.mainContent,
     ...Typography.bold,
-    paddingBottom: Spacing.xSmall,
+    paddingBottom: Spacing.xxxSmall,
     color: Colors.white,
   },
   subheaderText: {
@@ -128,9 +135,13 @@ const style = StyleSheet.create({
     ...Typography.description,
     paddingBottom: Spacing.xSmall,
   },
+  learnMoreCtaContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingBottom: Spacing.large,
+  },
   learnMoreCta: {
     color: Colors.primaryViolet,
-    paddingBottom: Spacing.large,
   },
   ctaArrow: {
     marginLeft: Spacing.xxSmall,
@@ -146,8 +157,11 @@ const style = StyleSheet.create({
     flexDirection: "row",
     paddingBottom: Spacing.small,
   },
-  listItemIcon: {
-    marginRight: Spacing.xSmall,
+  listItemIconContainer: {
+    width: Spacing.huge,
+  },
+  listItemText: {
+    color: Colors.darkGray,
   },
 })
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -73,26 +73,14 @@
     "start_title_bluetooth": "Help contain the spread of the virus and protect others in your community if you're diagnosed or test positive for COVID-19."
   },
   "exposure_history": {
-    "protect_yourself_and_others": "Protect yourself and others in your community",
-    "review_guidance_from_ha": "Review guidance from {{healthAuthorityName}}",
-    "learn_more": "Learn More",
     "exposure_detail": {
       "content": "Someone you were nearby has since tested positive for COVID-19.",
       "header": "You may have crossed paths with the COVID-19 virus."
     },
-    "how_does_this_work": "How does this work?",
-    "how_does_this_work_para": "When Exposure Notifications are on, your phone uses Bluetooth to swap and save random number strings (called random IDs) from any phones it encounters that also have Exposure Notifications enabled. Random IDs won’t identify you personally to other users and change many times a day to protect your privacy. Date and duration of the encounter are recorded along with an estimate of how close the two phones may have been. When a person reports a positive diagnosis, their phone’s recent random IDs are flagged to anonymously notify others. No locations or personal info is shared.",
-    "last_days": "Last 14 days",
-    "no_exposure_reports": "No Exposure Reports",
-    "no_exposure_reports_over_past": "You haven't received any exposure report over the past 14-days",
-    "possible_exposure": "Possible COVID-19 exposure",
-    "updated": "Updated",
-    "why_did_i_get_an_en": "Why did I get an exposure notification?",
-    "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you crossed paths with later receives a confirmed, positive diagnosis or test for COVID-19 and chooses to notify others",
     "exposure_window": {
-      "today_to_three_days_ago": "Within the last 3 days",
       "four_to_six_days_ago": "4 to 6 days ago",
-      "seven_to_fourteen_days_ago": "7 to 14 days ago"
+      "seven_to_fourteen_days_ago": "7 to 14 days ago",
+      "today_to_three_days_ago": "Within the last 3 days"
     },
     "health_guidelines": {
       "six_feet_apart": "Stay six feet apart",
@@ -100,7 +88,19 @@
       "title": "Health Guidelines",
       "wash_your_hands": "Wash your hands often",
       "wear_a_mask": "Wear a mask"
-    }
+    },
+    "how_does_this_work": "How does this work?",
+    "how_does_this_work_para": "When Exposure Notifications are on, your phone uses Bluetooth to swap and save random number strings (called random IDs) from any phones it encounters that also have Exposure Notifications enabled. Random IDs won’t identify you personally to other users and change many times a day to protect your privacy. Date and duration of the encounter are recorded along with an estimate of how close the two phones may have been. When a person reports a positive diagnosis, their phone’s recent random IDs are flagged to anonymously notify others. No locations or personal info is shared.",
+    "last_days": "Last 14 days",
+    "learn_more": "Learn More",
+    "no_exposure_reports": "No Exposure Reports",
+    "no_exposure_reports_over_past": "You haven't received any exposure report over the past 14-days",
+    "possible_exposure": "Possible COVID-19 exposure",
+    "protect_yourself_and_others": "Protect yourself and others in your community",
+    "review_guidance_from_ha": "Review guidance from {{healthAuthorityName}}",
+    "updated": "Updated",
+    "why_did_i_get_an_en": "Why did I get an exposure notification?",
+    "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you crossed paths with later receives a confirmed, positive diagnosis or test for COVID-19 and chooses to notify others"
   },
   "home": {
     "bluetooth": {

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -81,13 +81,13 @@ export const mediumFont: TextStyle = {
 
 export const largeFont: TextStyle = {
   ...base,
-  lineHeight: largestLineHeight,
+  lineHeight: largeLineHeight,
   fontSize: large,
 }
 
 export const largerFont: TextStyle = {
   ...base,
-  lineHeight: mediumLineHeight,
+  lineHeight: largeLineHeight,
   fontSize: larger,
 }
 
@@ -189,7 +189,7 @@ export const quaternaryContent: TextStyle = {
 export const description: TextStyle = {
   ...smallFont,
   color: Colors.primaryText,
-  lineHeight: smallerLineHeight,
+  lineHeight: smallLineHeight,
 }
 
 export const disclaimer: TextStyle = {


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

Added a few minor styling changes to the No Exposures screen.

#### Screenshots:

![Screen Shot 2020-07-28 at 1 05 52 PM](https://user-images.githubusercontent.com/5807753/88703994-122f7b80-d0d3-11ea-920a-2439a0456e13.png)

