### PR TITLE
Expose method to check if bluetooth is enabled

### DIFF
--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationsModule.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationsModule.java
@@ -1,6 +1,7 @@
 package covidsafepaths.bt.exposurenotifications;
 
 import android.app.Activity;
+import android.bluetooth.BluetoothAdapter;
 import android.util.Log;
 
 import com.facebook.react.bridge.Callback;
@@ -103,6 +104,11 @@ public class ExposureNotificationsModule extends ReactContextBaseJavaModule {
                                 callback.invoke(apiException.getStatus().toString());
                             }
                         });
+    }
+
+    @ReactMethod
+    public void isBluetoothEnabled(final Promise promise) {
+        promise.resolve(BluetoothAdapter.getDefaultAdapter().isEnabled());
     }
 
     /**

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationsModule.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationsModule.java
@@ -1,7 +1,6 @@
 package covidsafepaths.bt.exposurenotifications;
 
 import android.app.Activity;
-import android.bluetooth.BluetoothAdapter;
 import android.util.Log;
 
 import com.facebook.react.bridge.Callback;
@@ -104,11 +103,6 @@ public class ExposureNotificationsModule extends ReactContextBaseJavaModule {
                                 callback.invoke(apiException.getStatus().toString());
                             }
                         });
-    }
-
-    @ReactMethod
-    public void isBluetoothEnabled(final Promise promise) {
-        promise.resolve(BluetoothAdapter.getDefaultAdapter().isEnabled());
     }
 
     /**

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
@@ -1,7 +1,9 @@
 package covidsafepaths.bt.exposurenotifications;
 
 import android.bluetooth.BluetoothAdapter;
+import android.content.Context;
 import android.content.pm.PackageInfo;
+import android.location.LocationManager;
 
 import androidx.annotation.NonNull;
 
@@ -63,5 +65,15 @@ public class DeviceInfoModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void isBluetoothEnabled(final Promise promise) {
         promise.resolve(BluetoothAdapter.getDefaultAdapter().isEnabled());
+    }
+
+    @ReactMethod
+    public void isLocationEnabled(final Promise promise) {
+        final LocationManager manager = (LocationManager) getReactApplicationContext().getSystemService(Context.LOCATION_SERVICE);
+        if (manager != null) {
+            promise.resolve(manager.isProviderEnabled(LocationManager.GPS_PROVIDER));
+        } else {
+            promise.reject(new Exception("Location manager not found"));
+        }
     }
 }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
@@ -1,5 +1,6 @@
 package covidsafepaths.bt.exposurenotifications;
 
+import android.bluetooth.BluetoothAdapter;
 import android.content.pm.PackageInfo;
 
 import androidx.annotation.NonNull;
@@ -57,5 +58,10 @@ public class DeviceInfoModule extends ReactContextBaseJavaModule {
         return getReactApplicationContext()
                 .getPackageManager()
                 .getPackageInfo(getReactApplicationContext().getPackageName(), 0);
+    }
+
+    @ReactMethod
+    public void isBluetoothEnabled(final Promise promise) {
+        promise.resolve(BluetoothAdapter.getDefaultAdapter().isEnabled());
     }
 }

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -36,6 +36,10 @@ final class ExposureManager: NSObject {
   @objc var currentExposures: String {
     return Array(BTSecureStorage.shared.userState.exposures).jsonStringRepresentation()
   }
+
+  @objc var isBluetoothEnabled: Bool {
+    manager.exposureNotificationStatus != .bluetoothOff
+  }
   
   private var isDetectingExposures = false
   

--- a/ios/BT/bridge/DeviceInfoModule.m
+++ b/ios/BT/bridge/DeviceInfoModule.m
@@ -33,4 +33,15 @@ RCT_REMAP_METHOD(getVersion,
   resolve(version);
 }
 
+RCT_REMAP_METHOD(isBluetoothEnabled,
+                 isBluetoothEnabledWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  if ([[ExposureManager shared] isBluetoothEnabled]) {
+    resolve(@"true");
+  } else {
+    resolve(@"false");
+  }
+}
+
 @end

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -140,6 +140,10 @@ export const getVersion = async (): Promise<string> => {
   return deviceInfoModule.getVersion()
 }
 
+export const isBluetoothEnabled = async (): Promise<boolean> => {
+  return deviceInfoModule.isBluetoothEnabled()
+}
+
 // Debug Module
 const debugModule = NativeModules.DebugMenuModule
 


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
React Native needs a method to check if the bluetooth is enabled or not, this PR exposes its status.
Also expose a method to check if location is enabled on Android (GAEN requires both to work)