### PR TITLE
Remove rn device info dependency

### DIFF
--- a/android/app/src/main/java/covidsafepaths/bt/bridge/ExposureNotificationsPackage.java
+++ b/android/app/src/main/java/covidsafepaths/bt/bridge/ExposureNotificationsPackage.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 
 import covidsafepaths.bt.exposurenotifications.DebugMenuModule;
+import covidsafepaths.bt.exposurenotifications.DeviceInfoModule;
 import covidsafepaths.bt.exposurenotifications.ExposureKeyModule;
 import covidsafepaths.bt.exposurenotifications.ExposureNotificationsModule;
 
@@ -23,6 +24,7 @@ public class ExposureNotificationsPackage implements ReactPackage {
         modules.add(new ExposureNotificationsModule(reactContext));
         modules.add(new DebugMenuModule(reactContext));
         modules.add(new ExposureKeyModule(reactContext));
+        modules.add(new DeviceInfoModule(reactContext));
 
         return modules;
     }

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureKeyModule.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureKeyModule.java
@@ -13,9 +13,8 @@ import com.google.android.gms.nearby.exposurenotification.ExposureNotificationCl
 import org.pathcheck.covidsafepaths.MainActivity;
 
 import javax.annotation.Nonnull;
-import static covidsafepaths.bt.exposurenotifications.ExposureNotificationsModule.MODULE_NAME;
 
-@ReactModule(name = MODULE_NAME)
+@ReactModule(name = ExposureKeyModule.MODULE_NAME)
 public class ExposureKeyModule  extends ReactContextBaseJavaModule {
     public static final String MODULE_NAME = "ExposureKeyModule";
     private final ExposureNotificationClient exposureNotificationClient;

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
@@ -1,0 +1,61 @@
+package covidsafepaths.bt.exposurenotifications;
+
+import android.content.pm.PackageInfo;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
+
+import javax.annotation.Nonnull;
+
+@ReactModule(name = DeviceInfoModule.MODULE_NAME)
+public class DeviceInfoModule extends ReactContextBaseJavaModule {
+    public static final String MODULE_NAME = "DeviceInfoModule";
+    public static final String TAG = "DeviceInfoModule";
+
+    public DeviceInfoModule(@NonNull ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public @Nonnull
+    String getName() {
+        return MODULE_NAME;
+    }
+
+    @ReactMethod
+    public void getApplicationName(final Promise promise) {
+        String appName = getReactApplicationContext()
+                .getApplicationInfo()
+                .loadLabel(getReactApplicationContext().getPackageManager()).toString();
+        promise.resolve(appName);
+    }
+
+    @ReactMethod
+    public void getBuildNumber(final Promise promise) {
+        try {
+            promise.resolve(Integer.toString(getPackageInfo().versionCode));
+        } catch (Exception e) {
+            promise.resolve("unknown");
+        }
+    }
+
+    @ReactMethod
+    public void getVersion(final Promise promise) {
+        try {
+            promise.resolve(getPackageInfo().versionName);
+        } catch (Exception e) {
+            promise.resolve("unknown");
+        }
+    }
+
+    private PackageInfo getPackageInfo() throws Exception {
+        return getReactApplicationContext()
+                .getPackageManager()
+                .getPackageInfo(getReactApplicationContext().getPackageName(), 0);
+    }
+}

--- a/ios/BT/bridge/DeviceInfoModule.m
+++ b/ios/BT/bridge/DeviceInfoModule.m
@@ -1,0 +1,36 @@
+#import <React/RCTLog.h>
+#import <React/RCTBridgeModule.h>
+#import "BT-Swift.h"
+
+@interface DeviceInfoModule: NSObject <RCTBridgeModule>
+@end
+
+@implementation DeviceInfoModule
+
+RCT_EXPORT_MODULE();
+
+RCT_REMAP_METHOD(getApplicationName,
+                 getApplicationNameWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSString *applicationName = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)@"CFBundleDisplayName"];
+  resolve(applicationName);
+}
+
+RCT_REMAP_METHOD(getBuildNumber,
+                 getBuildNumberWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSString *buildNumber = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleVersionKey];
+  resolve(buildNumber);
+}
+
+RCT_REMAP_METHOD(getVersion,
+                 getVersionWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+  resolve(version);
+}
+
+@end

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		B01CF5299E2C4108F39C1232 /* libPods-BTTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D74339326986C2F8EE1F59BA /* libPods-BTTests.a */; };
 		B507A9EE24A197FF00E039D5 /* DownloadedPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B507A9ED24A197FF00E039D5 /* DownloadedPackage.swift */; };
 		B507AA0724A2533200E039D5 /* DownloadPackage+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B507AA0624A2533200E039D5 /* DownloadPackage+Helpers.swift */; };
+		B5081E4A24D9B8E300121884 /* DeviceInfoModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B5081E4924D9B8E300121884 /* DeviceInfoModule.m */; };
 		B52D88C0248F0FC00071ED51 /* SafePathsSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271881BF2461AF76001DE067 /* SafePathsSecureStorage.swift */; };
 		B52D88C4248F10FD0071ED51 /* BTSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52D88C3248F10FD0071ED51 /* BTSecureStorage.swift */; };
 		B54CBF32249A738500218477 /* IndexFileRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54CBF31249A738500218477 /* IndexFileRequests.swift */; };
@@ -206,6 +207,7 @@
 		B3D0B8224679467D85423742 /* IBMPlexMono-Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexMono-Italic.ttf"; path = "../app/assets/fonts/IBMPlexMono-Italic.ttf"; sourceTree = "<group>"; };
 		B507A9ED24A197FF00E039D5 /* DownloadedPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadedPackage.swift; sourceTree = "<group>"; };
 		B507AA0624A2533200E039D5 /* DownloadPackage+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadPackage+Helpers.swift"; sourceTree = "<group>"; };
+		B5081E4924D9B8E300121884 /* DeviceInfoModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DeviceInfoModule.m; sourceTree = "<group>"; };
 		B52D88C3248F10FD0071ED51 /* BTSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSecureStorage.swift; sourceTree = "<group>"; };
 		B54CBF31249A738500218477 /* IndexFileRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexFileRequests.swift; sourceTree = "<group>"; };
 		B5582D43249943DE001458A9 /* ExposureEventEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExposureEventEmitter.m; sourceTree = "<group>"; };
@@ -643,6 +645,7 @@
 				C550A66524B7906F002CA7F2 /* ExposureKeyModule.m */,
 				B59F4C3424BDF879007B09D5 /* ExposureHistoryModule.m */,
 				B5FB3B42248BD61A001DB1D5 /* DebugMenuModule.m */,
