### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Populate the following 2 `.env` files with the relevant urls for your GAEN serve
 .env.bt # variables used in building binaries
 ```
 
-**Note:** Members of the `Path-Check` org can complete this step by making a `.env` file based on the `example.env` file in the project and inputting their GitHub access token. Then run `bin/fetch_ha_env.sh` and passing in the 2-letter ha abbreviation as the first argument (i.e. `bin/fetch_ha_env.sh pc`)
+**Note:** Members of the `Path-Check` org can complete this step by making a `.env` file based on the `example.env` file in the project and inputting their GitHub access token. Then run `bin/set_ha.sh ${HA_LABEL}` and passing in the 2-letter ha abbreviation as the first argument (i.e. `bin/set_ha_env.sh pc`). This will also setup the values for the display name of the applications and will ensure that we are working with the latest configuration.
 
 ## Running
 


### PR DESCRIPTION
#### Description:
Recommend `bin/set_ha.sh` instead of `bin/fetch_ha_env` because `bin/set_ha.sh` already handles fetching the environment variables.