### PR TITLE
(Android) Add yarn command to assemble debug builds

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -24,7 +24,8 @@ platform :android do
   desc "Build a Debug AAB"
   lane :debug_bt do
     gradle(
-      task: "clean assembleDebug",
+      task: "assemble",
+      build_type: "debug",
       print_command: false,
     )
   end
@@ -80,7 +81,7 @@ platform :android do
       notify_testers: false,
       destinations: "Collaborators",
       release_notes: changeLogs,
-      file: "app/build/outputs/apk/release/app-" + options[:apkSuffix] + "-release.apk"
+      file: options[:apkPath]
     )
   end
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "i18n:pull": "./src/locales/pull.sh",
     "i18n:push": "./src/locales/push.sh",
     "test": "jest --config=./jest/config.js",
-    "test:watch": "jest --config=./jest/config.js --watch"
+    "test:watch": "jest --config=./jest/config.js --watch",
+    "assemble-android-debug": "react-native bundle --platform android --dev true --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res && cd android && ./gradlew assembleDebug"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
In order to distribute debug builds to AppCenter:
- Pass APK path to lane `android_alpha_apk`
- Add command `yarn assemble-android-debug` to build a debug APK. We cannot use `assembleDebug` here because it doesn't include all the resources that React Native needs.