### PR TITLE
Hide NotificationPermissions Activation Screen on android

### DIFF
--- a/src/Activation/ActivateProximityTracing.tsx
+++ b/src/Activation/ActivateProximityTracing.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react"
 import {
+  Platform,
   ScrollView,
   SafeAreaView,
   View,
@@ -10,6 +11,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
 import { usePermissionsContext } from "../PermissionsContext"
+import { useOnboardingContext } from "../OnboardingContext"
 import { ActivationScreens } from "../navigation"
 import { GlobalText } from "../components"
 import { Button } from "../components"
@@ -20,15 +22,24 @@ const ActivateProximityTracing: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
 
+  const { setOnboardingToComplete } = useOnboardingContext()
   const { exposureNotifications } = usePermissionsContext()
 
   const handleOnPressEnable = () => {
     exposureNotifications.request()
-    navigation.navigate(ActivationScreens.NotificationPermissions)
+    navigateToNextScreen()
   }
 
   const handleOnPressDontEnable = () => {
-    navigation.navigate(ActivationScreens.NotificationPermissions)
+    navigateToNextScreen()
+  }
+
+  const navigateToNextScreen = () => {
+    if (Platform.OS === "ios") {
+      navigation.navigate(ActivationScreens.NotificationPermissions)
+    } else {
+      setOnboardingToComplete()
+    }
   }
 
   return (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -212,9 +212,7 @@
     "screen4_image_label": "A person getting a notification on their phone",
     "screen5_header": "With the app, you can help break the chain of infection and get help direct from health experts",
     "screen5_image_label": "A person talking to a health expert virtually",
-    "step_1_of_3": "Step 1 of 3",
-    "step_2_of_3": "Step 2 of 3",
-    "step_3_of_3": "Step 3 of 3"
+    "step": "Step {{currentStep}} of {{totalSteps}}"
   },
   "report_issue": {
     "body": "Feedback (required)",

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react"
-import { TouchableOpacity, StyleSheet, View } from "react-native"
+import { Platform, TouchableOpacity, StyleSheet, View } from "react-native"
 import {
   createStackNavigator,
   StackNavigationOptions,
@@ -35,15 +35,17 @@ const ActivationStack: FunctionComponent = () => {
 
   const HeaderRight = (step: ActivationStep) => {
     const determineStepText = () => {
+      const totalSteps = Platform.OS === "ios" ? 3 : 2
+
       switch (step) {
         case "AcceptEula":
-          return t("onboarding.step_1_of_3")
+          return t("onboarding.step", { currentStep: 1, totalSteps })
         case "ActivateProximityTracing":
-          return t("onboarding.step_2_of_3")
+          return t("onboarding.step", { currentStep: 2, totalSteps })
         case "NotificationPermissions":
-          return t("onboarding.step_3_of_3")
+          return t("onboarding.step", { currentStep: 3, totalSteps })
         default:
-          return t("onboarding.step_1_of_3")
+          return t("onboarding.step", { currentStep: 1, totalSteps })
       }
     }
 


### PR DESCRIPTION
Why?
------
Android does not need to ask for permission to send notifications like iOS does.

This commit
------
Remove the NotificationPermissions Activation screen from the onboarding flow for android.

#### Linked issues:

[Trello](https://trello.com/c/OKLv4PdV/297-remove-screen-to-enable-notifications-on-android)

#### How to test:

On Android, walk through onboarding flow and confirm that the notification permissions screen is no longer present.
On iOS, walk through onboarding flow and confirm that nothing has changed.
