### PR TITLE
Add local push to simulate exposure EN debug button.

### DIFF
--- a/ios/BT/Extensions/Foundation/String+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/String+Extensions.swift
@@ -33,6 +33,7 @@ extension String {
   static let bluetoothNotificationIdentifier = "bluetooth-off"
   static let exposureDetectionErrorNotificationTitle = "Error Detecting Exposures"
   static let exposureDetectionErrorNotificationBody = "An error occurred while attempting to detect exposures."
+  static let newExposureNotificationTitle = "Possible COVID-19 Exposure"
   static let newExposureNotificationBody = "Someone you were near recently has been diagnosed with COVID-19. Tap for more details."
   static let exposureDetectionErrorNotificationIdentifier = "expososure-notification-error"
 

--- a/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
+++ b/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
@@ -42,6 +42,18 @@ extension ExposureManager {
                               totalRiskScore: .random(in: 1...8),
                               transmissionRiskLevel: .random(in: 0...7))
       BTSecureStorage.shared.storeExposures([exposure])
+      let content = UNMutableNotificationContent()
+      content.title = String.newExposureNotificationTitle.localized
+      content.body = String.newExposureNotificationBody.localized
+      content.sound = .default
+      let request = UNNotificationRequest(identifier: "identifier", content: content, trigger: nil)
+      UNUserNotificationCenter.current().add(request) { error in
+        DispatchQueue.main.async {
+          if let error = error {
+            print("Error showing error user notification: \(error)")
+          }
+        }
+      }
       resolve("Exposures: \(BTSecureStorage.shared.userState.exposures)")
     case .fetchExposures:
       resolve(currentExposures)

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -98,16 +98,16 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
         <ScrollView>
           <View style={style.section}>
             <DebugMenuListItem
+              label="Simulate Exposure"
+              onPress={handleOnPressSimulationButton(
+                NativeModule.simulateExposure,
+              )}
+            />
+            <DebugMenuListItem
               label="Show Last Processed File Path"
               onPress={handleOnPressSimulationButton(
                 NativeModule.showLastProcessedFilePath,
               )}
-            />
-            <DebugMenuListItem
-              label="Show Exposures"
-              onPress={() => {
-                navigation.navigate(Screens.ExposureListDebugScreen)
-              }}
             />
             <DebugMenuListItem
               label="Show Local Diagnosis Keys"
@@ -131,10 +131,10 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
           {__DEV__ ? (
             <View style={style.section}>
               <DebugMenuListItem
-                label="Simulate Exposure"
-                onPress={handleOnPressSimulationButton(
-                  NativeModule.simulateExposure,
-                )}
+                label="Show Exposures"
+                onPress={() => {
+                  navigation.navigate(Screens.ExposureListDebugScreen)
+                }}
               />
               <DebugMenuListItem
                 label="Toggle Exposure Notifications"


### PR DESCRIPTION
### Why
We need a way to simulate an exposure notification "on demand" and demo the corresponding Exposure Summary and Exposure Details screens to guide discussion about the level of configuration jurisdictions would like (per https://trello.com/c/hg1M9jhp/311-feature-flag-to-demo-gaen-exposure-notifications)

### This Commit
This commit updates the "simulate exposure" debug button to show a push as it would appear to a user when receiving a real exposure notification, and ensures that the button is visible in the builds that will go to testflight