### PR TITLE
Bump Target SDK Version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,9 +3,9 @@
 buildscript {
     ext.kotlin_version = '1.3.72'
     ext {
-        compileSdkVersion = 28
+        compileSdkVersion = 29
         buildToolsVersion = "28.0.3"
-        targetSdkVersion = 28
+        targetSdkVersion = 29
         minSdkVersion = 23
         supportLibVersion = "28.0.0"
         googlePlayServicesVersion = "11+"


### PR DESCRIPTION
#### Description:
Fix Google Play Dev console upload warning.
```
Warnings
Your app currently targets API level 28 and must target at least API level 29 to ensure it is built on the latest APIs optimized for security and performance.
From August 2020, new apps must target at least Android 10 (API level 29).
From November 2020, app updates must target Android 10 (API level 29).
Tip: Change your app's target API level. Learn how.
```