### PR TITLE
Add test for hmac key calculation helper

### DIFF
--- a/__mocks__/react-native-simple-crypto.ts
+++ b/__mocks__/react-native-simple-crypto.ts
@@ -1,1 +1,0 @@
-export default {};

--- a/jest/config.js
+++ b/jest/config.js
@@ -7,19 +7,19 @@ module.exports = {
     ...jestPreset.setupFiles,
     "./node_modules/react-native-gesture-handler/jestSetup.js",
   ],
-  "collectCoverage": true,
-  "coverageReporters": ["lcov", "text-summary"],
-  "coverageDirectory": "test-coverage",
-  "coverageThreshold": {
-   "global": {
-   "branches": 0,
-   "functions": 0,
-   "lines": 0,
-   "statements": 0
-   }
+  collectCoverage: true,
+  coverageReporters: ["lcov", "text-summary"],
+  coverageDirectory: "test-coverage",
+  coverageThreshold: {
+    global: {
+      branches: 0,
+      functions: 0,
+      lines: 0,
+      statements: 0,
+    },
   },
   transformIgnorePatterns: [
-    "node_modules/(?!(@react-native-community|react-native|react-native-linear-gradient)/)",
+    "node_modules/(?!(@react-native-community|react-native|react-native-linear-gradient|react-native-simple-crypto)/)",
   ],
   rootDir: "../",
   testPathIgnorePatterns: [

--- a/src/AffectedUserFlow/hmac.spec.ts
+++ b/src/AffectedUserFlow/hmac.spec.ts
@@ -1,0 +1,78 @@
+import RNSimpleCrypto from "react-native-simple-crypto"
+
+import { calculateHmac } from "./hmac"
+
+describe("calculateHmac", () => {
+  const mockRandomBytesGeneration = () => {
+    const randomBytes = new ArrayBuffer(1)
+    jest
+      .spyOn(RNSimpleCrypto.utils, "randomBytes")
+      .mockResolvedValueOnce(randomBytes)
+    return randomBytes
+  }
+
+  const mockConvertUtf8ToArray = () => {
+    const convertUtf8ToArrayBufferSpy = jest.spyOn(
+      RNSimpleCrypto.utils,
+      "convertUtf8ToArrayBuffer",
+    )
+    const messageArrayBuffer = new ArrayBuffer(2)
+    convertUtf8ToArrayBufferSpy.mockReturnValueOnce(messageArrayBuffer)
+
+    return [convertUtf8ToArrayBufferSpy, messageArrayBuffer]
+  }
+
+  const mockHmac256 = () => {
+    const hmac256Spy = jest.spyOn(RNSimpleCrypto.HMAC, "hmac256")
+    const signatureBuffer = new ArrayBuffer(3)
+    hmac256Spy.mockResolvedValueOnce(signatureBuffer)
+
+    return [hmac256Spy, signatureBuffer]
+  }
+
+  const mockConvertArrayBufferToBase64 = () => {
+    const convertArrayBufferToBase64Spy = jest.spyOn(
+      RNSimpleCrypto.utils,
+      "convertArrayBufferToBase64",
+    )
+    const base64Signature = "base64Signature"
+    convertArrayBufferToBase64Spy.mockReturnValueOnce(base64Signature)
+    const base64Key = "base64Key"
+    convertArrayBufferToBase64Spy.mockReturnValueOnce(base64Key)
+
+    return [convertArrayBufferToBase64Spy, base64Signature, base64Key]
+  }
+
+  it("serializes and encrypts the exposure keys into a payload", async () => {
+    const randomBytes = mockRandomBytesGeneration()
+    const [
+      convertUtf8ToArrayBufferSpy,
+      messageArrayBuffer,
+    ] = mockConvertUtf8ToArray()
+    const [hmac256Spy, signatureBuffer] = mockHmac256()
+    const [
+      convertArrayBufferToBase64Spy,
+      base64Signature,
+      base64Key,
+    ] = mockConvertArrayBufferToBase64()
+    const key = "key"
+    const rollingPeriod = 1
+    const rollingStartNumber = 1
+    const transmissionRisk = 1
+    const exposureKey = {
+      key,
+      rollingPeriod,
+      rollingStartNumber,
+      transmissionRisk,
+    }
+    const serializedKey = `${key}.${rollingPeriod}.${rollingStartNumber}.${transmissionRisk}`
+
+    const hmacKey = await calculateHmac([exposureKey])
+
+    expect(convertUtf8ToArrayBufferSpy).toHaveBeenCalledWith(serializedKey)
+    expect(hmac256Spy).toHaveBeenCalledWith(messageArrayBuffer, randomBytes)
+    expect(convertArrayBufferToBase64Spy).toHaveBeenCalledWith(signatureBuffer)
+    expect(convertArrayBufferToBase64Spy).toHaveBeenCalledWith(randomBytes)
+    expect(hmacKey).toEqual([base64Signature, base64Key])
+  })
+})

--- a/src/AffectedUserFlow/hmac.ts
+++ b/src/AffectedUserFlow/hmac.ts
@@ -6,10 +6,6 @@ export const generateKey = async (): Promise<ArrayBuffer> => {
   return await RNSimpleCrypto.utils.randomBytes(32)
 }
 
-export const arrayBufferToString = (arrayBuffer: ArrayBuffer): string => {
-  return RNSimpleCrypto.utils.convertArrayBufferToUtf8(arrayBuffer)
-}
-
 export const calculateHmac = async (
   exposureKeys: ExposureKey[],
 ): Promise<[string, string]> => {


### PR DESCRIPTION
Why:
----
This helper file was not tested and holds a pretty important part of the logic in sending the data to be verified.

This PR:
----
- Remove unnecessary mock of react-native-simple-crypto
- Transform simple crypto for testing
- Add test for hmac calculation method

Reviewers:
----
The method has quite a few mocks since most of the logic goes through calling the simple crypto library for encryption and random values generation purposes.
