### PR TITLE
Add tests for AffectedUserFlow

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -172,6 +172,7 @@ const CodeInputForm: FunctionComponent = () => {
           <TouchableOpacity
             onPress={handleOnPressCancel}
             style={style.secondaryButton}
+            accessibilityLabel={t("export.code_input_button_cancel")}
           >
             <GlobalText style={style.secondaryButtonText}>
               {t("export.code_input_button_cancel")}

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.spec.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import { Linking } from "react-native"
+import { render, fireEvent } from "@testing-library/react-native"
+import { useNavigation } from "@react-navigation/native"
+
+import EnableExposureNotifications from "./EnableExposureNotifications"
+
+jest.mock("@react-navigation/native")
+describe("EnableExposureNotifications", () => {
+  it("displays the explanations for the exposure notifications", () => {
+    const { getByText } = render(<EnableExposureNotifications />)
+    expect(
+      getByText(
+        "You must enable exposure notifcations to report a positive test result.",
+      ),
+    ).toBeDefined()
+    expect(getByText("Enable exposure notifications to continue")).toBeDefined()
+  })
+
+  it("navigates to the more screen if users cancels", () => {
+    const navigateSpy = jest.fn()
+    ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+    const { getByLabelText } = render(<EnableExposureNotifications />)
+
+    fireEvent.press(getByLabelText("Cancel"))
+    expect(navigateSpy).toHaveBeenCalledWith("More")
+  })
+
+  it("takes user to system settings if decide to activate notifications", () => {
+    const openSettingsSpy = jest.spyOn(Linking, "openSettings")
+    const { getByLabelText } = render(<EnableExposureNotifications />)
+
+    fireEvent.press(getByLabelText("Open Settings"))
+    expect(openSettingsSpy).toHaveBeenCalled()
+  })
+})

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
@@ -50,6 +50,7 @@ const EnableExposureNotifications: FunctionComponent = () => {
         <TouchableOpacity
           onPress={handleOnPressCancel}
           style={style.secondaryButton}
+          accessibilityLabel={t("export.code_input_button_cancel")}
         >
           <GlobalText style={style.secondaryButtonText}>
             {t("export.code_input_button_cancel")}

--- a/src/AffectedUserFlow/Complete.spec.tsx
+++ b/src/AffectedUserFlow/Complete.spec.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+import { useNavigation } from "@react-navigation/native"
+
+import Complete from "./Complete"
+
+jest.mock("@react-navigation/native")
+describe("Complete", () => {
+  it("displays information about completing the flow", () => {
+    const { getByText } = render(<Complete />)
+    expect(getByText("Thanks for keeping your community safe!")).toBeDefined()
+    expect(
+      getByText(
+        "By choosing to share your status and anonymously notify others, you’re helping contain the spread of the virus and protect others in your community.",
+      ),
+    ).toBeDefined()
+  })
+
+  it("navigates to the more screen when user press on done", () => {
+    const navigateSpy = jest.fn()
+    ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+    const { getByLabelText } = render(<Complete />)
+
+    fireEvent.press(getByLabelText("Done"))
+    expect(navigateSpy).toHaveBeenCalledWith("More")
+  })
+})

--- a/src/AffectedUserFlow/Complete.tsx
+++ b/src/AffectedUserFlow/Complete.tsx
@@ -21,6 +21,7 @@ export const ExportComplete: FunctionComponent = () => {
 
   const title = t("export.complete_title")
   const body = t("export.complete_body_bluetooth")
+  const doneCaption = t("common.done")
 
   return (
     <View style={style.backgroundImage}>
@@ -31,8 +32,12 @@ export const ExportComplete: FunctionComponent = () => {
             <GlobalText style={style.contentText}>{body}</GlobalText>
           </View>
 
-          <TouchableOpacity style={style.button} onPress={handleOnPressDone}>
-            <GlobalText style={style.buttonText}>{t("common.done")}</GlobalText>
+          <TouchableOpacity
+            style={style.button}
+            onPress={handleOnPressDone}
+            accessibilityLabel={doneCaption}
+          >
+            <GlobalText style={style.buttonText}>{doneCaption}</GlobalText>
           </TouchableOpacity>
         </View>
       </SafeAreaView>

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { cleanup, render, fireEvent, wait } from "@testing-library/react-native"
+import { render, fireEvent, wait } from "@testing-library/react-native"
 import "@testing-library/jest-native/extend-expect"
 import { useNavigation } from "@react-navigation/native"
 
@@ -7,40 +7,107 @@ import PublishConsentForm from "./PublishConsentForm"
 import { Screens } from "../../navigation"
 import { ExposureContext } from "../../ExposureContext"
 import { factories } from "../../factories"
-
-afterEach(cleanup)
+import { Alert } from "react-native"
 
 jest.mock("@react-navigation/native")
 
 describe("PublishConsentScreen", () => {
-  describe("when the provider has a valid hmac and certificate", () => {
-    describe("on a successful key submission", () => {
-      it("navigates to the affected user complete screen", async () => {
-        const navigateSpy = jest.fn()
-        ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+  it("navigates to the main settings screen when user cancels", () => {
+    const navigateSpy = jest.fn()
+    ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+    const { getByLabelText } = render(
+      <ExposureContext.Provider value={factories.exposureContext.build()}>
+        <PublishConsentForm hmacKey="hmacKey" certificate="certificate" />
+      </ExposureContext.Provider>,
+    )
 
-        const hmacKey = "hmacKey"
-        const certificate = "certificate"
-        const submitDiagnosisKeysSpy = jest.fn().mockResolvedValue("")
-        const exposureContext = factories.exposureContext.build({
-          submitDiagnosisKeys: submitDiagnosisKeysSpy,
-        })
+    fireEvent.press(getByLabelText("Cancel"))
 
-        const { getByLabelText } = render(
-          <ExposureContext.Provider value={exposureContext}>
-            <PublishConsentForm hmacKey={hmacKey} certificate={certificate} />
-          </ExposureContext.Provider>,
+    expect(navigateSpy).toHaveBeenCalledWith("More")
+  })
+
+  it("displays the consent title and body", () => {
+    const { getByText } = render(
+      <ExposureContext.Provider value={factories.exposureContext.build()}>
+        <PublishConsentForm hmacKey="hmacKey" certificate="certificate" />
+      </ExposureContext.Provider>,
+    )
+
+    expect(getByText("Notify your community")).toBeDefined()
+    expect(
+      getByText(
+        "Sharing your positive diagnosis is optional and can only be done with your consent.",
+        { exact: false },
+      ),
+    ).toBeDefined()
+    expect(
+      getByText(
+        "If you choose to do so, you're helping others in your community make informed decisions about their health and playing your part to contain the spread of the virus.",
+        { exact: false },
+      ),
+    ).toBeDefined()
+    expect(
+      getByText(
+        "The only information shared will be the random set of numbers your phone exchanged over Bluetooth with other phones that were nearby during the past 14 days, along with a weighted risk score based on when your symptoms developed.",
+        { exact: false },
+      ),
+    ).toBeDefined()
+  })
+
+  describe("on a successful key submission", () => {
+    it("navigates to the affected user complete screen", async () => {
+      const navigateSpy = jest.fn()
+      ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+
+      const hmacKey = "hmacKey"
+      const certificate = "certificate"
+      const submitDiagnosisKeysSpy = jest.fn().mockResolvedValue("")
+      const exposureContext = factories.exposureContext.build({
+        submitDiagnosisKeys: submitDiagnosisKeysSpy,
+      })
+
+      const { getByLabelText } = render(
+        <ExposureContext.Provider value={exposureContext}>
+          <PublishConsentForm hmacKey={hmacKey} certificate={certificate} />
+        </ExposureContext.Provider>,
+      )
+
+      fireEvent.press(getByLabelText("I understand and consent"))
+
+      await wait(() => {
+        expect(submitDiagnosisKeysSpy).toHaveBeenCalledWith(
+          certificate,
+          hmacKey,
         )
+        expect(navigateSpy).toHaveBeenCalledWith(Screens.AffectedUserComplete)
+      })
+    })
+  })
 
-        fireEvent.press(getByLabelText("I understand and consent"))
+  describe("on a failed key submission", () => {
+    it("displays an alert with a generic message", async () => {
+      const hmacKey = "hmacKey"
+      const certificate = "certificate"
+      const submitDiagnosisKeysSpy = jest.fn().mockRejectedValueOnce("reject")
+      const exposureContext = factories.exposureContext.build({
+        submitDiagnosisKeys: submitDiagnosisKeysSpy,
+      })
+      const alertSpy = jest.spyOn(Alert, "alert")
 
-        await wait(() => {
-          expect(submitDiagnosisKeysSpy).toHaveBeenCalledWith(
-            certificate,
-            hmacKey,
-          )
-          expect(navigateSpy).toHaveBeenCalledWith(Screens.AffectedUserComplete)
-        })
+      const { getByLabelText } = render(
+        <ExposureContext.Provider value={exposureContext}>
+          <PublishConsentForm hmacKey={hmacKey} certificate={certificate} />
+        </ExposureContext.Provider>,
+      )
+
+      fireEvent.press(getByLabelText("I understand and consent"))
+
+      await wait(() => {
+        expect(submitDiagnosisKeysSpy).toHaveBeenCalledWith(
+          certificate,
+          hmacKey,
+        )
+        expect(alertSpy).toHaveBeenCalledWith("Something went wrong", undefined)
       })
     })
   })

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -56,6 +56,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
     <ImageBackground
       source={Images.BlueGradientBackground}
       style={style.backgroundImage}
+      testID="publish-consent-form"
     >
       <SafeAreaView style={{ flex: 1 }}>
         <ScrollView
@@ -88,6 +89,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
             <TouchableOpacity
               onPress={handleOnPressCancel}
               style={style.secondaryButton}
+              accessibilityLabel={t("export.consent_button_cancel")}
             >
               <GlobalText style={style.secondaryButtonText}>
                 {t("export.consent_button_cancel")}

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.spec.tsx
@@ -1,0 +1,52 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+import { useNavigation } from "@react-navigation/native"
+
+import { AffectedUserContext } from "../AffectedUserContext"
+import PublishConsentScreen from "./PublishConsentScreen"
+
+jest.mock("@react-navigation/native")
+
+describe("PublishConsentScreen", () => {
+  describe("when the context contains hmacKey and certificate", () => {
+    it("renders the PublishConsentForm", () => {
+      const { queryByText, getByTestId } = render(
+        <AffectedUserContext.Provider
+          value={{
+            hmacKey: "hmacKey",
+            certificate: "certificate",
+            setExposureSubmissionCredentials: jest.fn(),
+          }}
+        >
+          <PublishConsentScreen />
+        </AffectedUserContext.Provider>,
+      )
+
+      expect(queryByText("Invalid State")).toBeNull()
+      expect(getByTestId("publish-consent-form")).toBeDefined()
+    })
+  })
+
+  describe("when the context is missing hmacKey and certificate", () => {
+    it("displays warning and prompts user to go back to more screen", () => {
+      const navigateSpy = jest.fn()
+      ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+      const { getByText } = render(
+        <AffectedUserContext.Provider
+          value={{
+            hmacKey: null,
+            certificate: null,
+            setExposureSubmissionCredentials: jest.fn(),
+          }}
+        >
+          <PublishConsentScreen />
+        </AffectedUserContext.Provider>,
+      )
+
+      expect(getByText("Invalid State")).toBeDefined()
+      fireEvent.press(getByText("Go Back"))
+
+      expect(navigateSpy).toHaveBeenCalledWith("More")
+    })
+  })
+})

--- a/src/AffectedUserFlow/Start.spec.tsx
+++ b/src/AffectedUserFlow/Start.spec.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+import { useNavigation } from "@react-navigation/native"
+
+import Start from "./Start"
+
+jest.mock("@react-navigation/native")
+describe("Start", () => {
+  it("displays information about sharing information through the flow", () => {
+    const { getByText } = render(<Start />)
+    expect(
+      getByText(
+        "Help contain the spread of the virus and protect others in your community if you're diagnosed or test positive for COVID-19.",
+      ),
+    ).toBeDefined()
+    expect(
+      getByText(
+        "Choose to anonymously notify others you may have encountered and help your community contain the spread of the virus.",
+      ),
+    ).toBeDefined()
+  })
+
+  it("navigates to the code input screen when user starts the flow", () => {
+    const navigateSpy = jest.fn()
+    ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+    const { getByLabelText } = render(<Start />)
+
+    fireEvent.press(getByLabelText("Start"))
+    expect(navigateSpy).toHaveBeenCalledWith("AffectedUserCodeInput")
+  })
+})


### PR DESCRIPTION
Why:
----
The `AffectedUserFlow` is lacking some test coverage

This Commit:
----
- Add tests for failing branch and content for Publish Consent Form
- Add tests for the publish consent screen
- Add tests for failure branch of certificate request on CodeInput
- Add tests to enable exposure notifications screen
- Add tests for the complete affected user flow screen
- Add tests for the start flow screen of the affected user flow
