### PR TITLE
Fix hmac calculations

### DIFF
--- a/src/AffectedUserFlow/hmac.spec.ts
+++ b/src/AffectedUserFlow/hmac.spec.ts
@@ -82,5 +82,27 @@ describe("calculateHmac", () => {
     expect(convertArrayBufferToBase64Spy).toHaveBeenCalledWith(signatureBuffer)
     expect(convertArrayBufferToBase64Spy).toHaveBeenCalledWith(randomBytes)
     expect(hmacKey).toEqual([base64Signature, base64Key])
+    jest.resetAllMocks()
+  })
+
+  it("does not include the risk if all keys have risk of 0", async () => {
+    const [convertUtf8ToArrayBufferSpy, ,] = mockConvertUtf8ToArray()
+    mockHmac256()
+    const [, , , base64TekKey] = mockConvertArrayBufferToBase64()
+    const key = "key"
+    const rollingPeriod = 1
+    const rollingStartNumber = 1
+    const transmissionRisk = 0
+    const exposureKey = {
+      key,
+      rollingPeriod,
+      rollingStartNumber,
+      transmissionRisk,
+    }
+    const serializedKey = `${base64TekKey}.${rollingPeriod}.${rollingStartNumber}`
+    await calculateHmac([exposureKey])
+
+    expect(convertUtf8ToArrayBufferSpy).toHaveBeenCalledWith(serializedKey)
+    jest.resetAllMocks()
   })
 })

--- a/src/AffectedUserFlow/hmac.spec.ts
+++ b/src/AffectedUserFlow/hmac.spec.ts
@@ -35,12 +35,19 @@ describe("calculateHmac", () => {
       RNSimpleCrypto.utils,
       "convertArrayBufferToBase64",
     )
+    const base64TekKey = "base64TekKey"
+    convertArrayBufferToBase64Spy.mockReturnValueOnce(base64TekKey)
     const base64Signature = "base64Signature"
     convertArrayBufferToBase64Spy.mockReturnValueOnce(base64Signature)
     const base64Key = "base64Key"
     convertArrayBufferToBase64Spy.mockReturnValueOnce(base64Key)
 
-    return [convertArrayBufferToBase64Spy, base64Signature, base64Key]
+    return [
+      convertArrayBufferToBase64Spy,
+      base64Signature,
+      base64Key,
+      base64TekKey,
+    ]
   }
 
   it("serializes and encrypts the exposure keys into a payload", async () => {
@@ -54,6 +61,7 @@ describe("calculateHmac", () => {
       convertArrayBufferToBase64Spy,
       base64Signature,
       base64Key,
+      base64TekKey,
     ] = mockConvertArrayBufferToBase64()
     const key = "key"
     const rollingPeriod = 1
@@ -65,7 +73,7 @@ describe("calculateHmac", () => {
       rollingStartNumber,
       transmissionRisk,
     }
-    const serializedKey = `${key}.${rollingPeriod}.${rollingStartNumber}.${transmissionRisk}`
+    const serializedKey = `${base64TekKey}.${rollingPeriod}.${rollingStartNumber}.${transmissionRisk}`
 
     const hmacKey = await calculateHmac([exposureKey])
 

--- a/src/AffectedUserFlow/hmac.ts
+++ b/src/AffectedUserFlow/hmac.ts
@@ -34,15 +34,18 @@ export const calculateHmac = async (
 }
 
 const serializeKeys = (exposureKeys: ExposureKey[]) => {
+  const serializer = allRisksAreZero(exposureKeys)
+    ? serializeExposureKeyWithoutRisk
+    : serializeFullExposureKey
   return exposureKeys
-    .map(serializeExposureKey)
+    .map(serializer)
     .sort((left: string, right: string) => {
       return left.localeCompare(right, "en", { sensitivity: "base" })
     })
     .join(",")
 }
 
-const serializeExposureKey = ({
+const serializeFullExposureKey = ({
   key,
   rollingPeriod,
   rollingStartNumber,
@@ -54,4 +57,20 @@ const serializeExposureKey = ({
     rollingStartNumber,
     transmissionRisk,
   ].join(".")
+}
+
+const serializeExposureKeyWithoutRisk = ({
+  key,
+  rollingPeriod,
+  rollingStartNumber,
+}: ExposureKey): string => {
+  return [utf8ToBase64String(key), rollingPeriod, rollingStartNumber].join(".")
+}
+
+const allRisksAreZero = (exposureKeys: ExposureKey[]): boolean => {
+  return (
+    exposureKeys.filter(({ transmissionRisk }) => {
+      return transmissionRisk > 0
+    }).length === 0
+  )
 }

--- a/src/AffectedUserFlow/hmac.ts
+++ b/src/AffectedUserFlow/hmac.ts
@@ -2,6 +2,11 @@ import RNSimpleCrypto from "react-native-simple-crypto"
 
 import { ExposureKey } from "../exposureKey"
 
+const utf8ToBase64String = (input: string): string => {
+  const utf8AsArrayBuffer = RNSimpleCrypto.utils.convertUtf8ToArrayBuffer(input)
+  return RNSimpleCrypto.utils.convertArrayBufferToBase64(utf8AsArrayBuffer)
+}
+
 export const generateKey = async (): Promise<ArrayBuffer> => {
   return await RNSimpleCrypto.utils.randomBytes(32)
 }
@@ -29,7 +34,12 @@ export const calculateHmac = async (
 }
 
 const serializeKeys = (exposureKeys: ExposureKey[]) => {
-  return exposureKeys.map(serializeExposureKey).join(",")
+  return exposureKeys
+    .map(serializeExposureKey)
+    .sort((left: string, right: string) => {
+      return left.localeCompare(right, "en", { sensitivity: "base" })
+    })
+    .join(",")
 }
 
 const serializeExposureKey = ({
@@ -38,5 +48,10 @@ const serializeExposureKey = ({
   rollingStartNumber,
   transmissionRisk,
 }: ExposureKey): string => {
-  return [key, rollingPeriod, rollingStartNumber, transmissionRisk].join(".")
+  return [
+    utf8ToBase64String(key),
+    rollingPeriod,
+    rollingStartNumber,
+    transmissionRisk,
+  ].join(".")
 }


### PR DESCRIPTION
Why:
----
A couple of things jumped up while we were reviewing the docs:
1. We need to encode TEKeys to base64 and sort them prior to encryption 
The [specification] on the HMAC Calculation says:

```
Each key segment contains the following data, period separated:
base64(TEK), rolling period start, rolling period count, transmission risk.

The key segments are sorted lexicographically based on the base64 encoding.
```

2. We need to skip the transmission risk when serializing TEK's if all risks are 0
The hmac calculation includes the transmission risk on each one of the instances. According to the [implementation], there is an alternative HMAC to be computed if all transmission risks are 0.

We are still seeing errors when submitting to the exposures server but these two fixes are necessary.

This PR:
----
- Encode to base 64 the TEKeys before serializing them
- Sort lexicographically the serialized TEK prior to concatenate them and encrypt them
- Avoid including the transmission risk on the serialization of the exposure key if all transmission risks are 0.

Reviewers:
----
This is an ongoing effort to get the submission of the JWT to the exposures server. Still getting the same error but these two fixes are expressed one on the [specification] and the [implementation] and the second one on the [implementation] only

[specification]: https://developers.google.com/android/exposure-notifications/verification-system#hmac-calc
[implementation]: https://github.com/google/exposure-notifications-server/blob/cff0326dca848b0ccbcbd71ccb74ebf3580583b4/pkg/verification/utils.go#L75