### PR TITLE
Check en permission on app state change

### DIFF
--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -6,12 +6,12 @@ import React, {
   useContext,
   useCallback,
 } from "react"
-
+import { Platform, AppState } from "react-native"
 import {
   checkNotifications,
   requestNotifications,
 } from "react-native-permissions"
-import { Platform } from "react-native"
+
 import { PermissionStatus, statusToEnum } from "./permissionStatus"
 
 export type ENAuthorization = `UNAUTHORIZED` | `AUTHORIZED`
@@ -77,6 +77,11 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
   }, [])
 
   useEffect(() => {
+    const handleAppStateChange = () => {
+      checkENPermission()
+    }
+
+    AppState.addEventListener("change", handleAppStateChange)
     const subscription = permissionStrategy.statusSubscription(
       (status: ENPermissionStatus) => {
         setExposureNotificationsPermission(status)
@@ -95,6 +100,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
 
     return () => {
       subscription?.remove()
+      AppState.removeEventListener("change", handleAppStateChange)
     }
   }, [checkENPermission])
 


### PR DESCRIPTION
Check en permission on app state change …
Why:
Currently if the user updates the permission for the app while the app
is backgrounded the application will not receive the onStatusUpdated
event from the native layer, which leads to a situation where the app
shows the incorrect permission status.

This commit:
Adds a subscription to the PermissionsContext using react-natives
AppState api and will check the permission status on every change of the
app state.

Note that we are still finding cases where the checkENPermission()
method is returning ["Authorized", "Enabled"] when we would expect
["Authorized", "Disabled"], which seems to be another bug unrelated to
the backgrounding behavior.

Co-Authored-By: mattthousand <matt@nicethings.io>
Co-Authored-By: amandabeiner <aebeiner@gmail.com>