### PR TITLE
Clean up About and Licenses styling

### DIFF
--- a/src/More/About.tsx
+++ b/src/More/About.tsx
@@ -22,6 +22,9 @@ export const AboutScreen: FunctionComponent = () => {
   const { t } = useTranslation()
 
   const versionInfo = `${getVersion()} (${getBuildNumber()})`
+  const osInfo = `${Platform.OS} v${Platform.Version}`
+  const pathCheckWebAddress = "pathcheck.org"
+  const pathCheckUrl = "https://pathcheck.org/"
 
   return (
     <ScrollView
@@ -39,28 +42,26 @@ export const AboutScreen: FunctionComponent = () => {
       <RTLEnabledText
         style={style.hyperlink}
         onPress={() => {
-          Linking.openURL("https://pathcheck.org/")
+          Linking.openURL(pathCheckUrl)
         }}
       >
-        <Text>pathcheck.org</Text>
+        <Text>{pathCheckWebAddress}</Text>
       </RTLEnabledText>
-
-      <View style={style.rowContainer}>
-        <View style={style.row}>
+      <View style={style.infoRowContainer}>
+        <View style={style.infoRow}>
           <RTLEnabledText style={style.aboutSectionParaLabel}>
             {t("about.version")}
           </RTLEnabledText>
-
           <RTLEnabledText style={style.aboutSectionParaContent}>
             {versionInfo}
           </RTLEnabledText>
         </View>
-        <View style={style.row}>
+        <View style={style.infoRow}>
           <RTLEnabledText style={style.aboutSectionParaLabel}>
             {t("about.operating_system_abbr")}
           </RTLEnabledText>
           <RTLEnabledText style={style.aboutSectionParaContent}>
-            {Platform.OS + " v" + Platform.Version}
+            {osInfo}
           </RTLEnabledText>
         </View>
       </View>
@@ -70,16 +71,17 @@ export const AboutScreen: FunctionComponent = () => {
 
 const style = StyleSheet.create({
   contentContainer: {
-    backgroundColor: Colors.primaryBackground,
-    paddingHorizontal: Spacing.medium,
-    paddingTop: Spacing.huge,
     flex: 1,
+    backgroundColor: Colors.primaryBackgroundFaintShade,
+    paddingTop: Spacing.large,
+    paddingHorizontal: Spacing.small,
   },
   headerContent: {
-    ...Typography.header2,
+    ...Typography.header3,
     marginBottom: Spacing.small,
   },
   hyperlink: {
+    ...Typography.secondaryContent,
     color: Colors.linkText,
     textDecorationLine: "underline",
   },
@@ -88,17 +90,17 @@ const style = StyleSheet.create({
   },
   aboutSectionParaLabel: {
     ...Typography.header5,
-    width: Spacing.xxxHuge * 2,
+    width: 100,
     marginTop: Spacing.small,
   },
   aboutSectionParaContent: {
     ...Typography.mainContent,
     marginTop: Spacing.small,
   },
-  rowContainer: {
+  infoRowContainer: {
     marginTop: Spacing.medium,
   },
-  row: {
+  infoRow: {
     flexDirection: "row",
   },
 })

--- a/src/More/Licenses.spec.tsx
+++ b/src/More/Licenses.spec.tsx
@@ -3,19 +3,28 @@ import "react-native"
 import { render } from "@testing-library/react-native"
 import "@testing-library/jest-native/extend-expect"
 import { useNavigation, useFocusEffect } from "@react-navigation/native"
+import { getApplicationName } from "react-native-device-info"
 
 import LicensesScreen from "./Licenses"
+
+jest.mock("react-native-device-info", () => {
+  return {
+    getApplicationName: jest.fn(),
+  }
+})
 
 jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 ;(useFocusEffect as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 
 describe("LicensesScreen", () => {
-  it("displays PathCheck BT", () => {
-    const { getByTestId } = render(<LicensesScreen />)
+  it("shows the name of the application", () => {
+    const applicationName = "application name"
 
-    expect(getByTestId("licenses-legal-header")).toHaveTextContent(
-      "PathCheck BT",
-    )
+    ;(getApplicationName as jest.Mock).mockReturnValueOnce(applicationName)
+
+    const { getByText } = render(<LicensesScreen />)
+
+    expect(getByText(applicationName)).toBeDefined()
   })
 })

--- a/src/More/Licenses.tsx
+++ b/src/More/Licenses.tsx
@@ -1,6 +1,5 @@
-import React from "react"
+import React, { FunctionComponent } from "react"
 import {
-  Image,
   Linking,
   ScrollView,
   StyleSheet,
@@ -8,25 +7,22 @@ import {
   View,
 } from "react-native"
 import { useTranslation } from "react-i18next"
+import { SvgXml } from "react-native-svg"
+import { getApplicationName } from "react-native-device-info"
 
 import { RTLEnabledText } from "../components/RTLEnabledText"
 
-import { Images } from "../assets"
 import { Colors, Spacing, Typography } from "../styles"
+import { Icons } from "../assets"
 
-const PRIVACY_POLICY_URL = "https://pathcheck.org/privacy-policy/"
-
-const Licenses = (): JSX.Element => {
+const Licenses: FunctionComponent = () => {
   const { t } = useTranslation()
 
-  const legalHeaderText = t("label.legal_page_header_bluetooth")
-
-  const infoAddress = "info@pathcheck.org"
-  const pathCheckAddress = "pathcheck.org"
-
-  const handleOnPressOpenUrl = (url: string) => {
-    return () => Linking.openURL(url)
-  }
+  const infoEmailAddress = "info@pathcheck.org"
+  const infoEmailLink = "mailto:info@pathcheck.org"
+  const pathCheckWebAddress = "pathcheck.org"
+  const pathCheckUrl = "https://pathcheck.org/"
+  const privacyPolicyUrl = "https://pathcheck.org/privacy-policy/"
 
   return (
     <>
@@ -39,42 +35,33 @@ const Licenses = (): JSX.Element => {
             style={style.headerContent}
             testID={"licenses-legal-header"}
           >
-            {legalHeaderText}
+            {getApplicationName()}
           </RTLEnabledText>
-          <View
-            style={{ paddingTop: Spacing.xSmall, paddingLeft: Spacing.medium }}
+          <RTLEnabledText style={style.contentText}>
+            {t("label.legal_page_address")}
+          </RTLEnabledText>
+          <RTLEnabledText
+            onPress={() => Linking.openURL(infoEmailLink)}
+            style={style.hyperlink}
           >
-            <RTLEnabledText style={style.contentText}>
-              {t("label.legal_page_address")}
-            </RTLEnabledText>
-            <View style={{ height: 20 }} />
-            <RTLEnabledText
-              onPress={handleOnPressOpenUrl("mailto:info@pathcheck.org")}
-              style={style.hyperlink}
-            >
-              {infoAddress}
-            </RTLEnabledText>
-            <RTLEnabledText
-              onPress={handleOnPressOpenUrl("https://pathcheck.org/")}
-              style={style.hyperlink}
-            >
-              {pathCheckAddress}
-            </RTLEnabledText>
-          </View>
+            {infoEmailAddress}
+          </RTLEnabledText>
+          <RTLEnabledText
+            onPress={() => Linking.openURL(pathCheckUrl)}
+            style={style.hyperlink}
+          >
+            {pathCheckWebAddress}
+          </RTLEnabledText>
         </View>
       </ScrollView>
       <TouchableOpacity
-        style={style.termsInfoRow}
-        onPress={handleOnPressOpenUrl(PRIVACY_POLICY_URL)}
+        style={style.privacyPolicy}
+        onPress={() => Linking.openURL(privacyPolicyUrl)}
       >
-        <RTLEnabledText
-          style={{ ...Typography.mainContent, color: Colors.white }}
-        >
+        <RTLEnabledText style={style.privacyPolicyText}>
           {t("label.privacy_policy")}
         </RTLEnabledText>
-        <View style={style.arrowContainer}>
-          <Image source={Images.ForeArrow} />
-        </View>
+        <SvgXml xml={Icons.ChevronRight} fill={Colors.white} />
       </TouchableOpacity>
     </>
   )
@@ -82,32 +69,35 @@ const Licenses = (): JSX.Element => {
 
 const style = StyleSheet.create({
   contentContainer: {
+    flex: 1,
     backgroundColor: Colors.primaryBackgroundFaintShade,
-    paddingHorizontal: 24,
-    paddingTop: 24,
+    paddingTop: Spacing.large,
+    paddingHorizontal: Spacing.small,
   },
   headerContent: {
-    ...Typography.header2,
+    ...Typography.header3,
+    marginBottom: Spacing.small,
+  },
+  contentText: {
+    ...Typography.secondaryContent,
+    marginBottom: Spacing.small,
   },
   hyperlink: {
     ...Typography.secondaryContent,
     color: Colors.linkText,
     textDecorationLine: "underline",
   },
-  termsInfoRow: {
+  privacyPolicy: {
     flexDirection: "row",
+    alignItems: "center",
     justifyContent: "space-between",
     backgroundColor: Colors.primaryBlue,
-    paddingVertical: 25,
-    paddingHorizontal: 15,
+    paddingVertical: Spacing.medium,
+    paddingHorizontal: Spacing.small,
   },
-  arrowContainer: {
-    alignSelf: "center",
-    paddingRight: 20,
-    paddingLeft: 20,
-  },
-  contentText: {
-    ...Typography.secondaryContent,
+  privacyPolicyText: {
+    ...Typography.mainContent,
+    color: Colors.white,
   },
 })
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -74,15 +74,15 @@
   },
   "exposure_history": {
     "exposure_detail": {
+      "6ft_apart": "6ft apart",
       "content": "Someone you were nearby has since tested positive for COVID-19.",
       "ha_guidance_header": "What should I do?",
       "ha_guidance_subheader": "See guidance from {{healthAuthorityName}}.",
       "header": "You may have crossed paths with the COVID-19 virus.",
       "isolate": "Isolate",
-      "wear_a_mask": "Wear a mask",
-      "6ft_apart": "6ft apart",
+      "next_steps": "Next Steps",
       "wash_your_hands": "Wash your hands",
-      "next_steps": "Next Steps"
+      "wear_a_mask": "Wear a mask"
     },
     "exposure_window": {
       "four_to_six_days_ago": "4 to 6 days ago",
@@ -121,7 +121,7 @@
     }
   },
   "label": {
-    "about_para": "The PathCheck app is made available by the PathCheck Foundation, a non-profit organization that is committed to providing free software to help stop the spread of COVID-19 and protect the privacy of individuals. \n\nFor more information, visit",
+    "about_para": "The PathCheck app is made available by the PathCheck Foundation, a non-profit organization that is committed to providing free software to help stop the spread of COVID-19 and protect the privacy of individuals. \n\nFor more information, visit:",
     "assessment_icon": "Clipboard icon with checkmark inside",
     "bell_icon": "Bell icon",
     "bluetooth_icon": "Searching bluetooth device icon",
@@ -150,7 +150,6 @@
     "launch_screen4_subheader_bluetooth": "This helps others in your community contain the spread of the virus.",
     "launch_set_up_phone_bluetooth": "Next",
     "legal_page_address": "PathCheck Foundation\n58 Day Street\nBox 441621\nSomerville, MA 02144",
-    "legal_page_header_bluetooth": "PathCheck BT",
     "more_icon": "Icon of three horizontal dots",
     "privacy_policy": "Privacy Policy",
     "question_icon": "Question mark icon",


### PR DESCRIPTION
Why: prior to this commit, the About and Licenses screens were not styled
appropriately.

![Screen Shot 2020-07-29 at 7 01 28 PM](https://user-images.githubusercontent.com/39350030/88862316-f8bf2a00-d1cd-11ea-8a9f-73a6208c8eb5.png)
![Screen Shot 2020-07-29 at 7 01 42 PM](https://user-images.githubusercontent.com/39350030/88862318-f957c080-d1cd-11ea-8b56-d2eae43a52de.png)