### PR TITLE
(Android) Add revisionToken to submit keys requests

### DIFF
--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/ExposureNotificationSharedPreferences.java
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/ExposureNotificationSharedPreferences.java
@@ -36,6 +36,7 @@ public class ExposureNotificationSharedPreferences {
     private static final String ATTENUATION_THRESHOLD_1_KEY = "ExposureNotificationSharedPreferences.ATTENUATION_THRESHOLD_1_KEY";
     private static final String ATTENUATION_THRESHOLD_2_KEY = "ExposureNotificationSharedPreferences.ATTENUATION_THRESHOLD_2_KEY";
     private static final String LAST_DETECTION_PROCESS_DATE = "ExposureNotificationSharedPreferences.LAST_DETECTION_PROCESS_DATE";
+    private static final String REVISION_TOKEN = "ExposureNotificationSharedPreferences.REVISION_TOKEN";
 
     private final SharedPreferences sharedPreferences;
 
@@ -84,5 +85,13 @@ public class ExposureNotificationSharedPreferences {
 
     public void setLastDetectionProcessDate(Long date) {
         sharedPreferences.edit().putLong(LAST_DETECTION_PROCESS_DATE, date).commit();
+    }
+
+    public String getRevisionToken(String defaultToken) {
+        return sharedPreferences.getString(REVISION_TOKEN, defaultToken);
+    }
+
+    public void setRevisionToken(String token) {
+        sharedPreferences.edit().putString(REVISION_TOKEN, token).commit();
     }
 }

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/KeyValues.kt
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/KeyValues.kt
@@ -3,13 +3,16 @@ package covidsafepaths.bt.exposurenotifications.storage
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 
-const val ONLY_KEY = "KEY_VALUES"
-
 /**
  * A catch all class for storing key value pairs.
  */
 open class KeyValues(
-        @PrimaryKey
-        var id: String = ONLY_KEY,
-        var lastDownloadedKeyZipFileName: String? = null
-) : RealmObject()
+    @PrimaryKey
+    var id: String = "",
+    var value: String? = null
+) : RealmObject() {
+    companion object {
+        const val LAST_PROCESSED_FILE_NAME_KEY = "LAST_PROCESSED_FILE_NAME"
+        const val REVISION_TOKEN_KEY = "REVISION_TOKEN"
+    }
+}

--- a/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/Migration.kt
+++ b/android/app/src/main/java/covidsafepaths/bt/exposurenotifications/storage/Migration.kt
@@ -1,18 +1,32 @@
 package covidsafepaths.bt.exposurenotifications.storage
 
+import android.util.Log
 import io.realm.DynamicRealm
 import io.realm.FieldAttribute
 import io.realm.RealmMigration
+import io.realm.RealmObject
+import io.realm.RealmObjectSchema
 
-internal class Migration: RealmMigration {
-  override fun migrate(realm: DynamicRealm, oldVersion: Long, newVersion: Long) {
-    val schema = realm.schema
+internal class Migration : RealmMigration {
+    override fun migrate(realm: DynamicRealm, oldVersion: Long, newVersion: Long) {
+        Log.d("Migration", "Running migration from version $oldVersion to $newVersion");
+        val schema = realm.schema
+        var version = oldVersion
 
-    if (oldVersion == 1L) {
-      schema.create("ExposureEntity")
-        .addField("id", Long::class.java, FieldAttribute.PRIMARY_KEY)
-        .addField("dateMillisSinceEpoch", Long::class.java)
-        .addField("receivedTimestampMs", Long::class.java)
+        if (version == 1L) {
+            schema.create("ExposureEntity")
+                .addField("id", Long::class.java, FieldAttribute.PRIMARY_KEY)
+                .addField("dateMillisSinceEpoch", Long::class.java)
+                .addField("receivedTimestampMs", Long::class.java)
+            version++
+        }
+
+        if (version == 2L) {
+            schema.get("KeyValues")
+                ?.renameField("lastDownloadedKeyZipFileName", "value")
+                ?.removePrimaryKey()
+                ?.transform { obj -> obj.setString("id", KeyValues.LAST_PROCESSED_FILE_NAME_KEY) }
+                ?.addPrimaryKey("id")
+        }
     }
-  }
 }


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
Currently the `exposureKeyModule.postDiagnosisKeys` method submits the exposure keys to the exposure notifications server but it is not adding the revisionToken on the request. This token will be returned from the exposure notification server once the new keys are submitted and it has to be used on subsequent updates of the exposure keys.

This PR saves the `revisionToken` in a shared preference and uses it in subsequent requests

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://trello.com/c/ogfTrV4b/333-when-the-post-diagnosis-keys-process-ends-and-th-user-shares-the-keys-with-the-exposures-server-we-need-to-store-a-revision-toke

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
Verify that `verifyToken` is not sent in the first request and it's added in subsequent requests.