### PR TITLE
(iOS) Upload dsyms to Crashlytics at Build time

### DIFF
--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -856,7 +856,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/FirebaseCrashlytics/upload-symbols\" -gsp \"${PROJECT_DIR}/GoogleService-Info.plist\" -p ios \"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"\n";
+			shellScript = "if [ \"${CONFIGURATION}\" = \"Release-BT\" ]; then\n\"${PODS_ROOT}/FirebaseCrashlytics/upload-symbols\" -gsp \"${PROJECT_DIR}/GoogleService-Info.plist\" -p ios \"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"\nfi\n";
 		};
 		B5D968F324C6036A008DE452 /* Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -682,6 +682,7 @@
 				D447FDBA24BF332B00250621 /* Configure ATS */,
 				C53FD0BB24719AD1006D3268 /* Bundle React Native code and images */,
 				B5D968F324C6036A008DE452 /* Crashlytics */,
+				B53575E124D0C2DE00E7310D /* Upload Symbols */,
 			);
 			buildRules = (
 			);
@@ -839,6 +840,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		B53575E124D0C2DE00E7310D /* Upload Symbols */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Upload Symbols";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/FirebaseCrashlytics/upload-symbols\" -gsp \"${PROJECT_DIR}/GoogleService-Info.plist\" -p ios \"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"\n";
+		};
 		B5D968F324C6036A008DE452 /* Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
### Why
We'd like to be able to desymbolicate crashes

### This Commit
This commit adds a script to upload dsyms at build time