### PR TITLE
Change RTLEnabledText to GlobalText

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -13,7 +13,7 @@ import {
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
-import { RTLEnabledText } from "../../components/RTLEnabledText"
+import { GlobalText } from "../../components/GlobalText"
 import { useAffectedUserContext } from "../AffectedUserContext"
 import * as API from "../verificationAPI"
 import { calculateHmac } from "../hmac"
@@ -127,13 +127,13 @@ const CodeInputForm: FunctionComponent = () => {
       <View style={style.container} testID={"affected-user-code-input-form"}>
         <View>
           <View style={style.headerContainer}>
-            <RTLEnabledText style={style.header}>
+            <GlobalText style={style.header}>
               {t("export.code_input_title_bluetooth")}
-            </RTLEnabledText>
+            </GlobalText>
 
-            <RTLEnabledText style={style.subheader}>
+            <GlobalText style={style.subheader}>
               {t("export.code_input_body_bluetooth")}
-            </RTLEnabledText>
+            </GlobalText>
           </View>
 
           <View>
@@ -151,9 +151,7 @@ const CodeInputForm: FunctionComponent = () => {
             />
           </View>
 
-          <RTLEnabledText style={style.errorSubtitle}>
-            {errorMessage}
-          </RTLEnabledText>
+          <GlobalText style={style.errorSubtitle}>{errorMessage}</GlobalText>
         </View>
         {isLoading ? <LoadingIndicator /> : null}
 
@@ -166,18 +164,18 @@ const CodeInputForm: FunctionComponent = () => {
             disabled={isDisabled}
             style={buttonStyle}
           >
-            <RTLEnabledText style={buttonTextStyle}>
+            <GlobalText style={buttonTextStyle}>
               {t("common.submit")}
-            </RTLEnabledText>
+            </GlobalText>
           </TouchableOpacity>
 
           <TouchableOpacity
             onPress={handleOnPressCancel}
             style={style.secondaryButton}
           >
-            <RTLEnabledText style={style.secondaryButtonText}>
+            <GlobalText style={style.secondaryButtonText}>
               {t("export.code_input_button_cancel")}
-            </RTLEnabledText>
+            </GlobalText>
           </TouchableOpacity>
         </View>
       </View>

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity, Linking, View, StyleSheet } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
-import { RTLEnabledText } from "../../components/RTLEnabledText"
+import { GlobalText } from "../../components/GlobalText"
 
 import { Stacks } from "../../navigation"
 import { Buttons, Colors, Typography, Spacing, Layout } from "../../styles"
@@ -26,13 +26,13 @@ const EnableExposureNotifications: FunctionComponent = () => {
       testID={"affected-user-enable-exposure-notifications-screen"}
     >
       <View style={style.headerContainer}>
-        <RTLEnabledText style={style.header}>
+        <GlobalText style={style.header}>
           {t("export.enable_exposure_notifications_title")}
-        </RTLEnabledText>
+        </GlobalText>
 
-        <RTLEnabledText style={style.subheader}>
+        <GlobalText style={style.subheader}>
           {t("export.enable_exposure_notifications_body")}
-        </RTLEnabledText>
+        </GlobalText>
       </View>
       <View>
         <TouchableOpacity
@@ -42,18 +42,18 @@ const EnableExposureNotifications: FunctionComponent = () => {
           accessibilityRole="button"
           style={style.button}
         >
-          <RTLEnabledText style={style.buttonText}>
+          <GlobalText style={style.buttonText}>
             {t("common.settings")}
-          </RTLEnabledText>
+          </GlobalText>
         </TouchableOpacity>
 
         <TouchableOpacity
           onPress={handleOnPressCancel}
           style={style.secondaryButton}
         >
-          <RTLEnabledText style={style.secondaryButtonText}>
+          <GlobalText style={style.secondaryButtonText}>
             {t("export.code_input_button_cancel")}
-          </RTLEnabledText>
+          </GlobalText>
         </TouchableOpacity>
       </View>
     </View>

--- a/src/AffectedUserFlow/Complete.tsx
+++ b/src/AffectedUserFlow/Complete.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
 import { useStatusBarEffect } from "../navigation"
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 
 import { Stacks } from "../navigation"
 
@@ -27,14 +27,12 @@ export const ExportComplete: FunctionComponent = () => {
       <SafeAreaView style={{ flex: 1 }}>
         <View style={style.container}>
           <View>
-            <RTLEnabledText style={style.header}>{title}</RTLEnabledText>
-            <RTLEnabledText style={style.contentText}>{body}</RTLEnabledText>
+            <GlobalText style={style.header}>{title}</GlobalText>
+            <GlobalText style={style.contentText}>{body}</GlobalText>
           </View>
 
           <TouchableOpacity style={style.button} onPress={handleOnPressDone}>
-            <RTLEnabledText style={style.buttonText}>
-              {t("common.done")}
-            </RTLEnabledText>
+            <GlobalText style={style.buttonText}>{t("common.done")}</GlobalText>
           </TouchableOpacity>
         </View>
       </SafeAreaView>

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
 import { Button } from "../../components/Button"
-import { RTLEnabledText } from "../../components/RTLEnabledText"
+import { GlobalText } from "../../components/GlobalText"
 
 import { Screens, Stacks } from "../../navigation"
 import { Icons, Images } from "../../assets"
@@ -73,8 +73,8 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
           </View>
 
           <View style={style.content}>
-            <RTLEnabledText style={style.header}>{title}</RTLEnabledText>
-            <RTLEnabledText style={style.contentText}>{body}</RTLEnabledText>
+            <GlobalText style={style.header}>{title}</GlobalText>
+            <GlobalText style={style.contentText}>{body}</GlobalText>
           </View>
 
           <View>
@@ -89,9 +89,9 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
               onPress={handleOnPressCancel}
               style={style.secondaryButton}
             >
-              <RTLEnabledText style={style.secondaryButtonText}>
+              <GlobalText style={style.secondaryButtonText}>
                 {t("export.consent_button_cancel")}
-              </RTLEnabledText>
+              </GlobalText>
             </TouchableOpacity>
           </View>
         </ScrollView>

--- a/src/AffectedUserFlow/Start.tsx
+++ b/src/AffectedUserFlow/Start.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { Button } from "../components/Button"
 import { useStatusBarEffect } from "../navigation"
 
@@ -51,8 +51,8 @@ export const ExportIntro = (): JSX.Element => {
               />
             </View>
 
-            <RTLEnabledText style={style.header}>{title}</RTLEnabledText>
-            <RTLEnabledText style={style.contentText}>{body}</RTLEnabledText>
+            <GlobalText style={style.header}>{title}</GlobalText>
+            <GlobalText style={style.contentText}>{body}</GlobalText>
           </View>
 
           <Button label={t("common.start")} onPress={handleOnPressNext} />

--- a/src/ErrorScreen.tsx
+++ b/src/ErrorScreen.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from "react"
 import { SafeAreaView, View, StyleSheet } from "react-native"
 import { useTranslation } from "react-i18next"
 
-import { RTLEnabledText } from "./components/RTLEnabledText"
+import { GlobalText } from "./components/GlobalText"
 import { Button } from "./components/Button"
 
 import { Colors, Spacing, Typography } from "./styles"
@@ -23,13 +23,11 @@ export const ErrorScreen: FunctionComponent<ErrorScreenProps> = ({
     <SafeAreaView style={style.container}>
       <View style={style.content}>
         <View style={style.textContainer}>
-          <RTLEnabledText style={style.title}>
-            {t("errors.title")}
-          </RTLEnabledText>
-          <RTLEnabledText style={style.subtitle}>
+          <GlobalText style={style.title}>{t("errors.title")}</GlobalText>
+          <GlobalText style={style.subtitle}>
             {t("errors.description")}
-          </RTLEnabledText>
-          <RTLEnabledText style={style.error}>{parseError}</RTLEnabledText>
+          </GlobalText>
+          <GlobalText style={style.error}>{parseError}</GlobalText>
         </View>
         <View style={style.buttonContainer}>
           <Button label={t("errors.reload")} onPress={resetError} />

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 
 import { ExposureHistoryStackParamList, Screens } from "../navigation"
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { useStatusBarEffect } from "../navigation"
 import { Possible, ExposureDatum, exposureWindowBucket } from "../exposure"
 
@@ -72,22 +72,22 @@ const ExposureDetail: FunctionComponent = () => {
               height={Iconography.small}
             />
           </View>
-          <RTLEnabledText style={style.exposureWindow}>
+          <GlobalText style={style.exposureWindow}>
             {exposureWindowBucketInWords(exposureDatum)}
-          </RTLEnabledText>
+          </GlobalText>
         </View>
-        <RTLEnabledText style={style.headerText}>{headerText}</RTLEnabledText>
-        <RTLEnabledText style={style.contentText}>{contentText}</RTLEnabledText>
+        <GlobalText style={style.headerText}>{headerText}</GlobalText>
+        <GlobalText style={style.contentText}>{contentText}</GlobalText>
       </View>
       <View style={style.bottomContainer}>
-        <RTLEnabledText style={style.bottomHeaderText}>
+        <GlobalText style={style.bottomHeaderText}>
           {t("exposure_history.exposure_detail.ha_guidance_header")}
-        </RTLEnabledText>
-        <RTLEnabledText style={style.bottomSubheaderText}>
+        </GlobalText>
+        <GlobalText style={style.bottomSubheaderText}>
           {t("exposure_history.exposure_detail.ha_guidance_subheader", {
             healthAuthorityName,
           })}
-        </RTLEnabledText>
+        </GlobalText>
         <View style={style.recommendations}>
           <RecommendationBubble
             icon={Icons.IsolateBubbles}
@@ -110,9 +110,9 @@ const ExposureDetail: FunctionComponent = () => {
           onPress={handleOnPressNextStep}
           style={style.nextStepsButton}
         >
-          <RTLEnabledText style={style.nextStepsButtonText}>
+          <GlobalText style={style.nextStepsButtonText}>
             {t("exposure_history.exposure_detail.next_steps")}
-          </RTLEnabledText>
+          </GlobalText>
         </TouchableOpacity>
       </View>
     </View>
@@ -136,7 +136,7 @@ const RecommendationBubble: FunctionComponent<RecommendationBubbleProps> = ({
           height={Iconography.small}
         />
       </View>
-      <RTLEnabledText style={style.recommendationText}>{text}</RTLEnabledText>
+      <GlobalText style={style.recommendationText}>{text}</GlobalText>
     </View>
   )
 }

--- a/src/ExposureHistory/History/DateInfoHeader.tsx
+++ b/src/ExposureHistory/History/DateInfoHeader.tsx
@@ -5,7 +5,7 @@ import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 dayjs.extend(relativeTime)
 
-import { RTLEnabledText } from "../../components/RTLEnabledText"
+import { GlobalText } from "../../components/GlobalText"
 import { DateTimeUtils } from "../../utils"
 
 import { Colors, Typography } from "../../styles"
@@ -33,12 +33,12 @@ const DateInfoHeader: FunctionComponent<DateInfoHeaderProps> = ({
     : ""
 
   return (
-    <RTLEnabledText style={style.subHeaderText}>
+    <GlobalText style={style.subHeaderText}>
       <>
         {lastDaysText}
         {updatedAtText}
       </>
-    </RTLEnabledText>
+    </GlobalText>
   )
 }
 

--- a/src/ExposureHistory/History/ExposureListItem.tsx
+++ b/src/ExposureHistory/History/ExposureListItem.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 
-import { RTLEnabledText } from "../../components/RTLEnabledText"
+import { GlobalText } from "../../components/GlobalText"
 import { Possible, ExposureDatum, exposureWindowBucket } from "../../exposure"
 
 import { Icons } from "../../assets"
@@ -54,12 +54,12 @@ const ExposureListItem: FunctionComponent<ExposureListItemProps> = ({
     >
       <View style={style.innerContainer}>
         <View>
-          <RTLEnabledText style={style.primaryText}>
+          <GlobalText style={style.primaryText}>
             {t("exposure_history.possible_exposure")}
-          </RTLEnabledText>
-          <RTLEnabledText style={style.secondaryText}>
+          </GlobalText>
+          <GlobalText style={style.secondaryText}>
             {exposureWindowBucketInWords(exposureDatum)}
-          </RTLEnabledText>
+          </GlobalText>
         </View>
         <SvgXml
           xml={Icons.ChevronRight}

--- a/src/ExposureHistory/History/History.tsx
+++ b/src/ExposureHistory/History/History.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
 import { ExposureDatum } from "../../exposure"
-import { RTLEnabledText } from "../../components/RTLEnabledText"
+import { GlobalText } from "../../components/GlobalText"
 
 import DateInfoHeader from "./DateInfoHeader"
 import ExposureList from "./ExposureList"
@@ -52,9 +52,7 @@ const History: FunctionComponent<HistoryProps> = ({
       >
         <View>
           <View style={style.headerRow}>
-            <RTLEnabledText style={style.headerText}>
-              {titleText}
-            </RTLEnabledText>
+            <GlobalText style={style.headerText}>{titleText}</GlobalText>
             <TouchableOpacity
               onPress={handleOnPressMoreInfo}
               style={style.moreInfoButton}

--- a/src/ExposureHistory/History/NoExposures.tsx
+++ b/src/ExposureHistory/History/NoExposures.tsx
@@ -4,7 +4,7 @@ import { Linking, View, StyleSheet, TouchableOpacity } from "react-native"
 import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
 
-import { RTLEnabledText } from "../../components/RTLEnabledText"
+import { GlobalText } from "../../components/GlobalText"
 import { Colors, Typography, Spacing, Outlines } from "../../styles"
 import { Icons } from "../../assets"
 
@@ -17,12 +17,12 @@ const NoExposures: FunctionComponent = () => {
   return (
     <View>
       <View style={style.noExposureCard}>
-        <RTLEnabledText style={style.headerText}>
+        <GlobalText style={style.headerText}>
           {t("exposure_history.no_exposure_reports")}
-        </RTLEnabledText>
-        <RTLEnabledText style={style.subheaderText}>
+        </GlobalText>
+        <GlobalText style={style.subheaderText}>
           {t("exposure_history.no_exposure_reports_over_past")}
-        </RTLEnabledText>
+        </GlobalText>
       </View>
       <HealthGuidelines />
     </View>
@@ -37,32 +37,32 @@ const HealthGuidelines: FunctionComponent = () => {
 
   return (
     <View style={style.card}>
-      <RTLEnabledText style={style.cardHeaderText}>
+      <GlobalText style={style.cardHeaderText}>
         {t("exposure_history.protect_yourself_and_others")}
-      </RTLEnabledText>
+      </GlobalText>
       {Boolean(healthAuthorityLink) && (
         <>
-          <RTLEnabledText style={style.cardSubheaderText}>
+          <GlobalText style={style.cardSubheaderText}>
             {t("exposure_history.review_guidance_from_ha", {
               healthAuthorityName,
             })}
-          </RTLEnabledText>
+          </GlobalText>
           <TouchableOpacity
             onPress={handleOnPressHALink}
             style={style.learnMoreCtaContainer}
           >
-            <RTLEnabledText style={style.learnMoreCta}>
+            <GlobalText style={style.learnMoreCta}>
               {t("exposure_history.learn_more")}
-            </RTLEnabledText>
+            </GlobalText>
             <SvgXml
               xml={Icons.Arrow}
               fill={Colors.primaryViolet}
               style={style.ctaArrow}
             />
           </TouchableOpacity>
-          <RTLEnabledText style={style.listHeading}>
+          <GlobalText style={style.listHeading}>
             {t("exposure_history.health_guidelines.title")}
-          </RTLEnabledText>
+          </GlobalText>
         </>
       )}
       <HealthGuidelineItem
@@ -98,7 +98,7 @@ const HealthGuidelineItem: FunctionComponent<HealthGuidelineItemProps> = ({
       <View style={style.listItemIconContainer}>
         <SvgXml xml={icon} fill={Colors.primaryViolet} />
       </View>
-      <RTLEnabledText style={style.listItemText}>{text}</RTLEnabledText>
+      <GlobalText style={style.listItemText}>{text}</GlobalText>
     </View>
   )
 }

--- a/src/ExposureHistory/MoreInfo.tsx
+++ b/src/ExposureHistory/MoreInfo.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from "react"
 import { View, ScrollView, StyleSheet } from "react-native"
 import { useTranslation } from "react-i18next"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { useStatusBarEffect } from "../navigation"
 
 import { Spacing, Typography, Colors } from "../styles"
@@ -18,20 +18,20 @@ const MoreInfo: FunctionComponent = () => {
         contentContainerStyle={style.contentContainer}
       >
         <View style={style.section}>
-          <RTLEnabledText style={style.headerText}>
+          <GlobalText style={style.headerText}>
             {t("exposure_history.why_did_i_get_an_en")}
-          </RTLEnabledText>
-          <RTLEnabledText style={style.contentText}>
+          </GlobalText>
+          <GlobalText style={style.contentText}>
             {t("exposure_history.why_did_i_get_an_en_para")}
-          </RTLEnabledText>
+          </GlobalText>
         </View>
         <View style={style.section}>
-          <RTLEnabledText style={style.headerText}>
+          <GlobalText style={style.headerText}>
             {t("exposure_history.how_does_this_work")}
-          </RTLEnabledText>
-          <RTLEnabledText style={style.contentText}>
+          </GlobalText>
+          <GlobalText style={style.contentText}>
             {t("exposure_history.how_does_this_work_para")}
-          </RTLEnabledText>
+          </GlobalText>
         </View>
       </ScrollView>
     </>

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -9,7 +9,7 @@ import {
 import { useTranslation } from "react-i18next"
 
 import { ENPermissionStatus } from "../PermissionsContext"
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { isPlatformiOS } from "../utils/index"
 
 import { Layout, Spacing, Colors, Typography, Buttons } from "../styles"
@@ -62,12 +62,12 @@ const Home = ({
   return (
     <View style={style.container}>
       <View style={style.contentContainer}>
-        <RTLEnabledText style={style.headerText} testID={"home-header"}>
+        <GlobalText style={style.headerText} testID={"home-header"}>
           {headerText}
-        </RTLEnabledText>
-        <RTLEnabledText style={style.subheaderText} testID={"home-subheader"}>
+        </GlobalText>
+        <GlobalText style={style.subheaderText} testID={"home-subheader"}>
           {subheaderText}
-        </RTLEnabledText>
+        </GlobalText>
       </View>
       {!isEnabledAndAuthorized ? (
         <TouchableOpacity
@@ -75,7 +75,7 @@ const Home = ({
           onPress={handleRequestPermission}
           style={style.button}
         >
-          <RTLEnabledText style={style.buttonText}>{buttonText}</RTLEnabledText>
+          <GlobalText style={style.buttonText}>{buttonText}</GlobalText>
         </TouchableOpacity>
       ) : null}
     </View>

--- a/src/More/About.tsx
+++ b/src/More/About.tsx
@@ -14,7 +14,7 @@ import {
   getVersion,
 } from "react-native-device-info"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 
 import { Colors, Spacing, Typography } from "../styles"
 
@@ -29,39 +29,39 @@ export const AboutScreen: FunctionComponent = () => {
       alwaysBounceVertical={false}
     >
       <View>
-        <RTLEnabledText style={style.headerContent}>
+        <GlobalText style={style.headerContent}>
           {getApplicationName()}
-        </RTLEnabledText>
+        </GlobalText>
       </View>
-      <RTLEnabledText style={style.aboutContent}>
+      <GlobalText style={style.aboutContent}>
         {t("label.about_para")}
-      </RTLEnabledText>
-      <RTLEnabledText
+      </GlobalText>
+      <GlobalText
         style={style.hyperlink}
         onPress={() => {
           Linking.openURL("https://pathcheck.org/")
         }}
       >
         <Text>pathcheck.org</Text>
-      </RTLEnabledText>
+      </GlobalText>
 
       <View style={style.rowContainer}>
         <View style={style.row}>
-          <RTLEnabledText style={style.aboutSectionParaLabel}>
+          <GlobalText style={style.aboutSectionParaLabel}>
             {t("about.version")}
-          </RTLEnabledText>
+          </GlobalText>
 
-          <RTLEnabledText style={style.aboutSectionParaContent}>
+          <GlobalText style={style.aboutSectionParaContent}>
             {versionInfo}
-          </RTLEnabledText>
+          </GlobalText>
         </View>
         <View style={style.row}>
-          <RTLEnabledText style={style.aboutSectionParaLabel}>
+          <GlobalText style={style.aboutSectionParaLabel}>
             {t("about.operating_system_abbr")}
-          </RTLEnabledText>
-          <RTLEnabledText style={style.aboutSectionParaContent}>
+          </GlobalText>
+          <GlobalText style={style.aboutSectionParaContent}>
             {Platform.OS + " v" + Platform.Version}
-          </RTLEnabledText>
+          </GlobalText>
         </View>
       </View>
     </ScrollView>

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -10,7 +10,7 @@ import {
   ActivityIndicator,
 } from "react-native"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { NativeModule } from "../gaen"
 import { NavigationProp, Screens } from "../navigation"
 
@@ -82,9 +82,7 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
   }: DebugMenuListItemProps) => {
     return (
       <TouchableOpacity style={[style.listItem, itemStyle]} onPress={onPress}>
-        <RTLEnabledText style={{ ...Typography.mainContent }}>
-          {label}
-        </RTLEnabledText>
+        <GlobalText style={{ ...Typography.mainContent }}>{label}</GlobalText>
       </TouchableOpacity>
     )
   }

--- a/src/More/ENLocalDiagnosisKeyScreen.tsx
+++ b/src/More/ENLocalDiagnosisKeyScreen.tsx
@@ -8,7 +8,7 @@ import {
   Text,
 } from "react-native"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { NavigationProp } from "../navigation"
 
 import { NativeModule } from "../gaen"
@@ -76,9 +76,9 @@ const ENLocalDiagnosisKeyScreen = ({
       keyExtractor={(item) => item.id}
       renderItem={(item) => (
         <View style={style.flatlistRowView}>
-          <RTLEnabledText style={style.itemText}>
+          <GlobalText style={style.itemText}>
             <Text>Rolling start number: {item.item.rollingStartNumber}</Text>
-          </RTLEnabledText>
+          </GlobalText>
         </View>
       )}
     />

--- a/src/More/ENSubmitDebugForm.tsx
+++ b/src/More/ENSubmitDebugForm.tsx
@@ -13,7 +13,7 @@ import {
 } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { NativeModule } from "../gaen"
 import * as API from "./debugAPI"
 
@@ -86,15 +86,15 @@ const CodeInputScreen: FunctionComponent = () => {
           <View style={style.container}>
             <View>
               <View style={style.headerContainer}>
-                <RTLEnabledText style={style.header}>
+                <GlobalText style={style.header}>
                   {t("more.debug.submit_your_debug_log")}
-                </RTLEnabledText>
+                </GlobalText>
               </View>
 
               <View style={style.inputContainer}>
-                <RTLEnabledText style={style.inputLabel}>
+                <GlobalText style={style.inputLabel}>
                   {t("label.email_optional")}
-                </RTLEnabledText>
+                </GlobalText>
                 <TextInput
                   value={email}
                   placeholder={"email@example.com"}
@@ -110,9 +110,9 @@ const CodeInputScreen: FunctionComponent = () => {
               </View>
 
               <View style={style.inputContainer}>
-                <RTLEnabledText style={style.inputLabel}>
+                <GlobalText style={style.inputLabel}>
                   {t("label.description_optional")}
-                </RTLEnabledText>
+                </GlobalText>
                 <TextInput
                   value={description}
                   style={style.descriptionInput}
@@ -125,9 +125,9 @@ const CodeInputScreen: FunctionComponent = () => {
                 />
               </View>
 
-              <RTLEnabledText style={style.errorSubtitle}>
+              <GlobalText style={style.errorSubtitle}>
                 {errorMessage}
-              </RTLEnabledText>
+              </GlobalText>
             </View>
             {isLoading ? <LoadingIndicator /> : null}
 
@@ -139,9 +139,9 @@ const CodeInputScreen: FunctionComponent = () => {
                 accessibilityRole="button"
                 style={style.button}
               >
-                <RTLEnabledText style={style.buttonText}>
+                <GlobalText style={style.buttonText}>
                   {t("common.submit")}
-                </RTLEnabledText>
+                </GlobalText>
               </TouchableOpacity>
             </View>
           </View>

--- a/src/More/ExposureListDebugScreen.tsx
+++ b/src/More/ExposureListDebugScreen.tsx
@@ -9,7 +9,7 @@ import {
   NativeModules,
 } from "react-native"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { NavigationProp } from "../navigation"
 
 import dayjs from "dayjs"
@@ -84,9 +84,9 @@ const ExposureListDebugScreen = ({
       keyExtractor={(item) => item.id}
       renderItem={(item) => (
         <View style={style.flatlistRowView}>
-          <RTLEnabledText style={style.itemText}>
+          <GlobalText style={style.itemText}>
             <Text>Date: {item.item.date}</Text>
-          </RTLEnabledText>
+          </GlobalText>
         </View>
       )}
     />

--- a/src/More/LanguageSelection.tsx
+++ b/src/More/LanguageSelection.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
 import { getLocaleList, setUserLocaleOverride } from "../locales/languages"
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 
 import { Colors, Spacing, Typography } from "../styles"
 
@@ -43,14 +43,14 @@ const LanguageSelection = (): JSX.Element => {
           }}
           onPress={() => onSelectLanguage(value)}
         >
-          <RTLEnabledText
+          <GlobalText
             style={{
               ...Typography.mainContent,
               fontWeight: language === value ? "700" : "500",
             }}
           >
             {label}
-          </RTLEnabledText>
+          </GlobalText>
         </TouchableHighlight>
       )}
       ItemSeparatorComponent={() => <Separator />}

--- a/src/More/Licenses.tsx
+++ b/src/More/Licenses.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native"
 import { useTranslation } from "react-i18next"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 
 import { Images } from "../assets"
 import { Colors, Spacing, Typography } from "../styles"
@@ -35,31 +35,31 @@ const Licenses = (): JSX.Element => {
         alwaysBounceVertical={false}
       >
         <View>
-          <RTLEnabledText
+          <GlobalText
             style={style.headerContent}
             testID={"licenses-legal-header"}
           >
             {legalHeaderText}
-          </RTLEnabledText>
+          </GlobalText>
           <View
             style={{ paddingTop: Spacing.xSmall, paddingLeft: Spacing.medium }}
           >
-            <RTLEnabledText style={style.contentText}>
+            <GlobalText style={style.contentText}>
               {t("label.legal_page_address")}
-            </RTLEnabledText>
+            </GlobalText>
             <View style={{ height: 20 }} />
-            <RTLEnabledText
+            <GlobalText
               onPress={handleOnPressOpenUrl("mailto:info@pathcheck.org")}
               style={style.hyperlink}
             >
               {infoAddress}
-            </RTLEnabledText>
-            <RTLEnabledText
+            </GlobalText>
+            <GlobalText
               onPress={handleOnPressOpenUrl("https://pathcheck.org/")}
               style={style.hyperlink}
             >
               {pathCheckAddress}
-            </RTLEnabledText>
+            </GlobalText>
           </View>
         </View>
       </ScrollView>
@@ -67,11 +67,9 @@ const Licenses = (): JSX.Element => {
         style={style.termsInfoRow}
         onPress={handleOnPressOpenUrl(PRIVACY_POLICY_URL)}
       >
-        <RTLEnabledText
-          style={{ ...Typography.mainContent, color: Colors.white }}
-        >
+        <GlobalText style={{ ...Typography.mainContent, color: Colors.white }}>
           {t("label.privacy_policy")}
-        </RTLEnabledText>
+        </GlobalText>
         <View style={style.arrowContainer}>
           <Image source={Images.ForeArrow} />
         </View>

--- a/src/More/Menu.tsx
+++ b/src/More/Menu.tsx
@@ -16,7 +16,7 @@ import {
 } from "react-navigation"
 
 import { getLocalNames } from "../locales/languages"
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { Stacks, Screens, useStatusBarEffect } from "../navigation"
 
 import { Icons } from "../assets"
@@ -50,9 +50,7 @@ const LanguageSelectionListItem = ({
         accessibilityLabel={iconLabel}
         style={[style.icon, { marginRight: Spacing.small }]}
       />
-      <RTLEnabledText style={{ ...Typography.mainContent }}>
-        {label}
-      </RTLEnabledText>
+      <GlobalText style={{ ...Typography.mainContent }}>{label}</GlobalText>
     </View>
   </TouchableHighlight>
 )
@@ -85,11 +83,9 @@ const MenuScreen: FunctionComponent<MenuScreenProps> = ({ navigation }) => {
         onPress={onPress}
       >
         <View>
-          <RTLEnabledText style={style.listItemText}>{label}</RTLEnabledText>
+          <GlobalText style={style.listItemText}>{label}</GlobalText>
           {description ? (
-            <RTLEnabledText style={style.descriptionText}>
-              {description}
-            </RTLEnabledText>
+            <GlobalText style={style.descriptionText}>{description}</GlobalText>
           ) : null}
         </View>
       </TouchableHighlight>
@@ -99,16 +95,14 @@ const MenuScreen: FunctionComponent<MenuScreenProps> = ({ navigation }) => {
   return (
     <ScrollView style={style.container}>
       <View style={style.sectionPrimary}>
-        <RTLEnabledText>
-          {t("settings.share_test_result_description")}
-        </RTLEnabledText>
+        <GlobalText>{t("settings.share_test_result_description")}</GlobalText>
         <TouchableOpacity
           onPress={() => navigation.navigate(Stacks.AffectedUserStack)}
           style={style.button}
         >
-          <RTLEnabledText style={style.buttonText}>
+          <GlobalText style={style.buttonText}>
             {t("settings.share_test_result")}
-          </RTLEnabledText>
+          </GlobalText>
         </TouchableOpacity>
       </View>
 

--- a/src/Onboarding/EulaModal.tsx
+++ b/src/Onboarding/EulaModal.tsx
@@ -15,7 +15,7 @@ import loadLocalResource from "react-native-local-resource"
 import WebView, { WebViewNavigation } from "react-native-webview"
 import { SvgXml } from "react-native-svg"
 
-import { Button, RTLEnabledText } from "../components"
+import { Button, GlobalText } from "../components"
 import en from "../locales/eula/en.html"
 import es_PR from "../locales/eula/es_PR.html"
 import ht from "../locales/eula/ht.html"
@@ -73,7 +73,7 @@ const Checkbox: FunctionComponent<CheckboxProps> = ({
         source={checked ? Images.BoxCheckedIcon : Images.BoxUncheckedIcon}
         style={style.checkboxIcon}
       />
-      <RTLEnabledText style={style.checkboxText}>{label}</RTLEnabledText>
+      <GlobalText style={style.checkboxText}>{label}</GlobalText>
     </TouchableOpacity>
   )
 }
@@ -144,9 +144,9 @@ const EulaModal: FunctionComponent<EulaModalProps> = ({
   return (
     <>
       <TouchableOpacity style={style.button} onPress={handleOnPressGetStarted}>
-        <RTLEnabledText style={style.buttonText}>
+        <GlobalText style={style.buttonText}>
           {t("label.launch_get_started")}
-        </RTLEnabledText>
+        </GlobalText>
       </TouchableOpacity>
       <Modal animationType="slide" transparent visible={modalVisible}>
         <View style={style.container}>
@@ -180,9 +180,9 @@ const EulaModal: FunctionComponent<EulaModalProps> = ({
                   onPress={() => toggleCheckbox(!boxChecked)}
                   checked={boxChecked}
                 />
-                <RTLEnabledText style={style.smallDescriptionText}>
+                <GlobalText style={style.smallDescriptionText}>
                   {t("onboarding.eula_message")}
-                </RTLEnabledText>
+                </GlobalText>
               </View>
               <Button
                 label={t("onboarding.eula_continue")}

--- a/src/Onboarding/ExplanationScreen.tsx
+++ b/src/Onboarding/ExplanationScreen.tsx
@@ -12,7 +12,7 @@ import { SvgXml } from "react-native-svg"
 
 import { Button } from "../components/Button"
 import { useStatusBarEffect } from "../navigation"
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 
 import { Buttons, Colors, Spacing, Iconography, Typography } from "../styles"
 
@@ -118,12 +118,12 @@ const ExplanationScreen = ({
               accessibilityLabel={explanationScreenContent.iconLabel}
             />
           </View>
-          <RTLEnabledText style={headerStyles}>
+          <GlobalText style={headerStyles}>
             {explanationScreenContent.header}
-          </RTLEnabledText>
-          <RTLEnabledText style={contentStyles}>
+          </GlobalText>
+          <GlobalText style={contentStyles}>
             {explanationScreenContent.body}
-          </RTLEnabledText>
+          </GlobalText>
         </ScrollView>
         <Button
           label={explanationScreenContent.primaryButtonLabel}

--- a/src/Onboarding/Welcome.tsx
+++ b/src/Onboarding/Welcome.tsx
@@ -10,7 +10,7 @@ import {
   TouchableOpacity,
 } from "react-native"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import EulaModal from "./EulaModal"
 import { getLocalNames } from "../locales/languages"
 
@@ -54,15 +54,15 @@ const Welcome: FunctionComponent = () => {
               onPress={() => navigation.navigate(Screens.LanguageSelection)}
               style={style.languageSelector}
             >
-              <RTLEnabledText style={style.languageSelectorText}>
+              <GlobalText style={style.languageSelectorText}>
                 {languageName}
-              </RTLEnabledText>
+              </GlobalText>
             </TouchableOpacity>
           </View>
           <View style={style.contentContainer}>
-            <RTLEnabledText style={style.mainText}>
+            <GlobalText style={style.mainText}>
               {t("label.launch_screen1_header")}
-            </RTLEnabledText>
+            </GlobalText>
           </View>
           <View style={style.footerContainer}>
             <EulaModal

--- a/src/SelfAssessment/Agreement.tsx
+++ b/src/SelfAssessment/Agreement.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from "@react-navigation/native"
 import InfoText from "./InfoText"
 import { Button } from "../components/Button"
 import { AssessmentLayout } from "./AssessmentLayout"
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 
 import { Colors, Typography } from "../styles"
 import { Icons } from "../assets"
@@ -52,7 +52,7 @@ const AgreementFooter: FunctionComponent<AgreementFooterProps> = ({
 }) => (
   <>
     <Button onPress={onPress} label={buttonTitle} />
-    <RTLEnabledText style={style.typographyStyle}>{description}</RTLEnabledText>
+    <GlobalText style={style.typographyStyle}>{description}</GlobalText>
   </>
 )
 

--- a/src/SelfAssessment/AssessmentQuestion.js
+++ b/src/SelfAssessment/AssessmentQuestion.js
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import { Button } from "../components/Button"
 import { AnswersContext } from "./Context"
 import { AssessmentOption } from "./AssessmentOption"
@@ -42,9 +42,9 @@ export const AssessmentQuestion = ({ onNext, onChange, option, question }) => {
       let l = line.trim()
       if (!l) continue
       elements.push(
-        <RTLEnabledText testID="description" key={l} style={style.description}>
+        <GlobalText testID="description" key={l} style={style.description}>
           {l}
-        </RTLEnabledText>,
+        </GlobalText>,
       )
     }
     return <View style={style.descriptionWrapper}>{elements}</View>
@@ -120,15 +120,15 @@ export const AssessmentQuestion = ({ onNext, onChange, option, question }) => {
     <SafeAreaView style={style.container}>
       <ScrollView style={style.scrollView}>
         <View style={style.header}>
-          <RTLEnabledText style={style.headerContent}>
+          <GlobalText style={style.headerContent}>
             {question.question_text}
-          </RTLEnabledText>
+          </GlobalText>
         </View>
         <View style={style.scrollViewContent}>
           {description}
-          <RTLEnabledText style={style.instruction}>
+          <GlobalText style={style.instruction}>
             {assessmentInputInstruction}
-          </RTLEnabledText>
+          </GlobalText>
           <View style={style.optionsWrapper}>{options}</View>
         </View>
       </ScrollView>

--- a/src/SelfAssessment/EmergencyAssessment.js
+++ b/src/SelfAssessment/EmergencyAssessment.js
@@ -9,7 +9,7 @@ import {
 } from "./constants"
 import { AssessmentLayout } from "./AssessmentLayout"
 import InfoText from "./InfoText"
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 
 import { Typography, Buttons, Colors } from "../styles"
 
@@ -64,12 +64,12 @@ const ChoiceButtons = ({ agreePress, disagreePress }) => {
         accessibilityRole="button"
         style={style.button}
       >
-        <RTLEnabledText style={{ ...style.buttonText, ...style.boldText }}>
+        <GlobalText style={{ ...style.buttonText, ...style.boldText }}>
           {t("assessment.i_am")}
-          <RTLEnabledText style={{ ...style.buttonText, ...style.regularText }}>
+          <GlobalText style={{ ...style.buttonText, ...style.regularText }}>
             {t("assessment.experiencing_some_symptoms")}
-          </RTLEnabledText>
-        </RTLEnabledText>
+          </GlobalText>
+        </GlobalText>
       </TouchableOpacity>
       <TouchableOpacity
         onPress={disagreePress}
@@ -78,12 +78,12 @@ const ChoiceButtons = ({ agreePress, disagreePress }) => {
         accessibilityRole="button"
         style={{ ...style.button, ...style.disagreeButton }}
       >
-        <RTLEnabledText style={{ ...style.buttonText, ...style.boldText }}>
+        <GlobalText style={{ ...style.buttonText, ...style.boldText }}>
           {t("assessment.i_am_not")}
-          <RTLEnabledText style={{ ...style.buttonText, ...style.regularText }}>
+          <GlobalText style={{ ...style.buttonText, ...style.regularText }}>
             {t("assessment.experiencing_any_symptoms")}
-          </RTLEnabledText>
-        </RTLEnabledText>
+          </GlobalText>
+        </GlobalText>
       </TouchableOpacity>
     </View>
   )

--- a/src/SelfAssessment/InfoText.tsx
+++ b/src/SelfAssessment/InfoText.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react"
 import { StyleSheet } from "react-native"
 
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 
 import { Typography } from "../styles"
 
@@ -13,11 +13,11 @@ interface InfoTextProps {
 const InfoText: FunctionComponent<InfoTextProps> = ({ title, description }) => {
   return (
     <>
-      <RTLEnabledText style={style.titleContent}>{title}</RTLEnabledText>
+      <GlobalText style={style.titleContent}>{title}</GlobalText>
       {description && (
-        <RTLEnabledText style={style.descriptionContent} testID="description">
+        <GlobalText style={style.descriptionContent} testID="description">
           {description}
-        </RTLEnabledText>
+        </GlobalText>
       )}
     </>
   )

--- a/src/SelfAssessment/Option.tsx
+++ b/src/SelfAssessment/Option.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, TouchableOpacity, View, ViewStyle } from "react-native"
 import { SvgXml } from "react-native-svg"
 
 import Icon from "../assets/svgs/check"
-import { RTLEnabledText } from "../components/RTLEnabledText"
+import { GlobalText } from "../components/GlobalText"
 import {
   SCREEN_TYPE_CHECKBOX,
   SCREEN_TYPE_DATE,
@@ -78,9 +78,9 @@ const OptionSelect: FunctionComponent<OptionSelectProps> = ({
             (inputType === SCREEN_TYPE_RADIO || inputType === SCREEN_TYPE_DATE)}
         </View>
       )}
-      <RTLEnabledText style={style.title} testID="label">
+      <GlobalText style={style.title} testID="label">
         {title}
-      </RTLEnabledText>
+      </GlobalText>
     </View>
   )
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
 } from "react-native"
 
-import { RTLEnabledText } from "./RTLEnabledText"
+import { GlobalText } from "./GlobalText"
 
 import { Buttons, Typography } from "../styles"
 
@@ -51,7 +51,7 @@ export const Button = ({
       {loading ? (
         <ActivityIndicator size={"large"} />
       ) : (
-        <RTLEnabledText style={buttonTextStyle}>{label}</RTLEnabledText>
+        <GlobalText style={buttonTextStyle}>{label}</GlobalText>
       )}
     </TouchableOpacity>
   )

--- a/src/components/GlobalText.tsx
+++ b/src/components/GlobalText.tsx
@@ -3,19 +3,19 @@ import { Text, TextStyle } from "react-native"
 
 import { useLanguageDirection } from "../locales/languages"
 
-interface RTLEnabledTextProps {
+interface GlobalTextProps {
   style?: TextStyle
   testID?: string
   onPress?: () => void
   children: JSX.Element | string
 }
 
-export const RTLEnabledText = ({
+export const GlobalText = ({
   style,
   testID,
   children,
   onPress,
-}: RTLEnabledTextProps): JSX.Element => {
+}: GlobalTextProps): JSX.Element => {
   const writingDirection = useLanguageDirection()
 
   return (

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,2 @@
 export { Button } from "./Button"
-export { RTLEnabledText } from "./RTLEnabledText"
+export { GlobalText } from "./GlobalText"


### PR DESCRIPTION
Why: RTLEnabledText is more visually fatiguing than GlobalText.

### Before & After
<img width="50%" alt="Screen Shot 2020-07-29 at 7 40 50 PM" src="https://user-images.githubusercontent.com/39350030/88864581-8e10ed00-d1d3-11ea-885b-9043bd8937ba.png"><img width="50%" alt="Screen Shot 2020-07-29 at 7 40 14 PM" src="https://user-images.githubusercontent.com/39350030/88864582-8ea98380-d1d3-11ea-935e-08d641771b19.png">