### PR TITLE
Update permissions en status and request on home

### DIFF
--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -24,7 +24,7 @@ final class ExposureManager: NSObject {
   let manager = ENManager()
   
   var enabledState: EnabledState {
-    return manager.exposureNotificationEnabled ? .enabled : .disabled
+    return manager.exposureNotificationStatus == .active ? .enabled : .disabled
   }
   
   var authorizationState: AuthorizationState {

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -20,7 +20,13 @@ const CodeInputScreen: FunctionComponent = () => {
   return (
     <View style={style.backgroundImage}>
       <SafeAreaView style={{ flex: 1 }}>
-        {isEnabled ? <CodeInputForm /> : <EnableExposureNotifications />}
+        {isEnabled ? (
+          <CodeInputForm />
+        ) : (
+          <EnableExposureNotifications
+            requestPermission={exposureNotifications.request}
+          />
+        )}
       </SafeAreaView>
     </View>
   )

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.spec.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { render, wait, fireEvent } from "@testing-library/react-native"
+import "@testing-library/jest-native/extend-expect"
+import { useNavigation } from "@react-navigation/native"
+
+import EnableExposureNotifications from "./EnableExposureNotifications"
+
+jest.mock("@react-navigation/native")
+;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
+
+describe("EnableExposureNotifications", () => {
+  it("it renders an Enable Notifications button which requests permissions", async () => {
+    const requestPermission = jest.fn()
+
+    const { getByTestId } = render(
+      <EnableExposureNotifications requestPermission={requestPermission} />,
+    )
+
+    const button = getByTestId("affected-user-request-permissions-button")
+
+    fireEvent.press(button)
+    await wait(() => {
+      expect(requestPermission).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react"
-import { TouchableOpacity, Linking, View, StyleSheet } from "react-native"
+import { TouchableOpacity, View, StyleSheet } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
@@ -8,12 +8,18 @@ import { RTLEnabledText } from "../../components/RTLEnabledText"
 import { Stacks } from "../../navigation"
 import { Buttons, Colors, Typography, Spacing, Layout } from "../../styles"
 
-const EnableExposureNotifications: FunctionComponent = () => {
+interface EnableExposureNotificationsProps {
+  requestPermission: () => void
+}
+
+const EnableExposureNotifications: FunctionComponent<EnableExposureNotificationsProps> = ({
+  requestPermission,
+}) => {
   const { t } = useTranslation()
   const navigation = useNavigation()
 
-  const handleOnPressOpenSettings = () => {
-    Linking.openSettings()
+  const handleOnPressRequestPermissions = () => {
+    requestPermission()
   }
 
   const handleOnPressCancel = () => {
@@ -36,14 +42,15 @@ const EnableExposureNotifications: FunctionComponent = () => {
       </View>
       <View>
         <TouchableOpacity
-          onPress={handleOnPressOpenSettings}
+          onPress={handleOnPressRequestPermissions}
           accessible
           accessibilityLabel={t("common.settings")}
           accessibilityRole="button"
+          testID={"affected-user-request-permissions-button"}
           style={style.button}
         >
           <RTLEnabledText style={style.buttonText}>
-            {t("common.settings")}
+            {t("export.enable_permissions")}
           </RTLEnabledText>
         </TouchableOpacity>
 

--- a/src/Home/Home.spec.tsx
+++ b/src/Home/Home.spec.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { Alert, Platform } from "react-native"
 import { render, cleanup, wait, fireEvent } from "@testing-library/react-native"
 import "@testing-library/jest-native/extend-expect"
 
@@ -32,34 +31,6 @@ describe("Home", () => {
   })
 
   describe("When the enPermissionStatus is not enabled", () => {
-    describe("when the enPermissionStatus is not authorized", () => {
-      it("displays an alert dialog if exposure notifications are not authorized", async () => {
-        const enPermissionStatus: ENPermissionStatus = [
-          "UNAUTHORIZED",
-          "DISABLED",
-        ]
-        const requestPermission = jest.fn()
-        const alert = jest.spyOn(Alert, "alert")
-
-        const { getByTestId } = render(
-          <Home
-            enPermissionStatus={enPermissionStatus}
-            requestPermission={requestPermission}
-          />,
-        )
-        const button = getByTestId("home-request-permissions-button")
-
-        fireEvent.press(button)
-        await wait(() => {
-          if (Platform.OS === "ios") {
-            expect(alert).toHaveBeenCalled()
-          } else {
-            expect(alert).not.toHaveBeenCalled()
-          }
-        })
-      })
-    })
-
     it("it renders a notification are not enabled message", () => {
       const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "DISABLED"]
       const requestPermission = jest.fn()

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -1,16 +1,9 @@
 import React from "react"
-import {
-  StyleSheet,
-  TouchableOpacity,
-  View,
-  Alert,
-  Linking,
-} from "react-native"
+import { StyleSheet, TouchableOpacity, View } from "react-native"
 import { useTranslation } from "react-i18next"
 
 import { ENPermissionStatus } from "../PermissionsContext"
 import { RTLEnabledText } from "../components/RTLEnabledText"
-import { isPlatformiOS } from "../utils/index"
 
 import { Layout, Spacing, Colors, Typography, Buttons } from "../styles"
 
@@ -38,25 +31,8 @@ const Home = ({
     : t("home.bluetooth.tracing_off_subheader")
   const buttonText = t("home.bluetooth.tracing_off_button")
 
-  const showUnauthorizedAlert = () => {
-    Alert.alert(
-      t("home.bluetooth.unauthorized_error_title"),
-      t("home.bluetooth.unauthorized_error_message"),
-      [
-        {
-          text: t("common.settings"),
-          onPress: () => Linking.openSettings(),
-        },
-      ],
-    )
-  }
-
   const handleRequestPermission = () => {
-    if (isAuthorized) {
-      requestPermission()
-    } else if (isPlatformiOS()) {
-      showUnauthorizedAlert()
-    }
+    requestPermission()
   }
 
   return (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,6 +62,7 @@
     "consent_button_title": "I understand and consent",
     "enable_exposure_notifications_body": "You must enable exposure notifcations to report a positive test result.",
     "enable_exposure_notifications_title": "Enable exposure notifications to continue",
+    "enable_permissions": "Enable Permissions",
     "error": {
       "invalid_code": "Try a different code",
       "unknown_code_verification_error": "Try a different code",


### PR DESCRIPTION
Why:
There are some inconsistencies in how we are receiving the devices en
permission status.

This commit:
Changes the check of the devices exposureNotificationStatus to check
against the status directly vs. via the exposureNotificationsEnabled
method. We also directly request permissions in the app when the app is
unauthorized rather than making the user open the os settings and
manually updating the permissions.

Co-Authored-By: mattthousand <matt@nicethings.io>