### PR TITLE
Fetch Exposure Configuration from Server (iOS)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,9 @@ jobs:
       - run: pod install --repo-update
         working-directory: ./ios
 
+      - name: Setup env
+        run: ./bin/set_ha_env_github.sh
+
       # TODO(https://pathcheck.atlassian.net/browse/SAF-250): remove the skip on COVIDSafePathsTests/testRendersWelcomeScreen once it's passing
       - run: |
           xcodebuild test -workspace COVIDSafePaths.xcworkspace \

--- a/example.env.bt
+++ b/example.env.bt
@@ -11,6 +11,7 @@ REGION_CODES='US'
 
 POST_DIAGNOSIS_KEYS_URL=https://example.app
 DOWNLOAD_BASE_URL=https://example.app/download
+EXPOSURE_CONFIGURATION_URL=https://example.app/exposureconfiguration
 
 GAEN_VERIFY_URL=https://verify.com
 GAEN_VERIFY_API_TOKEN=GAEN_VERIFY_API_TOKEN

--- a/ios/AppDelegate.m
+++ b/ios/AppDelegate.m
@@ -48,7 +48,6 @@
   // Schedule background task
   [[ExposureManager shared] scheduleBackgroundTaskIfNeeded];
 
-  // Broadcast EN Status and fetch exposure configuration
   [[ExposureManager shared] setup];
 
   [RNSplashScreen showSplash:@"LaunchScreen" inRootView:rootView];
@@ -57,7 +56,6 @@
 
 - (void)applicationWillEnterForeground:(UIApplication *)application
 {
-  // Broadcast EN Status and fetch exposure configuration
   [[ExposureManager shared] setup];
 }
 

--- a/ios/AppDelegate.m
+++ b/ios/AppDelegate.m
@@ -48,8 +48,8 @@
   // Schedule background task
   [[ExposureManager shared] scheduleBackgroundTaskIfNeeded];
 
-  // Broadcase EN Status
-  [[ExposureManager shared] broadcastCurrentEnabledStatus];
+  // Broadcast EN Status and fetch exposure configuration
+  [[ExposureManager shared] setup];
 
   [RNSplashScreen showSplash:@"LaunchScreen" inRootView:rootView];
   return YES;
