### PR TITLE
Update EulaModal placement and design

### DIFF
--- a/src/Activation/AcceptEula.spec.tsx
+++ b/src/Activation/AcceptEula.spec.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent, wait } from "@testing-library/react-native"
 import { useNavigation } from "@react-navigation/native"
 
 import i18n from "../locales/languages"
-import EulaModal from "./EulaModal"
+import AcceptEula from "./AcceptEula"
 
 jest.mock("react-native-local-resource", () => {
   return {
@@ -35,23 +35,13 @@ jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 
 describe("EulaModal", () => {
-  it("adds an accessible close button", () => {
-    const { getByLabelText } = render(
-      <I18nextProvider i18n={i18n}>
-        <EulaModal />
-      </I18nextProvider>,
-    )
-
-    expect(getByLabelText("Close")).toBeDefined()
-  })
-
   it("won't continue until a user accepts the terms of use", async () => {
     const navigationSpy = jest.fn()
     ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigationSpy })
 
     const { getByLabelText, getByTestId } = render(
       <I18nextProvider i18n={i18n}>
-        <EulaModal />
+        <AcceptEula />
       </I18nextProvider>,
     )
 
@@ -59,11 +49,14 @@ describe("EulaModal", () => {
     fireEvent.press(continueButton)
 
     expect(navigationSpy).not.toHaveBeenCalled()
-    fireEvent.press(getByTestId("accept-terms-of-use-checkbox"))
+    expect(getByLabelText("Unchecked checkbox")).toBeDefined()
 
+    fireEvent.press(getByTestId("accept-terms-of-use-checkbox"))
     fireEvent.press(continueButton)
+
     await wait(() => {
-      expect(navigationSpy).toHaveBeenCalledWith("Introduction")
+      expect(getByLabelText("Checked checkbox")).toBeDefined()
+      expect(navigationSpy).toHaveBeenCalledWith("ActivateProximityTracing")
     })
   })
 })

--- a/src/Activation/AcceptEula.tsx
+++ b/src/Activation/AcceptEula.tsx
@@ -6,31 +6,22 @@ import {
   View,
   SafeAreaView,
   ActivityIndicator,
-  Image,
 } from "react-native"
 import { useTranslation } from "react-i18next"
 import loadLocalResource from "react-native-local-resource"
 import WebView, { WebViewNavigation } from "react-native-webview"
-import { SvgXml } from "react-native-svg"
 import { useNavigation } from "@react-navigation/native"
+import { SvgXml } from "react-native-svg"
 
-import { Images } from "../assets"
+import { Icons } from "../assets"
 import { GlobalText } from "../components/GlobalText"
-import { OnboardingScreens } from "../navigation"
+import { ActivationScreens } from "../navigation"
 import { Button } from "../components/Button"
 import enEulaHtml from "../locales/eula/en.html"
 import esPREulaHtml from "../locales/eula/es_PR.html"
 import htEulaHtml from "../locales/eula/ht.html"
 
-import { Icons } from "../assets"
-import {
-  Forms,
-  Layout,
-  Colors,
-  Iconography,
-  Spacing,
-  Outlines,
-} from "../styles"
+import { Forms, Iconography, Colors, Spacing, Outlines } from "../styles"
 import { useStatusBarEffect } from "../navigation"
 
 const LoadingIndicator = () => {
@@ -44,7 +35,7 @@ const LoadingIndicator = () => {
 const DEFAULT_EULA_URL = "about:blank"
 type AvailableLocale = "en" | "es_PR" | "ht"
 
-const EulaModal: FunctionComponent = () => {
+const AcceptEula: FunctionComponent = () => {
   useStatusBarEffect("dark-content")
   const [html, setHtml] = useState<string | undefined>(undefined)
   const [isLoading, setIsLoading] = useState(true)
@@ -62,10 +53,6 @@ const EulaModal: FunctionComponent = () => {
   }
   const eulaPath = EULA_FILES[localeCode as AvailableLocale] || enEulaHtml
 
-  const checkboxImage = boxChecked
-    ? Images.BoxCheckedIcon
-    : Images.BoxUncheckedIcon
-
   const shouldStartLoadWithRequestHandler = (
     webViewState: WebViewNavigation,
   ) => {
@@ -76,7 +63,6 @@ const EulaModal: FunctionComponent = () => {
     }
     return shouldLoadRequest
   }
-
   useEffect(() => {
     const loadEula = async () => {
       setHtml(await loadLocalResource(eulaPath))
@@ -84,16 +70,16 @@ const EulaModal: FunctionComponent = () => {
     loadEula()
   }, [eulaPath])
 
+  const checkboxIcon = boxChecked
+    ? Icons.CheckboxChecked
+    : Icons.CheckboxUnchecked
+
+  const checkboxLabel = boxChecked
+    ? t("label.checked_checkbox")
+    : t("label.unchecked_checkbox")
+
   return (
     <SafeAreaView style={style.container}>
-      <TouchableOpacity
-        accessibilityLabel={t("label.close")}
-        accessible
-        style={style.closeIcon}
-        onPress={navigation.goBack}
-      >
-        <SvgXml fill={Colors.icon} xml={Icons.Close} />
-      </TouchableOpacity>
       {html && (
         <>
           <WebView
@@ -110,19 +96,26 @@ const EulaModal: FunctionComponent = () => {
           onPress={() => toggleCheckbox(!boxChecked)}
           accessible
           accessibilityRole="checkbox"
-          accessibilityLabel={t("label.checkbox")}
+          accessibilityLabel={checkboxLabel}
           testID="accept-terms-of-use-checkbox"
         >
-          <Image source={checkboxImage} style={style.checkboxIcon} />
+          <SvgXml
+            xml={checkboxIcon}
+            fill={Colors.primaryBlue}
+            width={Iconography.small}
+            height={Iconography.small}
+          />
           <GlobalText style={style.checkboxText}>
             {t("onboarding.eula_agree_terms_of_use")}
           </GlobalText>
         </TouchableOpacity>
         <Button
-          invert
-          onPress={() => navigation.navigate(OnboardingScreens.Introduction)}
+          onPress={() =>
+            navigation.navigate(ActivationScreens.ActivateProximityTracing)
+          }
           disabled={!boxChecked}
           label={t("common.continue")}
+          customButtonStyle={style.button}
         />
       </View>
     </SafeAreaView>
@@ -135,39 +128,36 @@ const style = StyleSheet.create({
     backgroundColor: Colors.primaryBackground,
     height: "100%",
   },
-  closeIcon: {
-    position: "absolute",
-    zIndex: Layout.zLevel1,
-    borderRadius: Outlines.borderRadiusMax,
-    backgroundColor: Colors.secondaryBackground,
-    width: Iconography.medium,
-    height: Iconography.medium,
-    alignItems: "center",
-    justifyContent: "center",
-    right: Spacing.medium,
-    top: Spacing.xHuge,
-  },
   loadingIndicator: {
     justifyContent: "center",
     height: "100%",
   },
   footerContainer: {
-    backgroundColor: Colors.primaryViolet,
-    padding: Spacing.medium,
+    position: "absolute",
+    bottom: 0,
+    width: "100%",
+    backgroundColor: Colors.primaryBackground,
+    paddingTop: Spacing.large,
+    paddingBottom: Spacing.huge,
+    paddingHorizontal: Spacing.xxLarge,
+    borderTopColor: Colors.lightGray,
+    borderTopWidth: Outlines.hairline,
   },
   checkboxContainer: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: Spacing.medium,
-  },
-  checkboxIcon: {
-    ...Forms.checkboxIcon,
+    alignSelf: "center",
+    marginBottom: Spacing.xxLarge,
   },
   checkboxText: {
     ...Forms.checkboxText,
+    color: Colors.primaryText,
     flex: 1,
     paddingLeft: Spacing.medium,
   },
+  button: {
+    alignSelf: "center",
+  },
 })
 
-export default EulaModal
+export default AcceptEula

--- a/src/Onboarding/OnboardingScreen.tsx
+++ b/src/Onboarding/OnboardingScreen.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from "react-i18next"
 
 import { Button } from "../components/Button"
 import { GlobalText } from "../components/GlobalText"
-import { Stacks, ActivationScreens } from "../navigation"
+import { Stacks, ActivationScreens, useStatusBarEffect } from "../navigation"
 import { NUMBER_OF_ONBOARDING_SCREENS } from "../navigation/OnboardingStack"
 
 import { Layout, Outlines, Colors, Spacing, Typography } from "../styles"
@@ -43,13 +43,15 @@ const OnboardingScreen: FunctionComponent<OnboardingScreenProps> = ({
   const { t } = useTranslation()
   const navigation = useNavigation()
 
+  useStatusBarEffect("dark-content")
+
   return (
     <SafeAreaView>
       <View>
         <TouchableOpacity
           onPress={() =>
             navigation.navigate(Stacks.Activation, {
-              screen: ActivationScreens.ActivateProximityTracing,
+              screen: ActivationScreens.AcceptEula,
             })
           }
           style={style.skipButtonContainer}

--- a/src/Onboarding/ValueProposition.tsx
+++ b/src/Onboarding/ValueProposition.tsx
@@ -22,7 +22,7 @@ const ValueProposition: FunctionComponent = () => {
   const onboardingScreenActions = {
     primaryButtonOnPress: () =>
       navigation.navigate(Stacks.Activation, {
-        screen: ActivationScreens.ActivateProximityTracing,
+        screen: ActivationScreens.AcceptEula,
       }),
   }
 

--- a/src/Onboarding/Welcome.spec.tsx
+++ b/src/Onboarding/Welcome.spec.tsx
@@ -39,6 +39,6 @@ describe("Welcome", () => {
     const { getByLabelText } = render(<Welcome />)
     const continueButton = getByLabelText("Get Started")
     fireEvent.press(continueButton)
-    expect(navigationSpy).toHaveBeenCalledWith("EulaModal")
+    expect(navigationSpy).toHaveBeenCalledWith("Introduction")
   })
 })

--- a/src/Onboarding/Welcome.tsx
+++ b/src/Onboarding/Welcome.tsx
@@ -53,7 +53,7 @@ const Welcome: FunctionComponent = () => {
           <Button
             invert
             label={t("label.launch_get_started")}
-            onPress={() => navigation.navigate(OnboardingScreens.EulaModal)}
+            onPress={() => navigation.navigate(OnboardingScreens.Introduction)}
           />
         </View>
       </View>

--- a/src/assets/svgs/checkboxChecked.ts
+++ b/src/assets/svgs/checkboxChecked.ts
@@ -1,0 +1,5 @@
+export default `
+<svg width="23" height="23" viewBox="0 0 23 23" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 0H5C2.23858 0 0 2.23858 0 5V18C0 20.7614 2.23858 23 5 23H18C20.7614 23 23 20.7614 23 18V5C23 2.23858 20.7614 0 18 0ZM4.625 11.705L8.795 15.875L19.385 5.295L20.795 6.705L8.795 18.705L3.205 13.115L4.625 11.705Z" />
+</svg>
+`

--- a/src/assets/svgs/checkboxUnchecked.ts
+++ b/src/assets/svgs/checkboxUnchecked.ts
@@ -1,0 +1,5 @@
+export default `
+<svg width="23" height="23" viewBox="0 0 23 23" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 2H5C3.34315 2 2 3.34315 2 5V18C2 19.6569 3.34315 21 5 21H18C19.6569 21 21 19.6569 21 18V5C21 3.34315 19.6569 2 18 2ZM18 0H5C2.23858 0 0 2.23858 0 5V18C0 20.7614 2.23858 23 5 23H18C20.7614 23 23 20.7614 23 18V5C23 2.23858 20.7614 0 18 0Z" />
+</svg>
+`

--- a/src/assets/svgs/index.ts
+++ b/src/assets/svgs/index.ts
@@ -4,6 +4,8 @@ import Arrow from "./arrow"
 import BackArrow from "./backArrow"
 import Bell from "./bell"
 import BellYellow from "./bellYellow"
+import CheckboxChecked from "./checkboxChecked"
+import CheckboxUnchecked from "./checkboxUnchecked"
 import Checkmark from "./checkmark"
 import CheckmarkCircle from "./checkmarkCircle"
 import ChevronRight from "./chevronRight"
@@ -35,6 +37,8 @@ export const Icons = {
   BackArrow,
   Bell,
   BellYellow,
+  CheckboxChecked,
+  CheckboxUnchecked,
   Checkmark,
   CheckmarkCircle,
   ChevronRight,

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -82,8 +82,8 @@ export const Button: FunctionComponent<ButtonProps> = ({
       testID={testID}
     >
       <LinearGradient
-        start={{ x: 0, y: 0.85 }}
-        end={{ x: 0.15, y: 0 }}
+        start={{ x: 0.2, y: 0.85 }}
+        end={{ x: 0.4, y: 0 }}
         colors={determineGradient()}
         style={buttonStyle}
       >

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -132,6 +132,8 @@
     "calendar_icon": "Calendar icon",
     "check": "Checkmark",
     "checkbox": "Checkbox",
+    "checked_checkbox": "Checked checkbox",
+    "unchecked_checkbox": "Unchecked checkbox",
     "close": "Close",
     "description_optional": "Description (Optional)",
     "email_optional": "Email (Optional)",

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next"
 import { GlobalText } from "../components"
 import { Stacks, ActivationScreen, ActivationScreens } from "./index"
 
+import AcceptEula from "../Activation/AcceptEula"
 import ActivateProximityTracing from "../Activation/ActivateProximityTracing"
 import NotificationPermissions from "../Activation/NotificationPermissions"
 
@@ -27,11 +28,16 @@ const ActivationStack: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
 
-  type ActivationStep = "ActivateProximityTracing" | "NotificationPermissions"
+  type ActivationStep =
+    | "ActivateProximityTracing"
+    | "NotificationPermissions"
+    | "AcceptEula"
 
   const HeaderRight = (step: ActivationStep) => {
     const determineStepText = () => {
       switch (step) {
+        case "AcceptEula":
+          return t("onboarding.step_1_of_3")
         case "ActivateProximityTracing":
           return t("onboarding.step_2_of_3")
         case "NotificationPermissions":
@@ -71,6 +77,13 @@ const ActivationStack: FunctionComponent = () => {
 
   return (
     <Stack.Navigator screenOptions={screenOptions}>
+      <Stack.Screen
+        name={ActivationScreens.AcceptEula}
+        component={AcceptEula}
+        options={{
+          headerRight: () => HeaderRight("AcceptEula"),
+        }}
+      />
       <Stack.Screen
         name={ActivationScreens.ActivateProximityTracing}
         component={ActivateProximityTracing}

--- a/src/navigation/OnboardingStack.tsx
+++ b/src/navigation/OnboardingStack.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from "react"
 import {
-  TransitionPresets,
   createStackNavigator,
   StackNavigationOptions,
 } from "@react-navigation/stack"
@@ -9,7 +8,6 @@ import { OnboardingScreen, OnboardingScreens } from "./index"
 
 import Welcome from "../Onboarding/Welcome"
 import PersonalPrivacy from "../Onboarding/PersonalPrivacy"
-import EulaModal from "../Onboarding/EulaModal"
 import LanguageSelection from "../More/LanguageSelection"
 import Introduction from "../Onboarding/Introduction"
 import PhoneRemembersDevices from "../Onboarding/PhoneRemembersDevices"
@@ -32,11 +30,6 @@ const OnboardingStack: FunctionComponent = () => {
   return (
     <Stack.Navigator screenOptions={onboardingScreenOptions}>
       <Stack.Screen name={OnboardingScreens.Welcome} component={Welcome} />
-      <Stack.Screen
-        name={OnboardingScreens.EulaModal}
-        component={EulaModal}
-        options={{ ...TransitionPresets.ModalTransition }}
-      />
       <Stack.Screen
         name={OnboardingScreens.Introduction}
         component={Introduction}

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -15,14 +15,16 @@ export type NavigationProp = NavigationScreenProp<
 >
 
 export type ActivationScreen =
-  | "NotificationPermissions"
+  | "AcceptEula"
   | "ActivateProximityTracing"
+  | "NotificationPermissions"
 
 export const ActivationScreens: {
   [key in ActivationScreen]: ActivationScreen
 } = {
-  NotificationPermissions: "NotificationPermissions",
+  AcceptEula: "AcceptEula",
   ActivateProximityTracing: "ActivateProximityTracing",
+  NotificationPermissions: "NotificationPermissions",
 }
 
 export type OnboardingScreen =
@@ -32,7 +34,6 @@ export type OnboardingScreen =
   | "PersonalPrivacy"
   | "GetNotified"
   | "ValueProposition"
-  | "EulaModal"
   | "LanguageSelection"
 
 export const OnboardingScreens: {
@@ -44,7 +45,6 @@ export const OnboardingScreens: {
   PersonalPrivacy: "PersonalPrivacy",
   GetNotified: "GetNotified",
   ValueProposition: "ValueProposition",
-  EulaModal: "EulaModal",
   LanguageSelection: "LanguageSelection",
 }
 

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -46,7 +46,7 @@ export const primary: ViewStyle = {
   ...large,
   borderRadius: Outlines.borderRadiusMax,
   paddingHorizontal: Spacing.huge,
-  minWidth: 200,
+  minWidth: 225,
 }
 
 export const secondary: ViewStyle = {

--- a/src/styles/forms.ts
+++ b/src/styles/forms.ts
@@ -33,7 +33,6 @@ export const checkboxIcon: ImageStyle = {
 
 export const checkboxText: TextStyle = {
   ...Typography.mediumFont,
-  color: Colors.invertedText,
 }
 
 export const textInput: TextStyle = {


### PR DESCRIPTION
Why: the design of our Eula acceptance has changed.

This commit:
- Moves the Eula acceptance to the front of the Activation stack
- Updates the design of the Eula acceptance screen

![accept_eula](https://user-images.githubusercontent.com/39350030/89562150-8b238700-d7e7-11ea-8819-9533527e2ec3.gif)