### PR TITLE
Remove unused properties from RawExposure interface.

### DIFF
--- a/src/exposure.ts
+++ b/src/exposure.ts
@@ -6,8 +6,6 @@ export interface Possible {
   kind: "Possible"
   date: Posix
   duration: number
-  totalRiskScore: number
-  transmissionRiskLevel: number
 }
 
 export interface NoKnown {

--- a/src/factories/exposureDatum.tsx
+++ b/src/factories/exposureDatum.tsx
@@ -11,6 +11,5 @@ export default Factory.define<ExposureDatum>(() => {
     date: defaultDate,
     duration: 300000,
     totalRiskScore: 4,
-    transmissionRiskLevel: 7,
   }
 })

--- a/src/factories/rawExposure.tsx
+++ b/src/factories/rawExposure.tsx
@@ -10,6 +10,5 @@ export default Factory.define<RawExposure>(() => {
     date: defaultDate,
     duration: 300000,
     totalRiskScore: 4,
-    transmissionRiskLevel: 7,
   }
 })

--- a/src/gaen/dataConverter.spec.ts
+++ b/src/gaen/dataConverter.spec.ts
@@ -25,16 +25,12 @@ describe("toExposureInfo", () => {
           id: "ABCD-EFGH",
           date: twoDaysAgo,
           duration,
-          totalRiskScore: 2,
-          transmissionRiskLevel: 3,
         },
       ]
       const expected: Possible = {
         kind: "Possible",
         date: DateTimeUtils.beginningOfDay(twoDaysAgo),
         duration: duration,
-        totalRiskScore: 2,
-        transmissionRiskLevel: 3,
       }
 
       const result = toExposureInfo(rawExposures)
@@ -56,30 +52,22 @@ describe("toExposureInfo", () => {
           id: "raw-exposure-1",
           date: beginningOfDay + 1000,
           duration: duration1,
-          totalRiskScore: 1,
-          transmissionRiskLevel: 3,
         },
         {
           id: "raw-exposure-2",
           date: beginningOfDay + 18000,
           duration: duration2,
-          totalRiskScore: 7,
-          transmissionRiskLevel: 2,
         },
         {
           id: "raw-exposure-3",
           date: beginningOfDay + 36000,
           duration: duration3,
-          totalRiskScore: 4,
-          transmissionRiskLevel: 5,
         },
       ]
       const expected: Possible = {
         kind: "Possible",
         date: DateTimeUtils.beginningOfDay(today),
         duration: duration1 + duration2 + duration3,
-        totalRiskScore: 7,
-        transmissionRiskLevel: 5,
       }
 
       const result = toExposureInfo(rawExposures)

--- a/src/gaen/dataConverters.ts
+++ b/src/gaen/dataConverters.ts
@@ -9,8 +9,6 @@ export interface RawExposure {
   id: UUID
   date: Posix
   duration: number
-  totalRiskScore: number
-  transmissionRiskLevel: number
 }
 
 export const toExposureInfo = (
@@ -26,8 +24,6 @@ const toPossible = (r: RawExposure): Possible => {
     kind: "Possible",
     date: beginningOfDay(r.date).valueOf(),
     duration: r.duration,
-    transmissionRiskLevel: r.transmissionRiskLevel,
-    totalRiskScore: r.totalRiskScore,
   }
 }
 
@@ -35,11 +31,6 @@ const combinePossibles = (a: Possible, b: Possible): Possible => {
   return {
     ...a,
     duration: a.duration + b.duration,
-    totalRiskScore: Math.max(a.totalRiskScore, b.totalRiskScore),
-    transmissionRiskLevel: Math.max(
-      a.transmissionRiskLevel,
-      b.transmissionRiskLevel,
-    ),
   }
 }
 


### PR DESCRIPTION
### Why
We'd like Android and iOS to be able to use different GAEN api versions and still be able to vend up exposures to the JS layer

### This Commit
This commit removes `totalRiskScore` and `transmissionRiskLevel` from the `RawExposure` interface so that the native layer can vend up objects containing just a date and duration