### PR TITLE
Fix lokalise pull script for android

### DIFF
--- a/.github/workflows/lokalise.yml
+++ b/.github/workflows/lokalise.yml
@@ -8,6 +8,7 @@ on:
       - src/locales/eula/en.html
       - ios/en.lproj/*.strings
       - android/app/src/main/res/values/strings.xml
+      - android/app/src/bt/res/values/strings.xml
       - .github/workflows/*.yml
       - src/locales/*.sh
 

--- a/android/app/src/bt/res/values-es-rPR/strings.xml
+++ b/android/app/src/bt/res/values-es-rPR/strings.xml
@@ -2,5 +2,4 @@
 <resources>
   <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
   <string name="notification_channel_description">Notificaciones de PathCheck BT</string>
-  <!-- Server URI for diagnosis key file download -->
 </resources>

--- a/android/app/src/bt/res/values-ht-rHT/strings.xml
+++ b/android/app/src/bt/res/values-ht-rHT/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">PathCheck Bluetooth upozornenia</string>
+  <string name="notification_channel_description">Notifikasyon Chase Kowona (\"PathCheck\") BT </string>
 </resources>

--- a/android/app/src/bt/res/values-ru/strings.xml
+++ b/android/app/src/bt/res/values-ru/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Настроить местные оповещения</string>
+  <string name="notification_channel_description">PathCheck BT уведомления</string>
 </resources>

--- a/android/app/src/bt/res/values/strings.xml
+++ b/android/app/src/bt/res/values/strings.xml
@@ -4,11 +4,10 @@
   <string name="app_name" translatable="false">PathCheck BT</string>
   <!-- Shown below icon on launcher only -->
   <string name="app_name_short" translatable="false">PathCheck BT</string>
+  <string name="exposure_notification_channel_description">Exposure notification alerts.</string>
+  <string name="exposure_notification_channel_name">Exposure Notification</string>
+  <string name="exposure_notification_message">Someone you were near has tested positive for COVID-19. Tap for more info.</string>
+  <string name="exposure_notification_title">Possible COVID-19 exposure</string>
   <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
   <string name="notification_channel_description">PathCheck BT notifications</string>
-
-  <string name="exposure_notification_title">Possible COVID-19 exposure</string>
-  <string name="exposure_notification_message">Someone you were near has tested positive for COVID-19. Tap for more info.</string>
-  <string name="exposure_notification_channel_name">Exposure Notification</string>
-  <string name="exposure_notification_channel_description">Exposure notification alerts.</string>
 </resources>

--- a/src/locales/pull.sh
+++ b/src/locales/pull.sh
@@ -54,7 +54,8 @@ lokalise2 file download \
   --export-empty-as skip \
   --format xml \
   --include-description \
-  --original-filenames \
+  --original-filenames=false \
+  --bundle-structure "values-%LANG_ISO%/strings.xml" \
   --unzip-to=android/app/src/bt/res \
   --export-sort=a_z \
   --config .lokalise.yml \


### PR DESCRIPTION
Why:
----
The android file structure resulting from executing the script for the localization files was of the form:
`android/app/src/bt/res/values-{LANG_ISO}/android/app/src/bt/res/values-{LANG_ISO}/strings.xml`

This is incorrect, the files should be stored in the structure
`android/app/src/bt/res/values-{LANG-ISO}/strings.xml`

This Commit:
----
- Update arguments for pulling files for the android project and unzipping them
- Execute pull script for android new file structure