### PR TITLE
Keydata Encoding Update

### DIFF
--- a/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
+++ b/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
@@ -12,7 +12,7 @@ extension ENTemporaryExposureKey {
 
   var asDictionary : [String: Any] {
     return [
-      "key": keyData,
+      "key": keyData.base64EncodedString(),
       "rollingPeriod": rollingPeriod,
       "rollingStartNumber": rollingStartNumber,
       "transmissionRisk": transmissionRiskLevel


### PR DESCRIPTION
### Why:
We'd like key data from the native layer to encode properly

### This Commit
This commit encodes key data from the native layer as a base64 string

Co-authored by:
John Schoeman <john.schoeman@thoughtbot.com>
Matt Buckley <matt@nicethings.io>