### PR TITLE
Fix exposure keys serialization

### DIFF
--- a/src/AffectedUserFlow/hmac.spec.ts
+++ b/src/AffectedUserFlow/hmac.spec.ts
@@ -64,16 +64,16 @@ describe("calculateHmac", () => {
       base64TekKey,
     ] = mockConvertArrayBufferToBase64()
     const key = "key"
-    const rollingPeriod = 1
     const rollingStartNumber = 1
-    const transmissionRisk = 1
+    const rollingPeriod = 2
+    const transmissionRisk = 3
     const exposureKey = {
       key,
       rollingPeriod,
       rollingStartNumber,
       transmissionRisk,
     }
-    const serializedKey = `${base64TekKey}.${rollingPeriod}.${rollingStartNumber}.${transmissionRisk}`
+    const serializedKey = `${base64TekKey}.${rollingStartNumber}.${rollingPeriod}.${transmissionRisk}`
 
     const hmacKey = await calculateHmac([exposureKey])
 
@@ -90,8 +90,8 @@ describe("calculateHmac", () => {
     mockHmac256()
     const [, , , base64TekKey] = mockConvertArrayBufferToBase64()
     const key = "key"
-    const rollingPeriod = 1
     const rollingStartNumber = 1
+    const rollingPeriod = 2
     const transmissionRisk = 0
     const exposureKey = {
       key,
@@ -99,7 +99,7 @@ describe("calculateHmac", () => {
       rollingStartNumber,
       transmissionRisk,
     }
-    const serializedKey = `${base64TekKey}.${rollingPeriod}.${rollingStartNumber}`
+    const serializedKey = `${base64TekKey}.${rollingStartNumber}.${rollingPeriod}`
     await calculateHmac([exposureKey])
 
     expect(convertUtf8ToArrayBufferSpy).toHaveBeenCalledWith(serializedKey)

--- a/src/AffectedUserFlow/hmac.ts
+++ b/src/AffectedUserFlow/hmac.ts
@@ -2,11 +2,6 @@ import RNSimpleCrypto from "react-native-simple-crypto"
 
 import { ExposureKey } from "../exposureKey"
 
-const utf8ToBase64String = (input: string): string => {
-  const utf8AsArrayBuffer = RNSimpleCrypto.utils.convertUtf8ToArrayBuffer(input)
-  return RNSimpleCrypto.utils.convertArrayBufferToBase64(utf8AsArrayBuffer)
-}
-
 export const generateKey = async (): Promise<ArrayBuffer> => {
   return await RNSimpleCrypto.utils.randomBytes(32)
 }
@@ -34,36 +29,14 @@ export const calculateHmac = async (
 }
 
 const serializeKeys = (exposureKeys: ExposureKey[]) => {
-  const serializer = allRisksAreZero(exposureKeys)
-    ? serializeExposureKeyWithoutRisk
-    : serializeFullExposureKey
-  return exposureKeys
-    .map(serializer)
-    .sort((left: string, right: string) => {
-      return left.localeCompare(right, "en", { sensitivity: "base" })
-    })
-    .join(",")
+  return exposureKeys.map(serializeExposureKey).sort().join(",")
 }
 
-const serializeFullExposureKey = (exposureKey: ExposureKey): string => {
-  return [
-    serializeExposureKeyWithoutRisk(exposureKey),
-    exposureKey.transmissionRisk,
-  ].join(".")
-}
-
-const serializeExposureKeyWithoutRisk = ({
+const serializeExposureKey = ({
   key,
   rollingStartNumber,
   rollingPeriod,
+  transmissionRisk,
 }: ExposureKey): string => {
-  return [utf8ToBase64String(key), rollingStartNumber, rollingPeriod].join(".")
-}
-
-const allRisksAreZero = (exposureKeys: ExposureKey[]): boolean => {
-  return (
-    exposureKeys.filter(({ transmissionRisk }) => {
-      return transmissionRisk > 0
-    }).length === 0
-  )
+  return [key, rollingStartNumber, rollingPeriod, transmissionRisk].join(".")
 }

--- a/src/AffectedUserFlow/hmac.ts
+++ b/src/AffectedUserFlow/hmac.ts
@@ -45,26 +45,19 @@ const serializeKeys = (exposureKeys: ExposureKey[]) => {
     .join(",")
 }
 
-const serializeFullExposureKey = ({
-  key,
-  rollingPeriod,
-  rollingStartNumber,
-  transmissionRisk,
-}: ExposureKey): string => {
+const serializeFullExposureKey = (exposureKey: ExposureKey): string => {
   return [
-    utf8ToBase64String(key),
-    rollingPeriod,
-    rollingStartNumber,
-    transmissionRisk,
+    serializeExposureKeyWithoutRisk(exposureKey),
+    exposureKey.transmissionRisk,
   ].join(".")
 }
 
 const serializeExposureKeyWithoutRisk = ({
   key,
-  rollingPeriod,
   rollingStartNumber,
+  rollingPeriod,
 }: ExposureKey): string => {
-  return [utf8ToBase64String(key), rollingPeriod, rollingStartNumber].join(".")
+  return [utf8ToBase64String(key), rollingStartNumber, rollingPeriod].join(".")
 }
 
 const allRisksAreZero = (exposureKeys: ExposureKey[]): boolean => {


### PR DESCRIPTION
Why:
----
The sorting algorithm for the list of exposure keys used to calculate the hmac should be lexicographical, meaning, numbers, symbols, capitals, and lowercase. Also, the keys from the native side are sent in base64 encoding so there's no need to re-encode them.
The [specification] says the hmac calculation on exposure keys should have the base64 encoded key, then the rolling start, then the rolling period, and finally the transmission risk joined by a `.`

This Commit:
----
- Removes the encoding logic for the TEKeys
- Sorts the list of exposure keys with the default sort algorithm
- Change the order of the exposure key serialization to put the `rollingStartNumber` first and the `rollingPeriod` after

[specification]: https://developers.google.com/android/exposure-notifications/verification-system#hmac-calc