### PR TITLE
Fix typo in env setup script

### DIFF
--- a/bin/set_ha.sh
+++ b/bin/set_ha.sh
@@ -4,7 +4,7 @@
 #
 # Usage
 #
-#   bin/fetch_env <health-authority-label>
+#   bin/set_ha <health-authority-label>
 #
 # Example
 #


### PR DESCRIPTION
Why: there was a typo.