### PR TITLE
(Android) Allow to build debug if release key passwords are not present

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -171,9 +171,9 @@ android {
         release {
             storeFile file('keystore.jks')
             if (file("./keystore.jks").exists()) {
-                keyAlias project.property("android.injected.signing.key.alias")
-                keyPassword project.property("android.injected.signing.key.password")
-                storePassword project.property("android.injected.signing.store.password")
+                keyAlias project.hasProperty('android.injected.signing.key.alias') ? project.property("android.injected.signing.key.alias") : ''
+                keyPassword project.hasProperty("android.injected.signing.key.password") ? project.property("android.injected.signing.key.password") : ''
+                storePassword project.hasProperty("android.injected.signing.store.password") ? project.hasProperty("android.injected.signing.store.password") : ''
                 storeFile file("./keystore.jks")
             } else {
                 project.logger.lifecycle('Could not find release key')


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
The previous code was looking for a password if there is a `keystore.jks` file (even if it's not used).
I'm adding placeholders for the password properties in order to make debug builds pass.