### PR TITLE
Make number pad dismissible for Verify Code Screen

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -135,15 +135,16 @@ const CodeInputForm: FunctionComponent = () => {
 
           <View>
             <TextInput
-              testID={"code-input"}
+              testID="code-input"
               value={code}
-              placeholder={"00000000"}
+              placeholder="00000000"
               placeholderTextColor={Colors.placeholderTextColor}
               maxLength={codeLength}
               style={style.codeInput}
-              keyboardType={"number-pad"}
-              returnKeyType={"done"}
+              keyboardType="number-pad"
+              returnKeyType="done"
               onChangeText={handleOnChangeText}
+              onSubmitEditing={Keyboard.dismiss}
               blurOnSubmit={false}
             />
           </View>


### PR DESCRIPTION
#### Description:

Why?
------
Cancel button is hidden when the keyboard opens and the number pad is not dismissible. The user is stuck without a way to cancel out of this screen without a valid code. Instead of adding a SafeAreaView here, we decided it was okay that the cancel is hidden while a user inputs a code, so long as the user also has the ability to dismiss the keyboard and cancel at any point.

This Commit
------
Add an onSubmitEditing that dismisses the number pad when pressing done.

#### Linked issues:

[Trello](https://trello.com/c/97krmfzq/300-button-regression-submit-verification-code-small-format-screens)

#### How to test:

Navigate to More bottom tab.
Click Report Positive Test Result.
Click Start.
If running in simulator, in CodeInputScreen.tsx, set isEnabled to true.
When entering a code, make sure you can dismiss the keyboard.

