### PR TITLE
(Android) Implement remaning debug methods

### DIFF
--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/DebugMenuModule.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/DebugMenuModule.java
@@ -13,8 +13,6 @@ import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationStatusCodes;
 import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey;
 
-import org.pathcheck.covidsafepaths.BuildConfig;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +20,6 @@ import javax.annotation.Nonnull;
 
 import covidsafepaths.bt.exposurenotifications.dto.RNDiagnosisKey;
 import covidsafepaths.bt.exposurenotifications.nearby.ProvideDiagnosisKeysWorker;
-import covidsafepaths.bt.exposurenotifications.storage.ExposureNotificationSharedPreferences;
 import covidsafepaths.bt.exposurenotifications.storage.RealmSecureStorageBte;
 import covidsafepaths.bt.exposurenotifications.utils.CallbackMessages;
 import covidsafepaths.bt.exposurenotifications.utils.RequestCodes;
@@ -32,26 +29,14 @@ import covidsafepaths.bt.exposurenotifications.utils.Util;
 public class DebugMenuModule extends ReactContextBaseJavaModule {
     static final String MODULE_NAME = "DebugMenuModule";
 
-    private ExposureNotificationSharedPreferences prefs;
-
     public DebugMenuModule(ReactApplicationContext context) {
         super(context);
-        prefs = new ExposureNotificationSharedPreferences(context);
     }
 
     @Override
     public @Nonnull
     String getName() {
         return MODULE_NAME;
-    }
-
-    @ReactMethod
-    public void fetchDebugLog(Promise promise) {
-        promise.resolve("AppId: " + BuildConfig.ANDROID_APPLICATION_ID +
-                "\nVersion: " + BuildConfig.VERSION_NAME +
-                "\nVersionName: " + BuildConfig.VERSION_CODE +
-                "\nLastProcessedFileName: " + RealmSecureStorageBte.INSTANCE.getLastProcessedKeyZipFileName() +
-                "\nLastDetectionProcessDate: " + prefs.getLastDetectionProcessDate());
     }
 
     @ReactMethod

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureHistoryModule.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureHistoryModule.java
@@ -14,9 +14,8 @@ import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
-import covidsafepaths.bt.exposurenotifications.dto.ExposureInformation;
+import covidsafepaths.bt.exposurenotifications.dto.RNExposureInformation;
 import covidsafepaths.bt.exposurenotifications.storage.ExposureNotificationSharedPreferences;
 
 @ReactModule(name = ExposureHistoryModule.MODULE_NAME)
@@ -42,15 +41,14 @@ public class ExposureHistoryModule extends ReactContextBaseJavaModule {
         ExposureNotificationClientWrapper exposureNotificationsClient = ExposureNotificationClientWrapper.get(getReactApplicationContext());
         exposureNotificationsClient.getExposureWindows()
                 .addOnSuccessListener(exposureWindows -> {
-                    List<ExposureInformation> exposures = new ArrayList<>();
+                    List<RNExposureInformation> exposures = new ArrayList<>();
                     for (ExposureWindow window : exposureWindows) {
                         long durationMinutes = 0;
                         for (ScanInstance scan : window.getScanInstances()) {
                             // We don't need a float type here, getSecondsSinceLastScan() is coarsened to 60-second increments
                             durationMinutes += scan.getSecondsSinceLastScan() / 60;
                         }
-                        ExposureInformation exposure = new ExposureInformation(
-                                UUID.randomUUID().toString(),
+                        RNExposureInformation exposure = new RNExposureInformation(
                                 window.getDateMillisSinceEpoch(),
                                 durationMinutes
                         );

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationClientWrapper.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationClientWrapper.java
@@ -62,10 +62,7 @@ public class ExposureNotificationClientWrapper {
 
                     ApiException apiException = (ApiException) exception;
                     if (apiException.getStatusCode() == ExposureNotificationStatusCodes.RESOLUTION_REQUIRED) {
-                        Activity activity = context.getCurrentActivity();
-                        if (activity != null) {
-                            showPermissionDialog(activity, apiException);
-                        }
+                        showPermissionDialog(context, apiException, RequestCodes.REQUEST_CODE_START_EXPOSURE_NOTIFICATION);
                     }
                 })
                 .addOnCanceledListener(() -> {
@@ -73,11 +70,14 @@ public class ExposureNotificationClientWrapper {
                 });
     }
 
-    public void showPermissionDialog(Activity activity, ApiException apiException) {
+    public void showPermissionDialog(ReactContext reactContext, ApiException apiException, int requestCode) {
         try {
-            apiException
-                    .getStatus()
-                    .startResolutionForResult(activity, RequestCodes.REQUEST_CODE_START_EXPOSURE_NOTIFICATION);
+            Activity activity = reactContext.getCurrentActivity();
+            if (activity != null) {
+                apiException
+                        .getStatus()
+                        .startResolutionForResult(activity, requestCode);
+            }
         } catch (IntentSender.SendIntentException e) {
 
         }

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationsModule.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationsModule.java
@@ -1,6 +1,5 @@
 package covidsafepaths.bt.exposurenotifications;
 
-import android.app.Activity;
 import android.util.Log;
 
 import com.facebook.react.bridge.Callback;
@@ -27,6 +26,7 @@ import covidsafepaths.bt.exposurenotifications.nearby.ExposureConfigurations;
 import covidsafepaths.bt.exposurenotifications.nearby.ProvideDiagnosisKeysWorker;
 import covidsafepaths.bt.exposurenotifications.notify.ShareDiagnosisManager;
 import covidsafepaths.bt.exposurenotifications.utils.CallbackMessages;
+import covidsafepaths.bt.exposurenotifications.utils.RequestCodes;
 import covidsafepaths.bt.exposurenotifications.utils.Util;
 
 import static covidsafepaths.bt.exposurenotifications.ExposureNotificationsModule.MODULE_NAME;
@@ -61,8 +61,8 @@ public class ExposureNotificationsModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void requestExposureNotificationAuthorization(final Callback callback) {
         ReactContext reactContext = getReactApplicationContext();
-        ExposureNotificationClientWrapper exposureNotificationClient = ExposureNotificationClientWrapper.get(reactContext);
-        exposureNotificationClient.start(reactContext)
+        ExposureNotificationClientWrapper client = ExposureNotificationClientWrapper.get(reactContext);
+        client.start(reactContext)
                 .addOnSuccessListener(unused -> {
                     callback.invoke(CallbackMessages.GENERIC_SUCCESS);
                 })
@@ -74,10 +74,7 @@ public class ExposureNotificationsModule extends ReactContextBaseJavaModule {
                     ApiException apiException = (ApiException) exception;
                     if (apiException.getStatusCode() == ExposureNotificationStatusCodes.RESOLUTION_REQUIRED) {
                         callback.invoke(CallbackMessages.GENERIC_SUCCESS);
-                        Activity activity = getCurrentActivity();
-                        if (activity != null) {
-                            exposureNotificationClient.showPermissionDialog(activity, apiException);
-                        }
+                        client.showPermissionDialog(getReactApplicationContext(), apiException, RequestCodes.REQUEST_CODE_START_EXPOSURE_NOTIFICATION);
                     } else {
                         callback.invoke(apiException.getStatus().toString());
                     }

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/dto/RNDiagnosisKey.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/dto/RNDiagnosisKey.java
@@ -1,0 +1,13 @@
+package covidsafepaths.bt.exposurenotifications.dto;
+
+import java.util.UUID;
+
+public class RNDiagnosisKey {
+    private String id;
+    private long rollingStartNumber;
+
+    public RNDiagnosisKey(long rollingStartNumber) {
+        this.id = UUID.randomUUID().toString();
+        this.rollingStartNumber = rollingStartNumber;
+    }
+}

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/dto/RNExposureInformation.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/dto/RNExposureInformation.java
@@ -1,12 +1,14 @@
 package covidsafepaths.bt.exposurenotifications.dto;
 
-public class ExposureInformation {
+import java.util.UUID;
+
+public class RNExposureInformation {
     private String id;
     private long date;
     private long duration; // Minutes
 
-    public ExposureInformation(String id, long date, long duration) {
-        this.id = id;
+    public RNExposureInformation(long date, long duration) {
+        this.id = UUID.randomUUID().toString();
         this.date = date;
         this.duration = duration;
     }

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/RealmSecureStorageBte.kt
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/RealmSecureStorageBte.kt
@@ -149,6 +149,15 @@ object RealmSecureStorageBte {
         return somethingAdded
     }
 
+    fun resetExposures() {
+        getRealmInstance().use {
+            it.executeTransaction { db ->
+                db.delete(ExposureEntity::class.java)
+                db.delete(KeyValues::class.java)
+            }
+        }
+    }
+
     @VisibleForTesting
     fun getRealmInstance(): Realm {
         return Realm.getInstance(realmConfig)

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/utils/RequestCodes.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/utils/RequestCodes.java
@@ -5,6 +5,7 @@ public final class RequestCodes {
     public static final int REQUEST_CODE_START_EXPOSURE_NOTIFICATION = 1111;
     public static final int REQUEST_CODE_GET_TEMP_EXPOSURE_KEY_HISTORY = 2222;
     public static final int REQUEST_CODE_UPLOAD_KEYS = 3333;
+    public static final int REQUEST_GET_DIAGNOSIS_KEYS = 4444;
 
     private RequestCodes() {
     }

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/utils/Util.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/utils/Util.java
@@ -4,13 +4,11 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
-import com.facebook.react.bridge.ReadableNativeArray;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -19,8 +17,6 @@ import org.json.JSONObject;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
-
-import covidsafepaths.bt.exposurenotifications.ExposureKey;
 
 public class Util {
     /**
@@ -54,23 +50,17 @@ public class Util {
         return new Random().nextInt((max - min) + 1) + min;
     }
 
-
-    public static String toJsonString(ExposureKey key) {
-        Gson gson = new Gson();
-        return gson.toJson(key);
-    }
-
-    public static WritableArray getKeysAsWritableArray(List<ExposureKey> keys){
+    public static WritableArray convertListToWritableArray(List<?> list){
         WritableArray array = new WritableNativeArray();
-        for (ExposureKey key : keys) {
-            WritableMap productMap = null;
+        for (Object value : list) {
+            WritableMap map = null;
             try {
-                productMap = convertJsonToMap(new
-                        JSONObject(toJsonString(key)));
+                Gson gson = new Gson();
+                map = convertJsonToMap(new JSONObject(gson.toJson(value)));
             } catch (JSONException e) {
                 e.printStackTrace();
             }
-            array.pushMap(productMap);
+            array.pushMap(map);
         }
         return array;
     }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/MainActivity.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/MainActivity.java
@@ -183,7 +183,7 @@ public class MainActivity extends ReactActivity {
                                   transmissionRisk));
                 }
 
-                getExposureKeysPromise.resolve(Util.getKeysAsWritableArray(exposureKeys));
+                getExposureKeysPromise.resolve(Util.convertListToWritableArray(exposureKeys));
               }
 
               @Override


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
Implement functionality for these debug buttons:
- Submit debug log
- Show local diagnosis keys
- Force App Crash
- Reset Exposures

These buttons cannot be implemented on Android because we are don't store Exposures in our database (we always take that information from the API)
- Simulate Exposure
- Simulate Exposure Detection Error

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://trello.com/c/ij8EtDKQ/305-add-remaining-debug-functionality

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
- Submit Debug Log -> Should send AppId, Version, VersionName, LastProcessedFileName & LastDetectionProcessDate
- Show local diagnosis keys -> Displays your diagnosis keys in a new screen
- Force App Crash -> Forces a crash in the app
- Reset Exposures -> Wipes the database, you should see the exposure notification again if you tap on "Detect exposures now"