### PR TITLE
Expose environment variables to React Native

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -151,7 +151,7 @@ android {
         versionName "1.0.8"
 
         //Fix problem in bt where .env.bt is not recognized
-        resValue "string", "build_config_package", "org.pathcheck.covidsafepaths.bt"
+        resValue "string", "build_config_package", "org.pathcheck.covidsafepaths"
     }
     splits {
         abi {


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
`ReactNativeConfigModule` was trying to read a `BuildConfig` file using the wrong package name.
That's why env variables in React Native were empty.

#### Linked issues:
https://trello.com/c/6rbibcC1/302-env-variables-dont-populate-on-android