### PR TITLE
Move constant closer to its use to avoid cycle

### DIFF
--- a/src/Onboarding/OnboardingScreen.tsx
+++ b/src/Onboarding/OnboardingScreen.tsx
@@ -23,7 +23,6 @@ import {
   useStatusBarEffect,
 } from "../navigation"
 import { getLocalNames } from "../locales/languages"
-import { NUMBER_OF_ONBOARDING_SCREENS } from "../navigation/OnboardingStack"
 
 import { Icons } from "../assets"
 import {
@@ -131,6 +130,8 @@ const OnboardingScreen: FunctionComponent<OnboardingScreenProps> = ({
 interface PositionDotsProps {
   screenNumber: number
 }
+
+const NUMBER_OF_ONBOARDING_SCREENS = 5
 
 const PositionDots: FunctionComponent<PositionDotsProps> = ({
   screenNumber,

--- a/src/navigation/OnboardingStack.tsx
+++ b/src/navigation/OnboardingStack.tsx
@@ -17,8 +17,6 @@ type OnboardingStackParams = {
   [key in OnboardingScreen]: undefined
 }
 
-export const NUMBER_OF_ONBOARDING_SCREENS = 5
-
 const Stack = createStackNavigator<OnboardingStackParams>()
 
 const onboardingScreenOptions: StackNavigationOptions = {


### PR DESCRIPTION
Why:
----
The number of onboarding screens defined on the onboarding stack is causing a require cycle.

This Commit:
----
- Move the `NUMBER_OF_ONBOARDING_SCREENS` constant closer to where it is used
