### PR TITLE
Update safearea view background color on history

### DIFF
--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -7,6 +7,8 @@ import History from "./History/History"
 
 import { ExposureInfo, ExposureDatum } from "../exposure"
 
+import { Colors } from "../styles"
+
 const toExposureList = (exposureInfo: ExposureInfo): ExposureDatum[] => {
   return exposureInfo
 }
@@ -19,7 +21,9 @@ const ExposureHistoryScreen = (): JSX.Element => {
   const exposures = toExposureList(exposureInfo)
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView
+      style={{ backgroundColor: Colors.primaryBackground, flex: 1 }}
+    >
       <History
         lastDetectionDate={lastExposureDetectionDate}
         exposures={exposures}


### PR DESCRIPTION
Why:
The safearea view background color was a bit off.

# After

<img width="545" alt="Screen Shot 2020-07-28 at 4 19 31 PM" src="https://user-images.githubusercontent.com/16049495/88717336-64ca6100-d0ee-11ea-9b82-ca4431512a14.png">
