### PR TITLE
Use time range for exposure history timestamp

### DIFF
--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -7,7 +7,7 @@ import { SvgXml } from "react-native-svg"
 import { ExposureHistoryStackParamList } from "../navigation"
 import { RTLEnabledText } from "../components/RTLEnabledText"
 import { useStatusBarEffect } from "../navigation"
-import { DateTimeUtils } from "../utils"
+import { Possible, ExposureDatum, exposureWindowBucket } from "../exposure"
 
 import { Colors, Iconography, Outlines, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
@@ -24,6 +24,23 @@ const ExposureDetail: FunctionComponent = () => {
   const headerText = t("exposure_history.exposure_detail.header")
   const contentText = t("exposure_history.exposure_detail.content")
 
+  const exposureWindowBucketInWords = (
+    exposureDatum: ExposureDatum,
+  ): string => {
+    const bucket = exposureWindowBucket(exposureDatum as Possible)
+    switch (bucket) {
+      case "TodayToThreeDaysAgo": {
+        return t("exposure_history.exposure_window.today_to_three_days_ago")
+      }
+      case "FourToSixDaysAgo": {
+        return t("exposure_history.exposure_window.four_to_six_days_ago")
+      }
+      case "SevenToFourteenDaysAgo": {
+        return t("exposure_history.exposure_window.seven_to_fourteen_days_ago")
+      }
+    }
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.headerContainer}>
@@ -35,7 +52,7 @@ const ExposureDetail: FunctionComponent = () => {
           />
         </View>
         <RTLEnabledText>
-          {DateTimeUtils.timeAgoInWords(exposureDatum.date)}
+          {exposureWindowBucketInWords(exposureDatum)}
         </RTLEnabledText>
         <RTLEnabledText style={styles.headerText}>{headerText}</RTLEnabledText>
         <RTLEnabledText style={styles.contentText}>

--- a/src/ExposureHistory/History/ExposureList.spec.tsx
+++ b/src/ExposureHistory/History/ExposureList.spec.tsx
@@ -14,7 +14,7 @@ describe("ExposureList", () => {
   describe("when given an exposure history that has possible exposures", () => {
     it("shows a list of the exposures", async () => {
       const twoDaysAgo = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(2))
-      const fourDaysAgo = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(4))
+      const fiveDaysAgo = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(5))
 
       const datum1 = factories.exposureDatum.build({
         kind: "Possible",
@@ -23,17 +23,19 @@ describe("ExposureList", () => {
 
       const datum2 = factories.exposureDatum.build({
         kind: "Possible",
-        date: fourDaysAgo,
+        date: fiveDaysAgo,
       })
 
       const exposures = [datum1, datum2]
 
-      const { getAllByText, queryByText } = render(
+      const { getAllByText, queryByText, getByText } = render(
         <ExposureList exposures={exposures} />,
       )
 
       expect(queryByText("No Exposure Reports")).toBeNull()
       expect(getAllByText("Possible COVID-19 exposure").length).toEqual(2)
+      expect(getByText("Within the last 3 days")).toBeDefined()
+      expect(getByText("4 to 6 days ago")).toBeDefined()
     })
   })
 })

--- a/src/ExposureHistory/History/ExposureListItem.tsx
+++ b/src/ExposureHistory/History/ExposureListItem.tsx
@@ -5,8 +5,7 @@ import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 
 import { RTLEnabledText } from "../../components/RTLEnabledText"
-import { ExposureDatum } from "../../exposure"
-import { DateTimeUtils } from "../../utils"
+import { Possible, ExposureDatum, exposureWindowBucket } from "../../exposure"
 
 import { Icons } from "../../assets"
 import { Screens } from "../../navigation"
@@ -28,6 +27,23 @@ const ExposureListItem: FunctionComponent<ExposureListItemProps> = ({
   const { t } = useTranslation()
   const navigation = useNavigation()
 
+  const exposureWindowBucketInWords = (
+    exposureDatum: ExposureDatum,
+  ): string => {
+    const bucket = exposureWindowBucket(exposureDatum as Possible)
+    switch (bucket) {
+      case "TodayToThreeDaysAgo": {
+        return t("exposure_history.exposure_window.today_to_three_days_ago")
+      }
+      case "FourToSixDaysAgo": {
+        return t("exposure_history.exposure_window.four_to_six_days_ago")
+      }
+      case "SevenToFourteenDaysAgo": {
+        return t("exposure_history.exposure_window.seven_to_fourteen_days_ago")
+      }
+    }
+  }
+
   return (
     <TouchableHighlight
       underlayColor={Colors.underlayPrimaryBackground}
@@ -42,7 +58,7 @@ const ExposureListItem: FunctionComponent<ExposureListItemProps> = ({
             {t("exposure_history.possible_exposure")}
           </RTLEnabledText>
           <RTLEnabledText style={styles.secondaryText}>
-            {DateTimeUtils.timeAgoInWords(exposureDatum.date)}
+            {exposureWindowBucketInWords(exposureDatum)}
           </RTLEnabledText>
         </View>
         <SvgXml

--- a/src/exposure.spec.ts
+++ b/src/exposure.spec.ts
@@ -1,0 +1,61 @@
+import { factories } from "./factories"
+import { DateTimeUtils } from "./utils"
+
+import { exposureWindowBucket, Possible } from "./exposure"
+
+describe("exposureWindow", () => {
+  describe("when the exposure date is one day ago", () => {
+    it("returns 1 day ago to 3 days ago", () => {
+      const today = Date.now()
+      const threeDaysAgo = DateTimeUtils.daysAgo(3)
+      const exposureToday = factories.exposureDatum.build({
+        kind: "Possible",
+        date: today,
+      })
+      const exposureThreeDaysAgo = factories.exposureDatum.build({
+        kind: "Possible",
+        date: threeDaysAgo,
+      })
+
+      const resultToday = exposureWindowBucket(exposureToday as Possible)
+      const resultThreeDaysAgo = exposureWindowBucket(
+        exposureThreeDaysAgo as Possible,
+      )
+
+      expect(resultToday).toEqual("TodayToThreeDaysAgo")
+      expect(resultThreeDaysAgo).toEqual("TodayToThreeDaysAgo")
+    })
+  })
+
+  describe("when the exposure date is 4 days ago", () => {
+    it("returns a bucket of 4 to 6 days ago", () => {
+      const fiveDaysAgo = DateTimeUtils.daysAgo(5)
+      const exposureFiveDaysAgo = factories.exposureDatum.build({
+        kind: "Possible",
+        date: fiveDaysAgo,
+      })
+
+      const resultFiveDaysAgo = exposureWindowBucket(
+        exposureFiveDaysAgo as Possible,
+      )
+
+      expect(resultFiveDaysAgo).toEqual("FourToSixDaysAgo")
+    })
+  })
+
+  describe("when the exposure date is more than 6 days ago", () => {
+    it("returns a bucket of 7 to 14 days ago", () => {
+      const eightDaysAgo = DateTimeUtils.daysAgo(8)
+      const exposureEightDaysAgo = factories.exposureDatum.build({
+        kind: "Possible",
+        date: eightDaysAgo,
+      })
+
+      const resultEightDaysAgo = exposureWindowBucket(
+        exposureEightDaysAgo as Possible,
+      )
+
+      expect(resultEightDaysAgo).toEqual("SevenToFourteenDaysAgo")
+    })
+  })
+})

--- a/src/exposure.ts
+++ b/src/exposure.ts
@@ -1,3 +1,5 @@
+import { DateTimeUtils } from "./utils"
+
 export type Posix = number
 
 export interface Possible {
@@ -21,3 +23,24 @@ export interface NoData {
 export type ExposureDatum = Possible | NoKnown | NoData
 
 export type ExposureInfo = ExposureDatum[]
+
+export type ExposureWindowBucket =
+  | "TodayToThreeDaysAgo"
+  | "FourToSixDaysAgo"
+  | "SevenToFourteenDaysAgo"
+
+export const exposureWindowBucket = (
+  exposureDatum: Possible,
+): ExposureWindowBucket => {
+  const date = exposureDatum.date
+  const threeDaysAgo = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(3))
+  const sevenDaysAgo = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(7))
+
+  if (date >= threeDaysAgo) {
+    return "TodayToThreeDaysAgo"
+  } else if (date > sevenDaysAgo) {
+    return "FourToSixDaysAgo"
+  } else {
+    return "SevenToFourteenDaysAgo"
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -85,7 +85,12 @@
     "possible_exposure": "Possible COVID-19 exposure",
     "updated": "Updated",
     "why_did_i_get_an_en": "Why did I get an exposure notification?",
-    "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you crossed paths with later receives a confirmed, positive diagnosis or test for COVID-19 and chooses to notify others"
+    "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you crossed paths with later receives a confirmed, positive diagnosis or test for COVID-19 and chooses to notify others",
+    "exposure_window": {
+      "today_to_three_days_ago": "Within the last 3 days",
+      "four_to_six_days_ago": "4 to 6 days ago",
+      "seven_to_fourteen_days_ago": "7 to 14 days ago"
+    }
   },
   "home": {
     "bluetooth": {


### PR DESCRIPTION
Why:
----
The actual data for an exposure event is not exact on the moment it happened. Showing an exact date, or relative date, is not correct and leads to confusion. The reality is that when we get an exposure history event, this could have happened anytime between 3 days from the occurrence reported.

How:
---
We opted for generating 3 buckets to classify the time range for an exposure event:

- within 3 days
- between 4 and 6 days
- between 7 and 14 days

Any event over 14 days of age will not be reported.

This PR:
----
- Introduces the exposureWindowBucket function to determine the range
where the exposure event falls in.
- Add translations for expressing the window bucket in words

Reviewers:
----
We needed to add a lot of type casting now that the exposure events that will be shown on the list are exclusively `Possible` events. This will be addressed in future iterations.

Co-Authored-By: Alejandro Dustet <alejandro@thoughtbot.com>

<img width="439" alt="Screen Shot 2020-07-28 at 2 14 45 PM" src="https://user-images.githubusercontent.com/2413802/88704866-b5d15980-d0dc-11ea-8735-4333d56e0bcb.png">