@@ -57,7 +57,8 @@
 
 - (void)applicationWillEnterForeground:(UIApplication *)application
 {
-  [[ExposureManager shared] broadcastCurrentEnabledStatus];
+  // Broadcast EN Status and fetch exposure configuration
+  [[ExposureManager shared] setup];
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge

--- a/ios/BT/API/APIClient.swift
+++ b/ios/BT/API/APIClient.swift
@@ -2,23 +2,29 @@ import Alamofire
 
 enum RequestType {
   case postKeys,
-  downloadKeys
+  downloadKeys,
+  exposureConfiguration
 }
 
 final class APIClient {
   
   let postKeysUrl: URL
   let downloadBaseUrl: URL
+  let exposureConfigurationUrl: URL
   static let shared = APIClient(
     postKeysUrl: URL(string: ReactNativeConfig.env(for: .postKeysUrl))!,
-    downloadBaseUrl: URL(string: ReactNativeConfig.env(for: .downloadBaseUrl))!
+    downloadBaseUrl: URL(string: ReactNativeConfig.env(for: .downloadBaseUrl))!,
+    exposureConfigurationUrl: URL(string: ReactNativeConfig.env(for: .exposureConfigurationUrl))!
   )
   
   private let sessionManager: SessionManager
-  
-  init(postKeysUrl: URL, downloadBaseUrl: URL) {
+
+  init(postKeysUrl: URL,
+       downloadBaseUrl: URL,
+       exposureConfigurationUrl: URL) {
     self.postKeysUrl = postKeysUrl
     self.downloadBaseUrl = downloadBaseUrl
+    self.exposureConfigurationUrl = exposureConfigurationUrl
     
     let configuration = URLSessionConfiguration.default
     
@@ -127,6 +133,8 @@ private extension APIClient {
       baseUrl = postKeysUrl
     case .downloadKeys:
       baseUrl = downloadBaseUrl
+    case .exposureConfiguration:
+      baseUrl = exposureConfigurationUrl
     }
     let r = sessionManager.request(
       baseUrl.appendingPathComponent(request.path, isDirectory: false),

--- a/ios/BT/API/Model/ExposureConfiguration.swift
+++ b/ios/BT/API/Model/ExposureConfiguration.swift
@@ -9,6 +9,8 @@ struct ExposureConfiguration: Codable {
   let daysSinceLastExposureLevelValues: [ENRiskLevelValue]
   let durationLevelValues: [ENRiskLevelValue]
   let transmissionRiskLevelValues: [ENRiskLevelValue]
+  let attenuationBucketWeights: [Float]
+  let triggerThresholdWeightedDuration: Int
 
 }
 
@@ -20,7 +22,9 @@ extension ExposureConfiguration {
                           attenuationLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],
                           daysSinceLastExposureLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],
                           durationLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],
-                          transmissionRiskLevelValues: [1, 2, 3, 4, 5, 6, 7, 8])
+                          transmissionRiskLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],
+                          attenuationBucketWeights: [1, 0.5, 0],
+                          triggerThresholdWeightedDuration: 15)
   }()
 
   var asENExposureConfiguration: ENExposureConfiguration {

--- a/ios/BT/API/Requests/ExposureConfigurationRequests.swift
+++ b/ios/BT/API/Requests/ExposureConfigurationRequests.swift
@@ -17,7 +17,7 @@ enum ExposureConfigurationRequest: APIRequest {
   var path: String {
     switch self {
     case .get:
-      return ""
+      return "exposureconfiguration.json"
     }
   }
 

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -20,6 +20,8 @@ final class ExposureManager: NSObject {
   @objc static let shared = ExposureManager()
   
   private static let backgroundTaskIdentifier = "\(Bundle.main.bundleIdentifier!).exposure-notification"
+
+  private var exposureConfiguration = ExposureConfiguration.placeholder
   
   let manager = ENManager()
   
@@ -65,6 +67,9 @@ final class ExposureManager: NSObject {
       name: .AuthorizationStatusDidChange,
       object: nil
     )
+
+    // Fetch exposure configuration
+    fetchExposureConfiguration()
   }
   
   deinit {
@@ -405,6 +410,17 @@ extension ExposureManager {
 // MARK: - Private
 
 private extension ExposureManager {
+
+  func fetchExposureConfiguration() {
+    APIClient.shared.request(ExposureConfigurationRequest.get, requestType: .exposureConfiguration) { result in
+      switch result {
+      case .success(let exposureConfiguration):
+        self.exposureConfiguration = exposureConfiguration
+      case .failure(let error):
+        print("Error fetching exposure configuration: \(error)")
+      }
+    }
+  }
   
   func notifyUserBlueToothOffIfNeeded() {
     let identifier = String.bluetoothNotificationIdentifier

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -351,7 +351,8 @@ final class ExposureManager: NSObject {
       }
     }
   }
-  
+
+  /// Broadcast EN Status and fetch exposure configuration
   @objc func setup() {
     fetchExposureConfiguration()
     broadcastCurrentEnabledStatus()

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -20,7 +20,7 @@ final class ExposureManager: NSObject {
   @objc static let shared = ExposureManager()
   
   private static let backgroundTaskIdentifier = "\(Bundle.main.bundleIdentifier!).exposure-notification"
-
+  
   private var exposureConfiguration = ExposureConfiguration.placeholder
   
   let manager = ENManager()
@@ -67,9 +67,7 @@ final class ExposureManager: NSObject {
       name: .AuthorizationStatusDidChange,
       object: nil
     )
-
-    // Fetch exposure configuration
-    fetchExposureConfiguration()
+    
   }
   
   deinit {
@@ -354,11 +352,9 @@ final class ExposureManager: NSObject {
     }
   }
   
-  @objc func broadcastCurrentEnabledStatus() {
-    NotificationCenter.default.post(Notification(
-      name: .AuthorizationStatusDidChange,
-      object: [self.authorizationState.rawValue, self.enabledState.rawValue]
-    ))
+  @objc func setup() {
+    fetchExposureConfiguration()
+    broadcastCurrentEnabledStatus()
   }
   
 }
@@ -410,7 +406,7 @@ extension ExposureManager {
 // MARK: - Private
 
 private extension ExposureManager {
-
+  
   func fetchExposureConfiguration() {
     APIClient.shared.request(ExposureConfigurationRequest.get, requestType: .exposureConfiguration) { result in
       switch result {
@@ -420,6 +416,13 @@ private extension ExposureManager {
         print("Error fetching exposure configuration: \(error)")
       }
     }
+  }
+  
+  func broadcastCurrentEnabledStatus() {
+    NotificationCenter.default.post(Notification(
+      name: .AuthorizationStatusDidChange,
+      object: [self.authorizationState.rawValue, self.enabledState.rawValue]
+    ))
   }
   
   func notifyUserBlueToothOffIfNeeded() {

--- a/ios/BT/Extensions/Foundation/String+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/String+Extensions.swift
@@ -22,6 +22,7 @@ extension String {
   // .env
   static let postKeysUrl = "POST_DIAGNOSIS_KEYS_URL"
   static let downloadBaseUrl = "DOWNLOAD_BASE_URL"
+  static let exposureConfigurationUrl = "EXPOSURE_CONFIGURATION_URL"
   static let downloadPath = "DOWNLOAD_PATH"
   static let hmackey = "HMAC_KEY"
   static let regionCodes = "REGION_CODES"


### PR DESCRIPTION
### Why
We'd like to be able to set the exposure configuration at runtime instead of hardcoding the value

### This Commit
This commit updates `APIClient` to accept a request to fetch the exposure configuration from the server, and executes that request on `init` (`ExposureManager`) and `willEnterForeground`