### PR TITLE
(iOS) Generate random padding data for each key submission 

### DIFF
--- a/ios/BT/API/Requests/DiagnosisKeyRequests.swift
+++ b/ios/BT/API/Requests/DiagnosisKeyRequests.swift
@@ -60,8 +60,18 @@ enum DiagnosisKeyListRequest: APIRequest {
         "appPackageName": Bundle.main.bundleIdentifier!,
         "verificationPayload": certificate,
         "hmackey": hmacKey,
-        "padding": String(decoding: Data(), as: UTF8.self)
+        "padding": Data.randomPadding(size: 1000)
       ]
     }
   }
+}
+
+private extension Data {
+
+  static func randomPadding(size: Int) -> String {
+    let bytes = [UInt32](repeating: 0, count: size).map { _ in arc4random() }
+    let data = Data(bytes: bytes, count: size)
+    return data.base64EncodedString()
+  }
+
 }

--- a/ios/BT/API/Requests/DiagnosisKeyRequests.swift
+++ b/ios/BT/API/Requests/DiagnosisKeyRequests.swift
@@ -53,16 +53,24 @@ enum DiagnosisKeyListRequest: APIRequest {
                let regions,
                let certificate,
                let hmacKey):
-               let keys = diagnosisKeys.map { try? $0.toJson() as? JSONObject }
+      let keys = diagnosisKeys.map { try? $0.toJson() as? JSONObject }
       return [
         "temporaryExposureKeys": keys,
         "regions": regions.map { $0 },
         "appPackageName": Bundle.main.bundleIdentifier!,
         "verificationPayload": certificate,
         "hmackey": hmacKey,
-        "padding": Data.randomPadding(size: 1000)
+        "padding": Data.randomPadding(size: .paddingSize())
       ]
     }
+  }
+}
+
+private extension Int {
+  /// Per https://google.github.io/exposure-notifications-server/server_functional_requirements.html
+  /// we add random data to obscure the size of the request (recommended size is ~1-2kb)
+  static func paddingSize() -> Int {
+    Int.random(in: 1000...2000)
   }
 }
 


### PR DESCRIPTION
### Why 
Per https://google.github.io/exposure-notifications-server/server_functional_requirements.html, the key submission request should contain random data to obscure the size of the request to network packet sniffers

### This Commit
This commit generates random data with each key submission request to be added to the payload