### PR TITLE
Fix icon in report flow and add alt text to exposure

### DIFF
--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -17,7 +17,14 @@ import { GlobalText } from "../../components/GlobalText"
 
 import { Screens, Stacks } from "../../navigation"
 import { Icons, Images } from "../../assets"
-import { Colors, Spacing, Buttons, Iconography, Typography } from "../../styles"
+import {
+  Outlines,
+  Colors,
+  Spacing,
+  Buttons,
+  Iconography,
+  Typography,
+} from "../../styles"
 import { useExposureContext } from "../../ExposureContext"
 
 interface PublishConsentFormProps {
@@ -63,11 +70,9 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
           style={{ flex: 1 }}
           contentContainerStyle={style.contentContainer}
         >
-          <View style={style.icon}>
+          <View style={style.iconContainerCircle}>
             <SvgXml
               xml={Icons.Bell}
-              accessible
-              accessibilityLabel={t("label.bell_icon")}
               width={Iconography.small}
               height={Iconography.small}
             />
@@ -104,7 +109,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
 
 const style = StyleSheet.create({
   contentContainer: {
-    paddingHorizontal: Spacing.large,
+    padding: Spacing.large,
     paddingBottom: Spacing.huge,
   },
   backgroundImage: {
@@ -121,9 +126,11 @@ const style = StyleSheet.create({
     color: Colors.white,
     paddingBottom: Spacing.medium,
   },
-  icon: {
+  iconContainerCircle: {
     ...Iconography.largeIcon,
+    borderRadius: Outlines.borderRadiusMax,
     backgroundColor: Colors.white,
+    marginBottom: Spacing.large,
   },
   contentText: {
     ...Typography.secondaryContent,

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -65,6 +65,8 @@ const ExposureDetail: FunctionComponent = () => {
         <View style={style.exposureWindowContainer}>
           <SvgXml
             xml={Icons.ExposureIcon}
+            accessible
+            accessibilityLabel={t("exposure_history.possible_exposure")}
             fill={Colors.primaryViolet}
             width={Iconography.xSmall}
             height={Iconography.xSmall}


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:
- Fixes the bell icon in the affected user reporting flow so that it matches with the rest of the screens
- Adds alt-text to the small exposure icon on the exposure detail screen

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

#### Linked issues:
https://trello.com/c/0eMi0AZP

<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:

![Simulator Screen Shot - iPhone 8 - 2020-08-03 at 16 02 36](https://user-images.githubusercontent.com/32882075/89222311-d567f680-d5a2-11ea-9613-ccf90d89448d.png)
<!-- If you're changing visuals, add a screenshot here -->

#### How to test:
Using an accessibility inspector, check that the exposure icon has the alt text "Possible COVID-19 exposure"
<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
