### PR TITLE
Fix language list

### DIFF
--- a/src/More/LanguageSelection.tsx
+++ b/src/More/LanguageSelection.tsx
@@ -1,5 +1,11 @@
 import React from "react"
-import { FlatList, View, StyleSheet, TouchableHighlight, SafeAreaView } from "react-native"
+import {
+  FlatList,
+  View,
+  StyleSheet,
+  TouchableHighlight,
+  SafeAreaView,
+} from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { useStatusBarEffect } from "../navigation"

--- a/src/More/LanguageSelection.tsx
+++ b/src/More/LanguageSelection.tsx
@@ -2,11 +2,13 @@ import React from "react"
 import { FlatList, View, StyleSheet, TouchableHighlight } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
+import { useStatusBarEffect } from "../navigation"
 
 import { getLocaleList, setUserLocaleOverride } from "../locales/languages"
 import { GlobalText } from "../components/GlobalText"
 
 import { Colors, Spacing, Typography } from "../styles"
+import { SafeAreaView } from "react-native-safe-area-context"
 
 const Separator = () => (
   <View
@@ -23,6 +25,7 @@ const LanguageSelection = (): JSX.Element => {
     i18n: { language },
   } = useTranslation()
   const navigation = useNavigation()
+  useStatusBarEffect("dark-content")
   const localeList = getLocaleList()
 
   const onSelectLanguage = (locale: string) => {
@@ -31,30 +34,32 @@ const LanguageSelection = (): JSX.Element => {
   }
 
   return (
-    <FlatList
-      keyExtractor={(_, i) => `${i}`}
-      data={localeList}
-      renderItem={({ item: { value, label } }) => (
-        <TouchableHighlight
-          underlayColor={Colors.underlayPrimaryBackground}
-          style={{
-            paddingVertical: Spacing.medium,
-            paddingHorizontal: Spacing.large,
-          }}
-          onPress={() => onSelectLanguage(value)}
-        >
-          <GlobalText
+    <SafeAreaView>
+      <FlatList
+        keyExtractor={(_, i) => `${i}`}
+        data={localeList}
+        renderItem={({ item: { value, label } }) => (
+          <TouchableHighlight
+            underlayColor={Colors.underlayPrimaryBackground}
             style={{
-              ...Typography.mainContent,
-              fontWeight: language === value ? "700" : "500",
+              paddingVertical: Spacing.medium,
+              paddingHorizontal: Spacing.large,
             }}
+            onPress={() => onSelectLanguage(value)}
           >
-            {label}
-          </GlobalText>
-        </TouchableHighlight>
-      )}
-      ItemSeparatorComponent={() => <Separator />}
-    />
+            <GlobalText
+              style={{
+                ...Typography.mainContent,
+                fontWeight: language === value ? "700" : "500",
+              }}
+            >
+              {label}
+            </GlobalText>
+          </TouchableHighlight>
+        )}
+        ItemSeparatorComponent={() => <Separator />}
+      />
+    </SafeAreaView>
   )
 }
 

--- a/src/More/LanguageSelection.tsx
+++ b/src/More/LanguageSelection.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { FlatList, View, StyleSheet, TouchableHighlight } from "react-native"
+import { FlatList, View, StyleSheet, TouchableHighlight, SafeAreaView } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { useStatusBarEffect } from "../navigation"
@@ -8,7 +8,6 @@ import { getLocaleList, setUserLocaleOverride } from "../locales/languages"
 import { GlobalText } from "../components/GlobalText"
 
 import { Colors, Spacing, Typography } from "../styles"
-import { SafeAreaView } from "react-native-safe-area-context"
 
 const Separator = () => (
   <View


### PR DESCRIPTION
When trying to choose a language in iOS devices with a top notch the list overlaps with it, I added a SafeAreaView there to prevent this issue

issue:
<img width="584" alt="Screen Shot 2020-08-03 at 16 14 53" src="https://user-images.githubusercontent.com/5033596/89218824-1bbe5500-d5a5-11ea-9a3a-af5d88754144.png">
fix:
<img width="584" alt="Screen Shot 2020-08-03 at 16 13 55" src="https://user-images.githubusercontent.com/5033596/89218839-20830900-d5a5-11ea-99eb-e72557e5f2ec.png">

