### PR TITLE
Remove react-native-push-notification

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,25 +40,6 @@
 
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
-        <meta-data
-            android:name="com.dieam.reactnativepushnotification.notification_channel_name"
-            android:value="covidsafepaths_kit_notification_channel" />
-        <meta-data
-            android:name="com.dieam.reactnativepushnotification.notification_channel_description"
-            android:value="@string/notification_channel_description" />
-        <!-- Change the resource name to your App's accent color - or any other color you want -->
-        <meta-data
-            android:name="com.dieam.reactnativepushnotification.notification_color"
-            android:resource="@android:color/white" />
-
-        <service
-            android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationListenerService"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT" />
-            </intent-filter>
-        </service>
-
         <receiver
             android:name="covidsafepaths.bt.exposurenotifications.nearby.ExposureNotificationBroadcastReceiver"
             android:exported="true"

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">إشعارات PathCheck BT</string>
 </resources>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">PathCheck BT notifikationer</string>
 </resources>

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Ειδοποιήσεις PathCheck BT</string>
 </resources>

--- a/android/app/src/main/res/values-es-rPR/strings.xml
+++ b/android/app/src/main/res/values-es-rPR/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Notificaciones de PathCheck BT</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Configurar notificaciones locales</string>
 </resources>

--- a/android/app/src/main/res/values-ht-rHT/strings.xml
+++ b/android/app/src/main/res/values-ht-rHT/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Notifikasyon Chase Kowona (\"PathCheck\") BT </string>
 </resources>

--- a/android/app/src/main/res/values-ht/strings.xml
+++ b/android/app/src/main/res/values-ht/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Notifikasyon Chase Kowona (\"PathCheck\") BT </string>
 </resources>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Notifiche PathCheck BT</string>
 </resources>

--- a/android/app/src/main/res/values-ml/strings.xml
+++ b/android/app/src/main/res/values-ml/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">എല്ലാ പ്രാദേശിക അറിയിപ്പുകളും കൈകാര്യം ചെയ്യുക</string>
 </resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Alle lokale meldingen afhandelen</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">PathCheck BT powiadomienia</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Notícias PathCheck BT</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">PathCheck BT уведомления</string>
 </resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">PathCheck Bluetooth upozornenia</string>
 </resources>

--- a/android/app/src/main/res/values-tl/strings.xml
+++ b/android/app/src/main/res/values-tl/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">BT Notifications ng PathCheck</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,6 +8,4 @@
   <string name="exposure_notification_channel_name">Exposure Notification</string>
   <string name="exposure_notification_message">Someone you were near has tested positive for COVID-19. Tap for more info.</string>
   <string name="exposure_notification_title">Possible COVID-19 exposure</string>
-  <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">PathCheck BT notifications</string>
 </resources>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,8 +5,6 @@ include ':react-native-fs'
 project(':react-native-fs').projectDir = new File(settingsDir, '../node_modules/react-native-fs/android')
 include ':react-native-zip-archive'
 project(':react-native-zip-archive').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-zip-archive/android')
-include ':react-native-push-notification'
-project(':react-native-push-notification').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-push-notification/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':react-native-local-resource'
 project(':react-native-local-resource').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-local-resource/android')

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "react-native-linear-gradient": "^2.5.6",
     "react-native-local-resource": "^0.1.6",
     "react-native-permissions": "^2.0.10",
-    "react-native-push-notification": "^4.0.0",
     "react-native-reanimated": "^1.7.1",
     "react-native-safe-area-context": "^3.0.5",
     "react-native-screens": "^2.8.0",

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -6,5 +6,3 @@ declare module "*.svg" {
 }
 
 declare module "*.png" {}
-
-declare module "react-native-push-notification"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,7 +1028,7 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.4.tgz#a05a9403f8ee09c7d7f7c2dda850b79cac376691"
   integrity sha512-mb664NOqPvyUZ4TznzdYEfdS3OhSXWGbZprgsDZn4THw2X/4wcBFcBUeWuMzeQ56KhY0rm/YBBlZWHrSf3C/Aw==
 
-"@react-native-community/push-notification-ios@^1.2.2", "@react-native-community/push-notification-ios@^1.4.0":
+"@react-native-community/push-notification-ios@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.4.0.tgz#e1781e60fb8a2569547e3f1613c62e1c3b46960c"
   integrity sha512-YnfxtAuHkiuvprh1d9npGZVwOrso6sys8+w8XY6RQAs8kD2LHZg0C8rA5gfX4jW/GrQV7m14Y6ngciE6Rpd91w==
@@ -6792,13 +6792,6 @@ react-native-local-resource@^0.1.6:
 react-native-permissions@^2.0.10:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-2.1.4.tgz#b0663839d28444d8ea6b5302303b2151ea70d2da"
-
-react-native-push-notification@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-push-notification/-/react-native-push-notification-4.0.0.tgz#85c795abef6ddbdbed039ca6a5ffcedc0f36d0dd"
-  integrity sha512-PwFxGupwlAKc8qz8nMhX9U+/En/kiEH/1cyuKvUQdMa+tx96xZ/t81RTyOkkehkx4lbsI+Tv2F+D+fJV9IQb+A==
-  dependencies:
-    "@react-native-community/push-notification-ios" "^1.2.2"
 
 react-native-reanimated@^1.7.1:
   version "1.8.0"


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
This library adds a notification channel that is shown to the user but seems to be unused.
I haven't seen any references in the code, are we using it to get notifications from Firebase?