### PR TITLE
(Android) Implement exposure history methods

### DIFF
--- a/android/app/src/main/java/covidsafepaths/bt/bridge/ExposureNotificationsPackage.java
+++ b/android/app/src/main/java/covidsafepaths/bt/bridge/ExposureNotificationsPackage.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import covidsafepaths.bt.exposurenotifications.DebugMenuModule;
 import covidsafepaths.bt.exposurenotifications.DeviceInfoModule;
+import covidsafepaths.bt.exposurenotifications.ExposureHistoryModule;
 import covidsafepaths.bt.exposurenotifications.ExposureKeyModule;
 import covidsafepaths.bt.exposurenotifications.ExposureNotificationsModule;
 
@@ -25,6 +26,7 @@ public class ExposureNotificationsPackage implements ReactPackage {
         modules.add(new DebugMenuModule(reactContext));
         modules.add(new ExposureKeyModule(reactContext));
         modules.add(new DeviceInfoModule(reactContext));
+        modules.add(new ExposureHistoryModule(reactContext));
 
         return modules;
     }

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureHistoryModule.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureHistoryModule.java
@@ -1,0 +1,71 @@
+package covidsafepaths.bt.exposurenotifications;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
+import com.google.android.gms.nearby.exposurenotification.ExposureWindow;
+import com.google.android.gms.nearby.exposurenotification.ScanInstance;
+import com.google.gson.Gson;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import covidsafepaths.bt.exposurenotifications.dto.ExposureInformation;
+import covidsafepaths.bt.exposurenotifications.storage.ExposureNotificationSharedPreferences;
+
+@ReactModule(name = ExposureHistoryModule.MODULE_NAME)
+public class ExposureHistoryModule extends ReactContextBaseJavaModule {
+    public static final String MODULE_NAME = "ExposureHistoryModule";
+    public static final String TAG = "ExposureHistoryModule";
+
+    private ExposureNotificationSharedPreferences prefs;
+
+    public ExposureHistoryModule(@NonNull ReactApplicationContext reactContext) {
+        super(reactContext);
+        prefs = new ExposureNotificationSharedPreferences(reactContext);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return MODULE_NAME;
+    }
+
+    @ReactMethod
+    public void getCurrentExposures(final Callback callback) {
+        ExposureNotificationClientWrapper exposureNotificationsClient = ExposureNotificationClientWrapper.get(getReactApplicationContext());
+        exposureNotificationsClient.getExposureWindows()
+                .addOnSuccessListener(exposureWindows -> {
+                    List<ExposureInformation> exposures = new ArrayList<>();
+                    for (ExposureWindow window : exposureWindows) {
+                        long durationMinutes = 0;
+                        for (ScanInstance scan : window.getScanInstances()) {
+                            // We don't need a float type here, getSecondsSinceLastScan() is coarsened to 60-second increments
+                            durationMinutes += scan.getSecondsSinceLastScan() / 60;
+                        }
+                        ExposureInformation exposure = new ExposureInformation(
+                                UUID.randomUUID().toString(),
+                                window.getDateMillisSinceEpoch(),
+                                durationMinutes
+                        );
+                        exposures.add(exposure);
+                    }
+
+                    String json = new Gson().toJson(exposures);
+                    callback.invoke(json);
+                });
+    }
+
+    @ReactMethod
+    public void fetchLastDetectionDate(Promise promise) {
+        Long lastDetectionDate = prefs.getLastDetectionProcessDate();
+        // Convert to double, we cannot send longs through the RN bridge
+        promise.resolve(lastDetectionDate != null ? lastDetectionDate.doubleValue() : null);
+    }
+}

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/dto/ExposureInformation.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/dto/ExposureInformation.java
@@ -1,0 +1,13 @@
+package covidsafepaths.bt.exposurenotifications.dto;
+
+public class ExposureInformation {
+    private String id;
+    private long date;
+    private long duration; // Minutes
+
+    public ExposureInformation(String id, long date, long duration) {
+        this.id = id;
+        this.date = date;
+        this.duration = duration;
+    }
+}

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/ExposureNotificationSharedPreferences.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/ExposureNotificationSharedPreferences.java
@@ -29,89 +29,60 @@ import android.content.SharedPreferences;
  */
 public class ExposureNotificationSharedPreferences {
 
-  private static final String SHARED_PREFERENCES_FILE =
-      "ExposureNotificationSharedPreferences.SHARED_PREFERENCES_FILE";
+    private static final String SHARED_PREFERENCES_FILE =
+            "ExposureNotificationSharedPreferences.SHARED_PREFERENCES_FILE";
 
-  private static final String ONBOARDING_STATE_KEY = "ExposureNotificationSharedPreferences.ONBOARDING_STATE_KEY";
-  private static final String NETWORK_MODE_KEY = "ExposureNotificationSharedPreferences.NETWORK_MODE_KEY";
-  private static final String ATTENUATION_THRESHOLD_1_KEY = "ExposureNotificationSharedPreferences.ATTENUATION_THRESHOLD_1_KEY";
-  private static final String ATTENUATION_THRESHOLD_2_KEY = "ExposureNotificationSharedPreferences.ATTENUATION_THRESHOLD_2_KEY";
-  private static final String LAST_INDEX_FILE = "ExposureNotificationSharedPreferences.LAST_INDEX_FILE";
+    private static final String NETWORK_MODE_KEY = "ExposureNotificationSharedPreferences.NETWORK_MODE_KEY";
+    private static final String ATTENUATION_THRESHOLD_1_KEY = "ExposureNotificationSharedPreferences.ATTENUATION_THRESHOLD_1_KEY";
+    private static final String ATTENUATION_THRESHOLD_2_KEY = "ExposureNotificationSharedPreferences.ATTENUATION_THRESHOLD_2_KEY";
+    private static final String LAST_DETECTION_PROCESS_DATE = "ExposureNotificationSharedPreferences.LAST_DETECTION_PROCESS_DATE";
 
-  private final SharedPreferences sharedPreferences;
+    private final SharedPreferences sharedPreferences;
 
-  public enum OnboardingStatus {
-    UNKNOWN(0),
-    ONBOARDED(1),
-    SKIPPED(2);
-
-    private final int value;
-
-    OnboardingStatus(int value) {
-      this.value = value;
+    public enum NetworkMode {
+        // Uses live but test instances of the diagnosis key upload and download servers.
+        TEST,
+        // Uses local faked implementations of the diagnosis key uploads and downloads; no actual network calls.
+        FAKE
     }
 
-    public int value() {
-      return value;
+    public ExposureNotificationSharedPreferences(Context context) {
+        // These shared preferences are stored in {@value Context#MODE_PRIVATE} to be made only
+        // accessible by the app.
+        sharedPreferences = context.getSharedPreferences(SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
     }
 
-    public static OnboardingStatus fromValue(int value) {
-      switch (value) {
-        case 1:
-          return ONBOARDED;
-        case 2:
-          return SKIPPED;
-        default:
-          return UNKNOWN;
-      }
+    public NetworkMode getNetworkMode(NetworkMode defaultMode) {
+        return NetworkMode.valueOf(
+                sharedPreferences.getString(NETWORK_MODE_KEY, defaultMode.toString()));
     }
-  }
 
-  public enum NetworkMode {
-    // Uses live but test instances of the diagnosis key upload and download servers.
-    TEST,
-    // Uses local faked implementations of the diagnosis key uploads and downloads; no actual network calls.
-    FAKE
-  }
+    public void setNetworkMode(NetworkMode key) {
+        sharedPreferences.edit().putString(NETWORK_MODE_KEY, key.toString()).commit();
+    }
 
-  public ExposureNotificationSharedPreferences(Context context) {
-    // These shared preferences are stored in {@value Context#MODE_PRIVATE} to be made only
-    // accessible by the app.
-    sharedPreferences = context.getSharedPreferences(SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
-  }
+    public int getAttenuationThreshold1(int defaultThreshold) {
+        return sharedPreferences.getInt(ATTENUATION_THRESHOLD_1_KEY, defaultThreshold);
+    }
 
-  public void setOnboardedState(boolean onboardedState) {
-    sharedPreferences.edit().putInt(ONBOARDING_STATE_KEY,
-        onboardedState ? OnboardingStatus.ONBOARDED.value() : OnboardingStatus.SKIPPED.value())
-        .apply();
-  }
+    public void setAttenuationThreshold1(int threshold) {
+        sharedPreferences.edit().putInt(ATTENUATION_THRESHOLD_1_KEY, threshold).commit();
+    }
 
-  public OnboardingStatus getOnboardedState() {
-    return OnboardingStatus.fromValue(sharedPreferences.getInt(ONBOARDING_STATE_KEY, 0));
-  }
+    public int getAttenuationThreshold2(int defaultThreshold) {
+        return sharedPreferences.getInt(ATTENUATION_THRESHOLD_2_KEY, defaultThreshold);
+    }
 
-  public NetworkMode getNetworkMode(NetworkMode defaultMode) {
-    return NetworkMode.valueOf(
-        sharedPreferences.getString(NETWORK_MODE_KEY, defaultMode.toString()));
-  }
+    public void setAttenuationThreshold2(int threshold) {
+        sharedPreferences.edit().putInt(ATTENUATION_THRESHOLD_2_KEY, threshold).commit();
+    }
 
-  public void setNetworkMode(NetworkMode key) {
-    sharedPreferences.edit().putString(NETWORK_MODE_KEY, key.toString()).commit();
-  }
+    public Long getLastDetectionProcessDate() {
+        long date = sharedPreferences.getLong(LAST_DETECTION_PROCESS_DATE, -1);
+        return date != -1 ? date : null;
+    }
 
-  public int getAttenuationThreshold1(int defaultThreshold) {
-    return sharedPreferences.getInt(ATTENUATION_THRESHOLD_1_KEY, defaultThreshold);
-  }
-
-  public void setAttenuationThreshold1(int threshold) {
-    sharedPreferences.edit().putInt(ATTENUATION_THRESHOLD_1_KEY, threshold).commit();
-  }
-
-  public int getAttenuationThreshold2(int defaultThreshold) {
-    return sharedPreferences.getInt(ATTENUATION_THRESHOLD_2_KEY, defaultThreshold);
-  }
-
-  public void setAttenuationThreshold2(int threshold) {
-    sharedPreferences.edit().putInt(ATTENUATION_THRESHOLD_2_KEY, threshold).commit();
-  }
+    public void setLastDetectionProcessDate(Long date) {
+        sharedPreferences.edit().putLong(LAST_DETECTION_PROCESS_DATE, date).commit();
+    }
 }


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
Implement Android methods to get current exposures and last detection date.
No changes made on the UI / Javascript side.

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->
<img src="https://user-images.githubusercontent.com/9491378/89573772-82d84580-d801-11ea-8d1a-6fb26bb35841.png" width="360" height="720"> <img src="https://user-images.githubusercontent.com/9491378/89573768-7fdd5500-d801-11ea-8ba2-085468aa1301.png" width="360" height="720">

#### How to test:
If you got an exposure notification in the last 14 days you can go to:
- Exposure history (tab in the middle of the screen)
- EN Debug Menu > Show Exposures

If you go to `EN Debug Menu > Detect Exposures Now` it should update the header that says "Updated X minutes ago" (after an app restart)