+				B5081E4924D9B8E300121884 /* DeviceInfoModule.m */,
 				B5582D43249943DE001458A9 /* ExposureEventEmitter.m */,
 			);
 			path = bridge;
@@ -1015,6 +1018,7 @@
 				B5FC37DF248A78FC006474EB /* ExposureConfiguration.swift in Sources */,
 				B5E79437249E666B00BD8596 /* Array+Extensions.swift in Sources */,
 				B5FC37CA2489B1C1006474EB /* JSON.swift in Sources */,
+				B5081E4A24D9B8E300121884 /* DeviceInfoModule.m in Sources */,
 				B5FC37D02489B3DE006474EB /* StructuredError.swift in Sources */,
 				B5C9723024B8A909007F4C0B /* Constants.swift in Sources */,
 			);

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -12,36 +12,30 @@ PODS:
     - React-Core (= 0.61.5)
     - React-jsi (= 0.61.5)
     - ReactCommon/turbomodule/core (= 0.61.5)
-  - Firebase/CoreOnly (6.25.0):
-    - FirebaseCore (= 6.7.1)
-  - Firebase/Crashlytics (6.25.0):
+  - Firebase/CoreOnly (6.28.1):
+    - FirebaseCore (= 6.9.1)
+  - Firebase/Crashlytics (6.28.1):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 4.1.0)
-  - FirebaseAnalyticsInterop (1.5.0)
-  - FirebaseCore (6.7.1):
+    - FirebaseCrashlytics (~> 4.3.0)
+  - FirebaseCore (6.9.1):
     - FirebaseCoreDiagnostics (~> 1.3)
-    - FirebaseCoreDiagnosticsInterop (~> 1.2)
-    - GoogleUtilities/Environment (~> 6.5)
-    - GoogleUtilities/Logger (~> 6.5)
-  - FirebaseCoreDiagnostics (1.3.0):
-    - FirebaseCoreDiagnosticsInterop (~> 1.2)
-    - GoogleDataTransportCCTSupport (~> 3.1)
-    - GoogleUtilities/Environment (~> 6.5)
-    - GoogleUtilities/Logger (~> 6.5)
+    - GoogleUtilities/Environment (~> 6.7)
+    - GoogleUtilities/Logger (~> 6.7)
+  - FirebaseCoreDiagnostics (1.5.0):
+    - GoogleDataTransport (~> 7.0)
+    - GoogleUtilities/Environment (~> 6.7)
+    - GoogleUtilities/Logger (~> 6.7)
     - nanopb (~> 1.30905.0)
-  - FirebaseCoreDiagnosticsInterop (1.2.0)
-  - FirebaseCrashlytics (4.1.0):
-    - FirebaseAnalyticsInterop (~> 1.2)
-    - FirebaseCore (~> 6.6)
+  - FirebaseCrashlytics (4.3.0):
+    - FirebaseCore (~> 6.8)
     - FirebaseInstallations (~> 1.1)
