### PR TITLE
(Android) Fix NPE on emulators

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
@@ -64,7 +64,7 @@ public class DeviceInfoModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void isBluetoothEnabled(final Promise promise) {
-        promise.resolve(BluetoothAdapter.getDefaultAdapter().isEnabled());
+        promise.resolve(BluetoothAdapter.getDefaultAdapter() != null && BluetoothAdapter.getDefaultAdapter().isEnabled());
     }
 
     @ReactMethod


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
`BluetoothAdapter.getDefaultAdapter()` returns null is bluetooth is not supported on the hardware, I think it will only happen on emulators.
This PR adds a null check to avoid having a NullPointerException in that case