### PR TITLE
Remove unused exposure types

### DIFF
--- a/src/ExposureHistory/ExposureDetail.spec.tsx
+++ b/src/ExposureHistory/ExposureDetail.spec.tsx
@@ -19,7 +19,6 @@ describe("ExposureDetail", () => {
       const today = DateTimeUtils.beginningOfDay(Date.now())
 
       const exposureDatum = factories.exposureDatum.build({
-        kind: "Possible",
         date: today,
       })
       ;(useRoute as jest.Mock).mockReturnValue({
@@ -35,7 +34,6 @@ describe("ExposureDetail", () => {
     it("formats the timeframe correctly ", () => {
       const fourDaysAgo = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(4))
       const exposureDatum = factories.exposureDatum.build({
-        kind: "Possible",
         date: fourDaysAgo,
       })
 
@@ -52,7 +50,6 @@ describe("ExposureDetail", () => {
         DateTimeUtils.daysAgo(7),
       )
       const exposureDatum = factories.exposureDatum.build({
-        kind: "Possible",
         date: sevenDaysAgo,
       })
 

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -9,7 +9,7 @@ import { ExposureHistoryStackParamList, Screens } from "../navigation"
 import { GlobalText } from "../components/GlobalText"
 import { Button } from "../components/Button"
 import { useStatusBarEffect } from "../navigation"
-import { Possible, ExposureDatum, exposureWindowBucket } from "../exposure"
+import { ExposureDatum, exposureWindowBucket } from "../exposure"
 
 import { Colors, Iconography, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
@@ -34,7 +34,7 @@ const ExposureDetail: FunctionComponent = () => {
   const exposureWindowBucketInWords = (
     exposureDatum: ExposureDatum,
   ): string => {
-    const bucket = exposureWindowBucket(exposureDatum as Possible)
+    const bucket = exposureWindowBucket(exposureDatum)
     switch (bucket) {
       case "TodayToThreeDaysAgo": {
         return t("exposure_history.exposure_window.today_to_three_days_ago")

--- a/src/ExposureHistory/History/ExposureList.spec.tsx
+++ b/src/ExposureHistory/History/ExposureList.spec.tsx
@@ -20,17 +20,14 @@ describe("ExposureList", () => {
       )
 
       const datum1 = factories.exposureDatum.build({
-        kind: "Possible",
         date: twoDaysAgo,
       })
 
       const datum2 = factories.exposureDatum.build({
-        kind: "Possible",
         date: fiveDaysAgo,
       })
 
       const datum3 = factories.exposureDatum.build({
-        kind: "Possible",
         date: sevenDaysAgo,
       })
 

--- a/src/ExposureHistory/History/ExposureListItem.tsx
+++ b/src/ExposureHistory/History/ExposureListItem.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 
 import { GlobalText } from "../../components/GlobalText"
-import { Possible, ExposureDatum, exposureWindowBucket } from "../../exposure"
+import { ExposureDatum, exposureWindowBucket } from "../../exposure"
 
 import { Icons } from "../../assets"
 import { Screens } from "../../navigation"
@@ -30,7 +30,7 @@ const ExposureListItem: FunctionComponent<ExposureListItemProps> = ({
   const exposureWindowBucketInWords = (
     exposureDatum: ExposureDatum,
   ): string => {
-    const bucket = exposureWindowBucket(exposureDatum as Possible)
+    const bucket = exposureWindowBucket(exposureDatum)
     switch (bucket) {
       case "TodayToThreeDaysAgo": {
         return t("exposure_history.exposure_window.today_to_three_days_ago")

--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -28,7 +28,6 @@ describe("History", () => {
     it("shows a list of the exposures", async () => {
       const twoDaysAgo = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(2))
       const datum1 = factories.exposureDatum.build({
-        kind: "Possible",
         date: twoDaysAgo,
       })
 

--- a/src/exposure.spec.ts
+++ b/src/exposure.spec.ts
@@ -1,7 +1,7 @@
 import { factories } from "./factories"
 import { DateTimeUtils } from "./utils"
 
-import { exposureWindowBucket, Possible } from "./exposure"
+import { exposureWindowBucket } from "./exposure"
 
 describe("exposureWindow", () => {
   describe("when the exposure date is one day ago", () => {
@@ -9,18 +9,14 @@ describe("exposureWindow", () => {
       const today = Date.now()
       const threeDaysAgo = DateTimeUtils.daysAgo(3)
       const exposureToday = factories.exposureDatum.build({
-        kind: "Possible",
         date: today,
       })
       const exposureThreeDaysAgo = factories.exposureDatum.build({
-        kind: "Possible",
         date: threeDaysAgo,
       })
 
-      const resultToday = exposureWindowBucket(exposureToday as Possible)
-      const resultThreeDaysAgo = exposureWindowBucket(
-        exposureThreeDaysAgo as Possible,
-      )
+      const resultToday = exposureWindowBucket(exposureToday)
+      const resultThreeDaysAgo = exposureWindowBucket(exposureThreeDaysAgo)
 
       expect(resultToday).toEqual("TodayToThreeDaysAgo")
       expect(resultThreeDaysAgo).toEqual("TodayToThreeDaysAgo")
@@ -31,13 +27,10 @@ describe("exposureWindow", () => {
     it("returns a bucket of 4 to 6 days ago", () => {
       const fiveDaysAgo = DateTimeUtils.daysAgo(5)
       const exposureFiveDaysAgo = factories.exposureDatum.build({
-        kind: "Possible",
         date: fiveDaysAgo,
       })
 
-      const resultFiveDaysAgo = exposureWindowBucket(
-        exposureFiveDaysAgo as Possible,
-      )
+      const resultFiveDaysAgo = exposureWindowBucket(exposureFiveDaysAgo)
 
       expect(resultFiveDaysAgo).toEqual("FourToSixDaysAgo")
     })
@@ -47,13 +40,10 @@ describe("exposureWindow", () => {
     it("returns a bucket of 7 to 14 days ago", () => {
       const eightDaysAgo = DateTimeUtils.daysAgo(8)
       const exposureEightDaysAgo = factories.exposureDatum.build({
-        kind: "Possible",
         date: eightDaysAgo,
       })
 
-      const resultEightDaysAgo = exposureWindowBucket(
-        exposureEightDaysAgo as Possible,
-      )
+      const resultEightDaysAgo = exposureWindowBucket(exposureEightDaysAgo)
 
       expect(resultEightDaysAgo).toEqual("SevenToFourteenDaysAgo")
     })

--- a/src/exposure.ts
+++ b/src/exposure.ts
@@ -2,23 +2,10 @@ import { DateTimeUtils } from "./utils"
 
 export type Posix = number
 
-export interface Possible {
-  kind: "Possible"
+export interface ExposureDatum {
   date: Posix
   duration: number
 }
-
-export interface NoKnown {
-  kind: "NoKnown"
-  date: Posix
-}
-
-export interface NoData {
-  kind: "NoData"
-  date: Posix
-}
-
-export type ExposureDatum = Possible | NoKnown | NoData
 
 export type ExposureInfo = ExposureDatum[]
 
@@ -28,7 +15,7 @@ export type ExposureWindowBucket =
   | "SevenToFourteenDaysAgo"
 
 export const exposureWindowBucket = (
-  exposureDatum: Possible,
+  exposureDatum: ExposureDatum,
 ): ExposureWindowBucket => {
   const date = exposureDatum.date
   const threeDaysAgo = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(3))

--- a/src/factories/exposureDatum.tsx
+++ b/src/factories/exposureDatum.tsx
@@ -7,7 +7,6 @@ import { ExposureDatum } from "../exposure"
 export default Factory.define<ExposureDatum>(() => {
   const defaultDate = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(2))
   return {
-    kind: "Possible",
     date: defaultDate,
     duration: 300000,
     totalRiskScore: 4,

--- a/src/gaen/dataConverter.spec.ts
+++ b/src/gaen/dataConverter.spec.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs"
 
 import { DateTimeUtils } from "../utils"
-import { Possible } from "../exposure"
+import { ExposureDatum } from "../exposure"
 import { toExposureInfo, RawExposure } from "./dataConverters"
 
 describe("toExposureInfo", () => {
@@ -27,8 +27,7 @@ describe("toExposureInfo", () => {
           duration,
         },
       ]
-      const expected: Possible = {
-        kind: "Possible",
+      const expected: ExposureDatum = {
         date: DateTimeUtils.beginningOfDay(twoDaysAgo),
         duration: duration,
       }
@@ -64,8 +63,7 @@ describe("toExposureInfo", () => {
           duration: duration3,
         },
       ]
-      const expected: Possible = {
-        kind: "Possible",
+      const expected: ExposureDatum = {
         date: DateTimeUtils.beginningOfDay(today),
         duration: duration1 + duration2 + duration3,
       }

--- a/src/gaen/dataConverters.ts
+++ b/src/gaen/dataConverters.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs"
 
-import { Possible, ExposureDatum } from "../exposure"
+import { ExposureDatum } from "../exposure"
 
 type UUID = string
 type Posix = number
@@ -14,33 +14,37 @@ export interface RawExposure {
 export const toExposureInfo = (
   rawExposures: RawExposure[],
 ): ExposureDatum[] => {
-  const groupedExposures = rawExposures.map(toPossible).reduce(groupByDate, {})
+  const groupedExposures = rawExposures
+    .map(toExposureDatum)
+    .reduce(groupByDate, {})
   return Object.values(groupedExposures).sort((a, b) => b.date - a.date)
 }
 
-const toPossible = (r: RawExposure): Possible => {
+const toExposureDatum = (r: RawExposure): ExposureDatum => {
   const beginningOfDay = (date: Posix) => dayjs(date).startOf("day")
   return {
-    kind: "Possible",
     date: beginningOfDay(r.date).valueOf(),
     duration: r.duration,
   }
 }
 
-const combinePossibles = (a: Possible, b: Possible): Possible => {
+const combineDatum = (
+  firstDatum: ExposureDatum,
+  secondDatum: ExposureDatum,
+): ExposureDatum => {
   return {
-    ...a,
-    duration: a.duration + b.duration,
+    ...firstDatum,
+    duration: firstDatum.duration + secondDatum.duration,
   }
 }
 
 const groupByDate = (
-  groupedExposures: Record<Posix, Possible>,
-  exposure: Possible,
-): Record<Posix, Possible> => {
+  groupedExposures: Record<Posix, ExposureDatum>,
+  exposure: ExposureDatum,
+): Record<Posix, ExposureDatum> => {
   const date = exposure.date
   if (groupedExposures[date]) {
-    groupedExposures[date] = combinePossibles(groupedExposures[date], exposure)
+    groupedExposures[date] = combineDatum(groupedExposures[date], exposure)
   } else {
     groupedExposures[date] = exposure
   }


### PR DESCRIPTION
Why:
Previously we had the need to build an exposure history that had needed
to represent days without exposures. Since we are now using a list view
to represent a users exposure history these data types are no longer
needed.

This commit:
Refactors the union type of an ExposureDatum to be an interface.