-    - GoogleDataTransport (~> 6.1)
-    - GoogleDataTransportCCTSupport (~> 3.1)
+    - GoogleDataTransport (~> 7.0)
     - nanopb (~> 1.30905.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstallations (1.2.0):
-    - FirebaseCore (~> 6.6)
-    - GoogleUtilities/Environment (~> 6.6)
-    - GoogleUtilities/UserDefaults (~> 6.6)
+  - FirebaseInstallations (1.5.0):
+    - FirebaseCore (~> 6.8)
+    - GoogleUtilities/Environment (~> 6.7)
+    - GoogleUtilities/UserDefaults (~> 6.7)
     - PromisesObjC (~> 1.2)
   - Folly (2018.10.22.00):
     - boost-for-react-native
@@ -53,15 +47,13 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - GoogleDataTransport (6.1.1)
-  - GoogleDataTransportCCTSupport (3.1.0):
-    - GoogleDataTransport (~> 6.1)
+  - GoogleDataTransport (7.0.0):
     - nanopb (~> 1.30905.0)
-  - GoogleUtilities/Environment (6.6.0):
+  - GoogleUtilities/Environment (6.7.1):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (6.6.0):
+  - GoogleUtilities/Logger (6.7.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/UserDefaults (6.6.0):
+  - GoogleUtilities/UserDefaults (6.7.1):
     - GoogleUtilities/Logger
   - nanopb (1.30905.0):
     - nanopb/decode (= 1.30905.0)
@@ -70,7 +62,7 @@ PODS:
   - nanopb/encode (1.30905.0)
   - Permission-Notifications (2.1.4):
     - RNPermissions
-  - PromisesObjC (1.2.8)
+  - PromisesObjC (1.2.9)
   - RCTRequired (0.61.5)
   - RCTTypeSafety (0.61.5):
     - FBLazyVector (= 0.61.5)
@@ -281,12 +273,12 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
     - ReactCommon/jscallinvoker (= 0.61.5)
-  - Realm (5.0.0):
-    - Realm/Headers (= 5.0.0)
-  - Realm/Headers (5.0.0)
-  - RealmSwift (5.0.0):
-    - Realm (= 5.0.0)
-  - RNBackgroundFetch (3.1.0):
+  - Realm (5.3.2):
+    - Realm/Headers (= 5.3.2)
+  - Realm/Headers (5.3.2)
+  - RealmSwift (5.3.2):
+    - Realm (= 5.3.2)
+  - RNBackgroundFetch (3.0.4):
     - React
   - RNCAsyncStorage (1.10.0):
     - React
@@ -295,8 +287,6 @@ PODS:
   - RNCPushNotificationIOS (1.4.0):
     - React
   - RNDateTimePicker (2.3.2):
-    - React
-  - RNDeviceInfo (5.6.3):
     - React
   - RNGestureHandler (1.6.1):
     - React
@@ -356,7 +346,11 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
+<<<<<<< HEAD
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
+=======
+  - RNFS (from `../node_modules/react-native-fs`)
+>>>>>>> Remove RNDeviceInfo dependency.
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
@@ -370,14 +364,11 @@ SPEC REPOS:
     - Alamofire
     - boost-for-react-native
     - Firebase
-    - FirebaseAnalyticsInterop
     - FirebaseCore
     - FirebaseCoreDiagnostics
-    - FirebaseCoreDiagnosticsInterop
     - FirebaseCrashlytics
     - FirebaseInstallations
     - GoogleDataTransport
-    - GoogleDataTransportCCTSupport
     - GoogleUtilities
     - nanopb
     - PromisesObjC
@@ -460,8 +451,13 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/push-notification-ios"
   RNDateTimePicker:
     :path: "../node_modules/@react-native-community/datetimepicker"
+<<<<<<< HEAD
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
+=======
+  RNFS:
+    :path: "../node_modules/react-native-fs"
+>>>>>>> Remove RNDeviceInfo dependency.
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNPermissions:
@@ -482,21 +478,18 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: aaeaf388755e4f29cd74acbc9e3b8da6d807c37f
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
-  Firebase: 5719b4f965f76643241a1bb8244483ff6117db39
-  FirebaseAnalyticsInterop: 3f86269c38ae41f47afeb43ebf32a001f58fcdae
-  FirebaseCore: 6023faeada5afa95a349fccafb40900e32e9ac42
-  FirebaseCoreDiagnostics: 4a773a47bd83bbd5a9b1ccf1ce7caa8b2d535e67
-  FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
-  FirebaseCrashlytics: fff345f16a07f0b23cb342d8de5a42cec6de3492
-  FirebaseInstallations: 2119fb3e46b0a88bfdbf12562f855ee3252462fa
+  Firebase: ed042590caa0029392257529a8003c25ee82bc18
+  FirebaseCore: 687b8e6a0a4337b898a6326d68254c2f80c143af
+  FirebaseCoreDiagnostics: 7535fe695737f8c5b350584292a70b7f8ff0357b
+  FirebaseCrashlytics: f6ae039fdaf07980425f2ae9f49131fc94009c58
+  FirebaseInstallations: 3c520c951305cbf9ca54eb891ff9e6d1fd384881
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  GoogleDataTransport: ad884314b81cdb808fb1d23787b367ff8da4e28a
-  GoogleDataTransportCCTSupport: d70a561f7d236af529fee598835caad5e25f6d3d
-  GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
+  GoogleDataTransport: 8a40cb194ad242b6f6dfe72c14fe40fc67c4dcd7
+  GoogleUtilities: e121a3867449ce16b0e35ddf1797ea7a389ffdf2
   nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
   Permission-Notifications: d437cafc026900006d35981d35a2d694f883f44e
-  PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
+  PromisesObjC: b48e0338dbbac2207e611750777895f7a5811b75
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -529,7 +522,6 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPushNotificationIOS: dc1c0c6aa18a128df123598149f42e848d26a4ac
   RNDateTimePicker: 4bd49e09f91ca73d69119a9e1173b0d43b82f5e5
-  RNDeviceInfo: 5be12a5bfbb8da3528c43ee4373abd9c30d04616
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8
   RNReanimated: 955cf4068714003d2f1a6e2bae3fb1118f359aff

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -278,7 +278,7 @@ PODS:
   - Realm/Headers (5.3.2)
   - RealmSwift (5.3.2):
     - Realm (= 5.3.2)
-  - RNBackgroundFetch (3.0.4):
+  - RNBackgroundFetch (3.1.0):
     - React
   - RNCAsyncStorage (1.10.0):
     - React
@@ -346,11 +346,6 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
-<<<<<<< HEAD
-  - RNDeviceInfo (from `../node_modules/react-native-device-info`)
-=======
-  - RNFS (from `../node_modules/react-native-fs`)
->>>>>>> Remove RNDeviceInfo dependency.
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
@@ -451,13 +446,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/push-notification-ios"
   RNDateTimePicker:
     :path: "../node_modules/@react-native-community/datetimepicker"
-<<<<<<< HEAD
-  RNDeviceInfo:
-    :path: "../node_modules/react-native-device-info"
-=======
-  RNFS:
-    :path: "../node_modules/react-native-fs"
->>>>>>> Remove RNDeviceInfo dependency.
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNPermissions:
@@ -515,8 +503,8 @@ SPEC CHECKSUMS:
   React-RCTText: 9ccc88273e9a3aacff5094d2175a605efa854dbe
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
-  Realm: 76066d333de26f97e9caedaa85ee3ff4a62ca265
-  RealmSwift: c1bdff09b422569dc6881410d9ccf712bcdb79b0
+  Realm: c6794276ca8884808ba168a22f9d71362b170b85
+  RealmSwift: 42ec6cec3170aeeda407f797f07268a7d055ebc7
   RNBackgroundFetch: 8dbb63141792f1473e863a0797ffbd5d987af2fc
   RNCAsyncStorage: 6d99641f8e6f15d169d695d8ef184bf187903f11
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f

--- a/package.json
+++ b/package.json
@@ -57,11 +57,6 @@
     "react-native": "0.61.5",
     "react-native-background-fetch": "^3.1.0",
     "react-native-config": "^1.2.1",
-<<<<<<< HEAD
-    "react-native-device-info": "^5.6.3",
-=======
-    "react-native-fs": "^2.16.6",
->>>>>>> Remove RNDeviceInfo dependency.
     "react-native-gesture-handler": "^1.6.1",
     "react-native-linear-gradient": "^2.5.6",
     "react-native-local-resource": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,11 @@
     "react-native": "0.61.5",
     "react-native-background-fetch": "^3.1.0",
     "react-native-config": "^1.2.1",
+<<<<<<< HEAD
     "react-native-device-info": "^5.6.3",
+=======
+    "react-native-fs": "^2.16.6",
+>>>>>>> Remove RNDeviceInfo dependency.
     "react-native-gesture-handler": "^1.6.1",
     "react-native-linear-gradient": "^2.5.6",
     "react-native-local-resource": "^0.1.6",

--- a/src/More/About.spec.tsx
+++ b/src/More/About.spec.tsx
@@ -3,46 +3,42 @@ import { Linking } from "react-native"
 import { render, fireEvent } from "@testing-library/react-native"
 
 import AboutScreen from "./About"
-import {
-  getApplicationName,
-  getBuildNumber,
-  getVersion,
-} from "../gaen/nativeModule"
+import { useApplicationInfo } from "./useApplicationInfo"
 
-jest.mock("nativeModule", () => {
-  return {
-    getApplicationName: jest.fn(),
-    getBuildNumber: jest.fn(),
-    getVersion: jest.fn(),
-  }
-})
-
+jest.mock("./useApplicationInfo")
 describe("About", () => {
   it("shows the name of the application", () => {
     const applicationName = "application name"
-
-    ;(getApplicationName as jest.Mock).mockReturnValueOnce(applicationName)
-
+    ;(useApplicationInfo as jest.Mock).mockReturnValueOnce({
+      applicationName,
+      versionInfo: "versionInfo",
+    })
     const { getByText } = render(<AboutScreen />)
 
     expect(getByText(applicationName)).toBeDefined()
   })
 
   it("shows the build and version number of the application", () => {
-    const buildNumber = 8
-    const versionNumber = 0.18
-
-    ;(getBuildNumber as jest.Mock).mockReturnValueOnce(buildNumber)
-    ;(getVersion as jest.Mock).mockReturnValueOnce(versionNumber)
+    const buildNumber = "8"
+    const versionNumber = "0.18"
+    const versionInfo = `${versionNumber} (${buildNumber})`
+    ;(useApplicationInfo as jest.Mock).mockReturnValueOnce({
+      applicationName: "name",
+      versionInfo,
+    })
 
     const { getByText } = render(<AboutScreen />)
 
     expect(getByText("Version:")).toBeDefined()
-    expect(getByText(`${versionNumber} (${buildNumber})`)).toBeDefined()
+    expect(getByText(versionInfo)).toBeDefined()
   })
 
   it("navigates to the pathcheck organization when tapped on the url", () => {
     const openURLSpy = jest.spyOn(Linking, "openURL")
+    ;(useApplicationInfo as jest.Mock).mockReturnValueOnce({
+      applicationName: "name",
+      versionInfo: "versionInfo",
+    })
 
     const { getByText } = render(<AboutScreen />)
 
@@ -56,6 +52,10 @@ describe("About", () => {
     const mockOsVersion = "osVersion"
     jest.mock("react-native/Libraries/Utilities/Platform", () => {
       return { OS: mockOsName, Version: mockOsVersion }
+    })
+    ;(useApplicationInfo as jest.Mock).mockReturnValueOnce({
+      applicationName: "name",
+      versionInfo: "versionInfo",
     })
 
     const { getByText } = render(<AboutScreen />)

--- a/src/More/About.spec.tsx
+++ b/src/More/About.spec.tsx
@@ -1,15 +1,15 @@
 import React from "react"
 import { Linking } from "react-native"
 import { render, fireEvent } from "@testing-library/react-native"
-import {
-  getApplicationName,
-  getVersion,
-  getBuildNumber,
-} from "react-native-device-info"
 
 import AboutScreen from "./About"
+import {
+  getApplicationName,
+  getBuildNumber,
+  getVersion,
+} from "../gaen/nativeModule"
 
-jest.mock("react-native-device-info", () => {
+jest.mock("nativeModule", () => {
   return {
     getApplicationName: jest.fn(),
     getBuildNumber: jest.fn(),

--- a/src/More/About.tsx
+++ b/src/More/About.tsx
@@ -8,13 +8,14 @@ import {
   Text,
   View,
 } from "react-native"
-import {
-  getApplicationName,
-  getBuildNumber,
-  getVersion,
-} from "react-native-device-info"
 
 import { GlobalText } from "../components/GlobalText"
+
+import {
+  getVersion,
+  getBuildNumber,
+  getApplicationName,
+} from "../gaen/nativeModule"
 
 import { Colors, Spacing, Typography } from "../styles"
 

--- a/src/More/About.tsx
+++ b/src/More/About.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState, useEffect } from "react"
+import React, { FunctionComponent } from "react"
 import { useTranslation } from "react-i18next"
 import {
   Linking,
@@ -11,13 +11,8 @@ import {
 
 import { GlobalText } from "../components/GlobalText"
 
-import {
-  getVersion,
-  getBuildNumber,
-  getApplicationName,
-} from "../gaen/nativeModule"
-
 import { Colors, Spacing, Typography } from "../styles"
+import { useApplicationInfo } from "./useApplicationInfo"
 
 export const AboutScreen: FunctionComponent = () => {
   const { t } = useTranslation()
@@ -25,20 +20,7 @@ export const AboutScreen: FunctionComponent = () => {
   const osInfo = `${Platform.OS} v${Platform.Version}`
   const pathCheckWebAddress = "pathcheck.org"
   const pathCheckUrl = "https://pathcheck.org/"
-  const [applicationName, setApplicationName] = useState("")
-  const [versionInfo, setVersionInfo] = useState("")
-
-  const fetchDeviceInfo = async () => {
-    const name = await getApplicationName()
-    const version = await getVersion()
-    const buildNumber = await getBuildNumber()
-    setApplicationName(name)
-    setVersionInfo(`${version} (${buildNumber})`)
-  }
-
-  useEffect(() => {
-    fetchDeviceInfo()
-  }, [])
+  const { applicationName, versionInfo } = useApplicationInfo()
 
   return (
     <ScrollView

--- a/src/More/About.tsx
+++ b/src/More/About.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent, useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import {
   Linking,
@@ -22,10 +22,23 @@ import { Colors, Spacing, Typography } from "../styles"
 export const AboutScreen: FunctionComponent = () => {
   const { t } = useTranslation()
 
-  const versionInfo = `${getVersion()} (${getBuildNumber()})`
   const osInfo = `${Platform.OS} v${Platform.Version}`
   const pathCheckWebAddress = "pathcheck.org"
   const pathCheckUrl = "https://pathcheck.org/"
+  const [applicationName, setApplicationName] = useState("")
+  const [versionInfo, setVersionInfo] = useState("")
+
+  const fetchDeviceInfo = async () => {
+    const name = await getApplicationName()
+    const version = await getVersion()
+    const buildNumber = await getBuildNumber()
+    setApplicationName(name)
+    setVersionInfo(`${version} (${buildNumber})`)
+  }
+
+  useEffect(() => {
+    fetchDeviceInfo()
+  }, [])
 
   return (
     <ScrollView
@@ -33,9 +46,7 @@ export const AboutScreen: FunctionComponent = () => {
       alwaysBounceVertical={false}
     >
       <View>
-        <GlobalText style={style.headerContent}>
-          {getApplicationName()}
-        </GlobalText>
+        <GlobalText style={style.headerContent}>{applicationName}</GlobalText>
       </View>
       <GlobalText style={style.aboutContent}>
         {t("label.about_para")}

--- a/src/More/Licenses.spec.tsx
+++ b/src/More/Licenses.spec.tsx
@@ -3,11 +3,11 @@ import "react-native"
 import { render } from "@testing-library/react-native"
 import "@testing-library/jest-native/extend-expect"
 import { useNavigation, useFocusEffect } from "@react-navigation/native"
-import { getApplicationName } from "react-native-device-info"
 
 import LicensesScreen from "./Licenses"
+import { getApplicationName } from "../gaen/nativeModule"
 
-jest.mock("react-native-device-info", () => {
+jest.mock("nativeModule", () => {
   return {
     getApplicationName: jest.fn(),
   }

--- a/src/More/Licenses.spec.tsx
+++ b/src/More/Licenses.spec.tsx
@@ -1,30 +1,29 @@
 import React from "react"
 import "react-native"
-import { render } from "@testing-library/react-native"
+import { render, wait } from "@testing-library/react-native"
 import "@testing-library/jest-native/extend-expect"
 import { useNavigation, useFocusEffect } from "@react-navigation/native"
+import { useApplicationName } from "./useApplicationInfo"
 
 import LicensesScreen from "./Licenses"
-import { getApplicationName } from "../gaen/nativeModule"
-
-jest.mock("nativeModule", () => {
-  return {
-    getApplicationName: jest.fn(),
-  }
-})
 
 jest.mock("@react-navigation/native")
+jest.mock("./useApplicationInfo")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 ;(useFocusEffect as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 
 describe("LicensesScreen", () => {
-  it("shows the name of the application", () => {
+  it("shows the name of the application", async () => {
     const applicationName = "application name"
 
-    ;(getApplicationName as jest.Mock).mockReturnValueOnce(applicationName)
+    ;(useApplicationName as jest.Mock).mockReturnValueOnce({
+      applicationName,
+    })
 
     const { getByText } = render(<LicensesScreen />)
 
-    expect(getByText(applicationName)).toBeDefined()
+    await wait(() => {
+      expect(getByText(applicationName)).toBeDefined()
+    })
   })
 })

--- a/src/More/Licenses.tsx
+++ b/src/More/Licenses.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useState } from "react"
+import React, { FunctionComponent } from "react"
 import {
   Linking,
   ScrollView,
@@ -9,25 +9,16 @@ import {
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 import env from "react-native-config"
+import { useApplicationName } from "./useApplicationInfo"
 
 import { GlobalText } from "../components/GlobalText"
 
-import { getApplicationName } from "../gaen/nativeModule"
 import { Colors, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
 
 const Licenses: FunctionComponent = () => {
   const { t } = useTranslation()
-  const [applicationName, setApplicationName] = useState("")
-
-  const fetchApplicationName = async () => {
-    const name = await getApplicationName()
-    setApplicationName(name)
-  }
-
-  useEffect(() => {
-    fetchApplicationName()
-  }, [])
+  const { applicationName } = useApplicationName()
 
   const infoEmailAddress = "info@pathcheck.org"
   const infoEmailLink = "mailto:info@pathcheck.org"

--- a/src/More/Licenses.tsx
+++ b/src/More/Licenses.tsx
@@ -8,11 +8,11 @@ import {
 } from "react-native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
-import { getApplicationName } from "react-native-device-info"
 import env from "react-native-config"
 
 import { GlobalText } from "../components/GlobalText"
 
+import { getApplicationName } from "../gaen/nativeModule"
 import { Colors, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
 

--- a/src/More/Licenses.tsx
+++ b/src/More/Licenses.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent, useEffect, useState } from "react"
 import {
   Linking,
   ScrollView,
@@ -18,6 +18,16 @@ import { Icons } from "../assets"
 
 const Licenses: FunctionComponent = () => {
   const { t } = useTranslation()
+  const [applicationName, setApplicationName] = useState("")
+
+  const fetchApplicationName = async () => {
+    const name = await getApplicationName()
+    setApplicationName(name)
+  }
+
+  useEffect(() => {
+    fetchApplicationName()
+  }, [])
 
   const infoEmailAddress = "info@pathcheck.org"
   const infoEmailLink = "mailto:info@pathcheck.org"
@@ -37,7 +47,7 @@ const Licenses: FunctionComponent = () => {
             style={style.headerContent}
             testID={"licenses-legal-header"}
           >
-            {getApplicationName()}
+            {applicationName}
           </GlobalText>
           <GlobalText style={style.contentText}>
             {t("label.legal_page_address")}

--- a/src/More/useApplicationInfo.spec.tsx
+++ b/src/More/useApplicationInfo.spec.tsx
@@ -1,0 +1,49 @@
+import React, { FunctionComponent } from "react"
+import { Text } from "react-native"
+import { wait, render } from "@testing-library/react-native"
+
+import {
+  getVersion,
+  getBuildNumber,
+  getApplicationName,
+} from "../gaen/nativeModule"
+import { useApplicationName, useVersionInfo } from "./useApplicationInfo"
+
+jest.mock("../gaen/nativeModule")
+
+describe("useApplicationName", () => {
+  it("fetches the application name from the module", async () => {
+    const applicationName = "applicationName"
+    ;(getApplicationName as jest.Mock).mockResolvedValueOnce(applicationName)
+    const Container: FunctionComponent = () => {
+      const { applicationName } = useApplicationName()
+      return <Text>{applicationName}</Text>
+    }
+
+    const { getByText } = render(<Container />)
+
+    await wait(() => {
+      expect(getByText(applicationName)).toBeDefined()
+    })
+  })
+})
+
+describe("useVersionInfo", () => {
+  it("fetches the version and build number from the native modules", async () => {
+    const version = "version"
+    const buildNumber = 1
+    const resultingVersionInfo = `${version} (${buildNumber})`
+    ;(getVersion as jest.Mock).mockResolvedValueOnce(version)
+    ;(getBuildNumber as jest.Mock).mockResolvedValueOnce(buildNumber)
+    const Container: FunctionComponent = () => {
+      const { versionInfo } = useVersionInfo()
+      return <Text>{versionInfo}</Text>
+    }
+
+    const { getByText } = render(<Container />)
+
+    await wait(() => {
+      expect(getByText(resultingVersionInfo)).toBeDefined()
+    })
+  })
+})

--- a/src/More/useApplicationInfo.ts
+++ b/src/More/useApplicationInfo.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react"
+
+import {
+  getVersion,
+  getBuildNumber,
+  getApplicationName,
+} from "../gaen/nativeModule"
+
+interface ApplicationInfo {
+  applicationName: string
+  versionInfo: string
+}
+
+const useApplicationName = (): Pick<ApplicationInfo, "applicationName"> => {
+  const [applicationName, setApplicationName] = useState("")
+
+  const fetchApplicationName = async () => {
+    const name = await getApplicationName()
+    setApplicationName(name)
+  }
+
+  useEffect(() => {
+    fetchApplicationName()
+  }, [])
+
+  return { applicationName }
+}
+
+const useVersionInfo = (): Pick<ApplicationInfo, "versionInfo"> => {
+  const [versionInfo, setVersionInfo] = useState("")
+
+  const fetchVersion = async () => {
+    const version = await getVersion()
+    const buildNumber = await getBuildNumber()
+    setVersionInfo(`${version} (${buildNumber})`)
+  }
+
+  useEffect(() => {
+    fetchVersion()
+  }, [])
+
+  return { versionInfo }
+}
+
+const useApplicationInfo = (): ApplicationInfo => {
+  const { applicationName } = useApplicationName()
+  const { versionInfo } = useVersionInfo()
+
+  return { applicationName, versionInfo }
+}
+
+export { useApplicationInfo, useApplicationName, useVersionInfo }

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -125,6 +125,21 @@ export const submitDiagnosisKeys = async (
   return exposureKeyModule.postDiagnosisKeys(certificate, hmacKey)
 }
 
+// Device Info Module
+const deviceInfoModule = NativeModules.DeviceInfoModule
+
+export const getApplicationName = async (): Promise<string> => {
+  return deviceInfoModule.getApplicationName()
+}
+
+export const getBuildNumber = async (): Promise<string> => {
+  return deviceInfoModule.getBuildNumber()
+}
+
+export const getVersion = async (): Promise<string> => {
+  return deviceInfoModule.getVersion()
+}
+
 // Debug Module
 const debugModule = NativeModules.DebugMenuModule
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,17 +1021,14 @@
 "@react-native-community/masked-view@^0.1.10":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
-  integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
 
 "@react-native-community/netinfo@^5.9.4":
   version "5.9.4"
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.4.tgz#a05a9403f8ee09c7d7f7c2dda850b79cac376691"
-  integrity sha512-mb664NOqPvyUZ4TznzdYEfdS3OhSXWGbZprgsDZn4THw2X/4wcBFcBUeWuMzeQ56KhY0rm/YBBlZWHrSf3C/Aw==
 
 "@react-native-community/push-notification-ios@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.4.0.tgz#e1781e60fb8a2569547e3f1613c62e1c3b46960c"
-  integrity sha512-YnfxtAuHkiuvprh1d9npGZVwOrso6sys8+w8XY6RQAs8kD2LHZg0C8rA5gfX4jW/GrQV7m14Y6ngciE6Rpd91w==
   dependencies:
     invariant "^2.2.4"
 
@@ -1180,7 +1177,6 @@
 "@testing-library/jest-native@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-3.1.0.tgz#414c834dfb524ca82b86509d5479e365d4d5bbec"
-  integrity sha512-MZdsTsD6xrP5V0FTz2gVPG00ZMoKn4WniRitUH40zZTQ0DfMa5CVDpkAd5ed6qX1coDwS8vSCZS/JGMIDYjRQQ==
   dependencies:
     chalk "^2.4.1"
     jest-diff "^24.0.0"
@@ -1192,7 +1188,6 @@
 "@testing-library/react-native@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-5.0.3.tgz#8821dcf7fe7364bc7f427d853cd96e4407d88a4f"
-  integrity sha512-lQH7vUgwESfagFw4BlKsfpX7Rv/m7h2NYfubY0aoQromSwI1slCxrhwZws8gABTXweob/DyLATsOamHsWdwDnA==
   dependencies:
     pretty-format "^24.9.0"
     wait-for-expect "^3.0.0"
@@ -1315,7 +1310,6 @@
 "@types/react-test-renderer@^16.9.2":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz#e1c408831e8183e5ad748fdece02214a7c2ab6c5"
-  integrity sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==
   dependencies:
     "@types/react" "*"
 
@@ -1659,7 +1653,6 @@ array-find-index@^1.0.1:
 array-flat-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz#1e3a4255be619dfbffbfd1d635c1cf357cd034e7"
-  integrity sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==
 
 array-includes@^3.0.3, array-includes@^3.1.1:
   version "3.1.1"
@@ -2798,7 +2791,6 @@ didyoumean@^1.2.1:
 diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
-  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -3146,7 +3138,6 @@ eslint-plugin-react-hooks@^2.0.1:
 eslint-plugin-react-hooks@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.4.tgz#aed33b4254a41b045818cacb047b81e6df27fa58"
-  integrity sha512-equAdEIsUETLFNCmmCkiCGq6rkSK5MoJhXFPFYeUebcjKgBmWWcgVOqZyQC8Bv1BwVCnTq9tBxgJFgAJTWoJtA==
 
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"
@@ -3681,7 +3672,6 @@ find-versions@^3.2.0:
 fishery@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/fishery/-/fishery-0.4.1.tgz#ba4fb0c79e68ace59e5ae42ae804c28fb54c501a"
-  integrity sha512-MwXwgm2LPBGZbTIxq7E0S8pfEBumrgKmOI4CiVnc6sAQn8xsxGMuEqfnUUyTEKYJRWtZV61YUgcMnmGhBFtiMA==
   dependencies:
     lodash.merge "^4.6.2"
 
@@ -4044,7 +4034,6 @@ hermes-engine@^0.2.1:
 hex-lite@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/hex-lite/-/hex-lite-1.5.0.tgz#482db64f673dcacdb8be93c629a799ce5a76b24d"
-  integrity sha512-bXFMCFoKcksmJ1kDRq6B0+Go5Wgq84Dq/3rX99+0OzBQZKUBEMLguPd1lZSpvmzJACb516n07eyswF4KHAF9cg==
 
 hoist-non-react-statics@^2.3.1:
   version "2.5.5"
@@ -4622,7 +4611,6 @@ jest-config@^25.5.4:
 jest-diff@^24.0.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
-  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
   dependencies:
     chalk "^2.0.1"
     diff-sequences "^24.9.0"
@@ -4757,7 +4745,6 @@ jest-leak-detector@^25.5.0:
 jest-matcher-utils@^24.0.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
-  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
   dependencies:
     chalk "^2.0.1"
     jest-diff "^24.9.0"
@@ -5349,7 +5336,6 @@ locate-path@^5.0.0:
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -5366,7 +5352,6 @@ lodash.unescape@4.0.1:
 lodash@4.x.x, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -6703,7 +6688,6 @@ ramda@^0.25.0:
 ramda@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -6739,12 +6723,6 @@ react-native-background-fetch@^3.1.0:
 react-native-config@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.2.1.tgz#f80454fc58ea89b549819ccb4bdab26518a9f0db"
-  integrity sha512-u7MDku3fUUKAtxfUFLLwnj4htBYO840EBGdlDB9ry/eX1TY+asHwULaUkAj9x+pJo4vSpIp8GtYxxi8dLzDtJw==
-
-react-native-device-info@^5.6.3:
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-5.6.3.tgz#8b964866fc538bcfb82e25ad88f872139d7a591d"
-  integrity sha512-fmaXRjG0NW9FAOdOD86cmjgoxA/2I0lBq1NZmxQ2sgElyRjLxZLtuJn/QpP8hmFeTlKFDSZpSDvEnB+UUihcmw==
 
 react-native-gesture-handler@^1.6.1:
   version "1.6.1"
@@ -6781,7 +6759,6 @@ react-native-reanimated@^1.7.1:
 react-native-safe-area-context@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.0.5.tgz#3dd9bf2fea3b51f894b9849f11108ac303bbefe5"
-  integrity sha512-cLZtHvzm/tdCTCOCgNRUsnl9ma8MozE9vtxHQVftuY6hRt+esCBdXA5jXcuCaCj+yUe4Akw+c5BPFNUF5vOTjQ==
 
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"
@@ -6792,12 +6769,10 @@ react-native-safe-area-view@^0.14.9:
 react-native-screens@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.8.0.tgz#9f989096fc5ccf248e0dfa93a74f1a64057e15f1"
-  integrity sha512-fUCIQLZX+5XB0ypWX038P3zso54IFFjTsQUZJWEsjC3pp5rPItAt5SzqtJn+uVjcJaczZ+dpIuvj6IFLqkWLZQ==
 
 react-native-simple-crypto@^0.2.12:
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/react-native-simple-crypto/-/react-native-simple-crypto-0.2.12.tgz#942d050950fa60b0191fd69ddd6807fe6de958aa"
-  integrity sha512-zjeYa7eJ4agPyj1UZhABjfPzmT6nwckzVwfN1XuPAylo98OImfspDMtBSeeGp0qh6GUF8Kd/q5WwJGKbKUB/3Q==
   dependencies:
     base64-js "^1.3.0"
     hex-lite "^1.5.0"
@@ -6878,7 +6853,6 @@ react-refresh@^0.4.0:
 react-test-renderer@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
-  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
@@ -6955,7 +6929,6 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.5, readable
 readable-stream@^3.1.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -7331,7 +7304,6 @@ scheduler@0.15.0:
 scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,14 +1021,17 @@
 "@react-native-community/masked-view@^0.1.10":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
+  integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
 
 "@react-native-community/netinfo@^5.9.4":
   version "5.9.4"
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.4.tgz#a05a9403f8ee09c7d7f7c2dda850b79cac376691"
+  integrity sha512-mb664NOqPvyUZ4TznzdYEfdS3OhSXWGbZprgsDZn4THw2X/4wcBFcBUeWuMzeQ56KhY0rm/YBBlZWHrSf3C/Aw==
 
 "@react-native-community/push-notification-ios@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.4.0.tgz#e1781e60fb8a2569547e3f1613c62e1c3b46960c"
+  integrity sha512-YnfxtAuHkiuvprh1d9npGZVwOrso6sys8+w8XY6RQAs8kD2LHZg0C8rA5gfX4jW/GrQV7m14Y6ngciE6Rpd91w==
   dependencies:
     invariant "^2.2.4"
 
@@ -1177,6 +1180,7 @@
 "@testing-library/jest-native@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-3.1.0.tgz#414c834dfb524ca82b86509d5479e365d4d5bbec"
+  integrity sha512-MZdsTsD6xrP5V0FTz2gVPG00ZMoKn4WniRitUH40zZTQ0DfMa5CVDpkAd5ed6qX1coDwS8vSCZS/JGMIDYjRQQ==
   dependencies:
     chalk "^2.4.1"
     jest-diff "^24.0.0"
@@ -1188,6 +1192,7 @@
 "@testing-library/react-native@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-5.0.3.tgz#8821dcf7fe7364bc7f427d853cd96e4407d88a4f"
+  integrity sha512-lQH7vUgwESfagFw4BlKsfpX7Rv/m7h2NYfubY0aoQromSwI1slCxrhwZws8gABTXweob/DyLATsOamHsWdwDnA==
   dependencies:
     pretty-format "^24.9.0"
     wait-for-expect "^3.0.0"
@@ -1310,6 +1315,7 @@
 "@types/react-test-renderer@^16.9.2":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz#e1c408831e8183e5ad748fdece02214a7c2ab6c5"
+  integrity sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==
   dependencies:
     "@types/react" "*"
 
@@ -1653,6 +1659,7 @@ array-find-index@^1.0.1:
 array-flat-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz#1e3a4255be619dfbffbfd1d635c1cf357cd034e7"
+  integrity sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==
 
 array-includes@^3.0.3, array-includes@^3.1.1:
   version "3.1.1"
@@ -2791,6 +2798,7 @@ didyoumean@^1.2.1:
 diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -3138,6 +3146,7 @@ eslint-plugin-react-hooks@^2.0.1:
 eslint-plugin-react-hooks@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.4.tgz#aed33b4254a41b045818cacb047b81e6df27fa58"
+  integrity sha512-equAdEIsUETLFNCmmCkiCGq6rkSK5MoJhXFPFYeUebcjKgBmWWcgVOqZyQC8Bv1BwVCnTq9tBxgJFgAJTWoJtA==
 
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"
@@ -3672,6 +3681,7 @@ find-versions@^3.2.0:
 fishery@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/fishery/-/fishery-0.4.1.tgz#ba4fb0c79e68ace59e5ae42ae804c28fb54c501a"
+  integrity sha512-MwXwgm2LPBGZbTIxq7E0S8pfEBumrgKmOI4CiVnc6sAQn8xsxGMuEqfnUUyTEKYJRWtZV61YUgcMnmGhBFtiMA==
   dependencies:
     lodash.merge "^4.6.2"
 
@@ -4034,6 +4044,7 @@ hermes-engine@^0.2.1:
 hex-lite@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/hex-lite/-/hex-lite-1.5.0.tgz#482db64f673dcacdb8be93c629a799ce5a76b24d"
+  integrity sha512-bXFMCFoKcksmJ1kDRq6B0+Go5Wgq84Dq/3rX99+0OzBQZKUBEMLguPd1lZSpvmzJACb516n07eyswF4KHAF9cg==
 
 hoist-non-react-statics@^2.3.1:
   version "2.5.5"
@@ -4611,6 +4622,7 @@ jest-config@^25.5.4:
 jest-diff@^24.0.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
   dependencies:
     chalk "^2.0.1"
     diff-sequences "^24.9.0"
@@ -4745,6 +4757,7 @@ jest-leak-detector@^25.5.0:
 jest-matcher-utils@^24.0.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
+  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
   dependencies:
     chalk "^2.0.1"
     jest-diff "^24.9.0"
@@ -5336,6 +5349,7 @@ locate-path@^5.0.0:
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -5352,6 +5366,7 @@ lodash.unescape@4.0.1:
 lodash@4.x.x, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -6688,6 +6703,7 @@ ramda@^0.25.0:
 ramda@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -6723,6 +6739,7 @@ react-native-background-fetch@^3.1.0:
 react-native-config@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.2.1.tgz#f80454fc58ea89b549819ccb4bdab26518a9f0db"
+  integrity sha512-u7MDku3fUUKAtxfUFLLwnj4htBYO840EBGdlDB9ry/eX1TY+asHwULaUkAj9x+pJo4vSpIp8GtYxxi8dLzDtJw==
 
 react-native-gesture-handler@^1.6.1:
   version "1.6.1"
@@ -6759,6 +6776,7 @@ react-native-reanimated@^1.7.1:
 react-native-safe-area-context@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.0.5.tgz#3dd9bf2fea3b51f894b9849f11108ac303bbefe5"
+  integrity sha512-cLZtHvzm/tdCTCOCgNRUsnl9ma8MozE9vtxHQVftuY6hRt+esCBdXA5jXcuCaCj+yUe4Akw+c5BPFNUF5vOTjQ==
 
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"
@@ -6769,10 +6787,12 @@ react-native-safe-area-view@^0.14.9:
 react-native-screens@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.8.0.tgz#9f989096fc5ccf248e0dfa93a74f1a64057e15f1"
+  integrity sha512-fUCIQLZX+5XB0ypWX038P3zso54IFFjTsQUZJWEsjC3pp5rPItAt5SzqtJn+uVjcJaczZ+dpIuvj6IFLqkWLZQ==
 
 react-native-simple-crypto@^0.2.12:
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/react-native-simple-crypto/-/react-native-simple-crypto-0.2.12.tgz#942d050950fa60b0191fd69ddd6807fe6de958aa"
+  integrity sha512-zjeYa7eJ4agPyj1UZhABjfPzmT6nwckzVwfN1XuPAylo98OImfspDMtBSeeGp0qh6GUF8Kd/q5WwJGKbKUB/3Q==
   dependencies:
     base64-js "^1.3.0"
     hex-lite "^1.5.0"
@@ -6853,6 +6873,7 @@ react-refresh@^0.4.0:
 react-test-renderer@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
+  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
@@ -6929,6 +6950,7 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.5, readable
 readable-stream@^3.1.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -7304,6 +7326,7 @@ scheduler@0.15.0:
 scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Why:
----
The `react-native-device-info` package has security vulnerabilities potentially leaking phone numbers on the android build. We need to display the info provided by this package without the security vulnerabilities.

How:
----
Native modules are added on the android and ios side exposing the build number, version number and the package name to display to users.

This PR:
----
- Remove RNDeviceInfo dependency.
- Implement device info native module (iOS)
- Implement device info native module (Android)
- Add hook to consume application name and version info

<img width="419" alt="Screen Shot 2020-08-06 at 12 09 55 PM" src="https://user-images.githubusercontent.com/2413802/89555209-bef9af00-d7dd-11ea-93bc-07c9738c4b8c.png">

