### PR TITLE
Update exposure configuration (iOS)

### DIFF
--- a/ios/BT/API/Model/ExposureConfiguration.swift
+++ b/ios/BT/API/Model/ExposureConfiguration.swift
@@ -16,7 +16,7 @@ extension ExposureConfiguration {
 
   static var placeholder: ExposureConfiguration = {
     ExposureConfiguration(minimumRiskScore: 0,
-                          attenuationDurationThresholds: [50, 70],
+                          attenuationDurationThresholds: [53, 60],
                           attenuationLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],
                           daysSinceLastExposureLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],
                           durationLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],


### PR DESCRIPTION
### Why
We'd like update the `attenuationDurationThresholds` on our exposure configuration. This change is temporary, as we'll ultimately be getting these values from a server

### This Commit
This commit updates our working exposure configuration to match the `attenuationDurationThresholds` values used by the Swiss PT – DP3T App:
https://github.com/DP-3T/dp3t-config-backend-ch/blob/55fbe7493775402804493eced4c8128ac15db9f8/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/GAENSDKConfig.java#L15
