### PR TITLE
Add revision token to key submission request (iOS)

### DIFF
--- a/ios/BT/API/Model/KeySubmissionResponse.swift
+++ b/ios/BT/API/Model/KeySubmissionResponse.swift
@@ -1,0 +1,3 @@
+struct KeySubmissionResponse: Codable {
+  let revisionToken: String?
+}

--- a/ios/BT/API/Model/UserState.swift
+++ b/ios/BT/API/Model/UserState.swift
@@ -10,6 +10,7 @@ class UserState: Object {
   @objc dynamic var remainingDailyFileProcessingCapacity: Int = Constants.dailyFileProcessingCapacity
   @objc dynamic var exposureDetectionErrorLocalizedDescription: String = .default
   @objc dynamic var urlOfMostRecentlyDetectedKeyFile: String = .default
+  @objc dynamic var revisionToken: String = .default
   let exposures: List<Exposure> = List<Exposure>()
 
   override class func primaryKey() -> String? {

--- a/ios/BT/API/Requests/DiagnosisKeyRequests.swift
+++ b/ios/BT/API/Requests/DiagnosisKeyRequests.swift
@@ -29,9 +29,13 @@ enum DiagnosisKeyRequest: APIRequest {
 
 enum DiagnosisKeyListRequest: APIRequest {
 
-  typealias ResponseType = Void
+  typealias ResponseType = KeySubmissionResponse
 
-  case post([ExposureKey], [RegionCode], String, String)
+  case post([ExposureKey],
+    [RegionCode],
+    String,
+    String,
+    String)
 
   var method: HTTPMethod {
     switch self {
@@ -52,7 +56,8 @@ enum DiagnosisKeyListRequest: APIRequest {
     case .post(let diagnosisKeys,
                let regions,
                let certificate,
-               let hmacKey):
+               let hmacKey,
+               let revisionToken):
       let keys = diagnosisKeys.map { try? $0.toJson() as? JSONObject }
       return [
         "temporaryExposureKeys": keys,
@@ -60,7 +65,8 @@ enum DiagnosisKeyListRequest: APIRequest {
         "appPackageName": Bundle.main.bundleIdentifier!,
         "verificationPayload": certificate,
         "hmackey": hmacKey,
-        "padding": Data.randomPadding(size: .paddingSize())
+        "padding": Data.randomPadding(size: .paddingSize()),
+        "revisionToken": revisionToken
       ]
     }
   }

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -313,11 +313,15 @@ final class ExposureManager: NSObject {
         let currentKeys = allKeys.current()
         
         let regionCodes = ReactNativeConfig.env(for: .regionCodes)!.regionCodes
+
+        let revisionToken = BTSecureStorage.shared.userState.revisionToken
         
-        APIClient.shared.request(DiagnosisKeyListRequest.post(currentKeys.compactMap { $0.asCodableKey }, regionCodes, certificate, HMACKey),
+        APIClient.shared.request(DiagnosisKeyListRequest.post(currentKeys.compactMap { $0.asCodableKey }, regionCodes, certificate, HMACKey, revisionToken),
                                  requestType: .postKeys) { result in
                                   switch result {
-                                  case .success:
+                                  case .success(let response):
+                                    // Save revisionToken to use on subsequent key submission requests
+                                    BTSecureStorage.shared.revisionToken = response.revisionToken ?? .default
                                     resolve("Submitted: \(currentKeys.count) keys.")
                                   case .failure(let error):
                                     reject(String.networkFailure, "Failed to post exposure keys \(error.localizedDescription)", error)

--- a/ios/BT/Extensions/Foundation/Notification+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Notification+Extensions.swift
@@ -3,6 +3,7 @@ extension Notification.Name {
   public static let StorageExposureDetectionErrorLocalizedDescriptionDidChange = Notification.Name(rawValue: "BTSecureStorageExposureDetectionErrorLocalizedDescriptionDidChange")
   public static let dateLastPerformedFileCapacityResetDidChange = Notification.Name(rawValue: "BTSecureStorageDateLastPerformedExposureDetectionDidChange")
   public static let HMACKeyDidChange = Notification.Name(rawValue: "BTSecureStorageHMACKeyDidChange")
+  public static let revisionTokenDidChange = Notification.Name(rawValue: "onRevisionTokenDidChange")
   public static let ExposuresDidChange = Notification.Name(rawValue: "onExposureRecordUpdated")
   public static let AuthorizationStatusDidChange = Notification.Name(rawValue: "onEnabledStatusUpdated")
   public static let remainingDailyFileProcessingCapacityDidChange = Notification.Name(rawValue: "remainingDailyFileProcessingCapacityDidChange")

--- a/ios/BT/Extensions/Foundation/String+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/String+Extensions.swift
@@ -4,6 +4,9 @@ extension String {
 
   static let `default` = ""
 
+  // API
+  static let revisionToken = "revisionToken"
+
   // EN
   static let notAuthorized = "notAuthorized"
   static let authorized = "authorized"

--- a/ios/BT/Storage/BTSecureStorage.swift
+++ b/ios/BT/Storage/BTSecureStorage.swift
@@ -27,10 +27,10 @@ final class BTSecureStorage: SafePathsSecureStorage {
   override func getRealmConfig() -> Realm.Configuration? {
     if let key = getEncryptionKey() {
       if (inMemory) {
-        return Realm.Configuration(inMemoryIdentifier: identifier, encryptionKey: key as Data, schemaVersion: 4,
+        return Realm.Configuration(inMemoryIdentifier: identifier, encryptionKey: key as Data, schemaVersion: 5,
                                    migrationBlock: { _, _ in }, objectTypes: [UserState.self, Exposure.self])
       } else {
-        return Realm.Configuration(encryptionKey: key as Data, schemaVersion: 4,
+        return Realm.Configuration(encryptionKey: key as Data, schemaVersion: 5,
                                    migrationBlock: { _, _ in }, objectTypes: [UserState.self, Exposure.self])
       }
     } else {
@@ -94,6 +94,10 @@ final class BTSecureStorage: SafePathsSecureStorage {
   @Persisted(keyPath: .keyPathHMACKey,
              notificationName: .HMACKeyDidChange, defaultValue: "")
   var HMACKey: String
+
+  @Persisted(keyPath: .revisionToken,
+             notificationName: .revisionTokenDidChange, defaultValue: "")
+  var revisionToken: String
 
   @Persisted(keyPath: .keyPathExposureDetectionErrorLocalizedDescription, notificationName:
     .StorageExposureDetectionErrorLocalizedDescriptionDidChange, defaultValue: .default)

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		B507A9EE24A197FF00E039D5 /* DownloadedPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B507A9ED24A197FF00E039D5 /* DownloadedPackage.swift */; };
 		B507AA0724A2533200E039D5 /* DownloadPackage+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B507AA0624A2533200E039D5 /* DownloadPackage+Helpers.swift */; };
 		B5081E4A24D9B8E300121884 /* DeviceInfoModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B5081E4924D9B8E300121884 /* DeviceInfoModule.m */; };
+		B51D8D2724E43AE4001C28E1 /* KeySubmissionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51D8D2624E43AE4001C28E1 /* KeySubmissionResponse.swift */; };
 		B52D88C0248F0FC00071ED51 /* SafePathsSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271881BF2461AF76001DE067 /* SafePathsSecureStorage.swift */; };
 		B52D88C4248F10FD0071ED51 /* BTSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52D88C3248F10FD0071ED51 /* BTSecureStorage.swift */; };
 		B54CBF32249A738500218477 /* IndexFileRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54CBF31249A738500218477 /* IndexFileRequests.swift */; };
@@ -205,6 +206,7 @@
 		B507A9ED24A197FF00E039D5 /* DownloadedPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadedPackage.swift; sourceTree = "<group>"; };
 		B507AA0624A2533200E039D5 /* DownloadPackage+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadPackage+Helpers.swift"; sourceTree = "<group>"; };
 		B5081E4924D9B8E300121884 /* DeviceInfoModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DeviceInfoModule.m; sourceTree = "<group>"; };
+		B51D8D2624E43AE4001C28E1 /* KeySubmissionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySubmissionResponse.swift; sourceTree = "<group>"; };
 		B52D88C3248F10FD0071ED51 /* BTSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSecureStorage.swift; sourceTree = "<group>"; };
 		B54CBF31249A738500218477 /* IndexFileRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexFileRequests.swift; sourceTree = "<group>"; };
 		B5582D43249943DE001458A9 /* ExposureEventEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExposureEventEmitter.m; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 			isa = PBXGroup;
 			children = (
 				B5FC37DC248A78D2006474EB /* ExposureKey.swift */,
+				B51D8D2624E43AE4001C28E1 /* KeySubmissionResponse.swift */,
 				B507A9ED24A197FF00E039D5 /* DownloadedPackage.swift */,
 				B5FC37DE248A78FC006474EB /* ExposureConfiguration.swift */,
 				B5FC37E2248A82AE006474EB /* Exposure.swift */,
@@ -981,6 +984,7 @@
 				B54CBF32249A738500218477 /* IndexFileRequests.swift in Sources */,
 				B52D88C4248F10FD0071ED51 /* BTSecureStorage.swift in Sources */,
 				B5FC37CC2489B251006474EB /* Result.swift in Sources */,
+				B51D8D2724E43AE4001C28E1 /* KeySubmissionResponse.swift in Sources */,
 				C58463E42486C51100BCB842 /* ExposureManager.swift in Sources */,
 				B5FC37C62489B1B3006474EB /* APIRequest.swift in Sources */,
 				B5FBB0D124916A7200433980 /* Persisted.swift in Sources */,


### PR DESCRIPTION
#### Description:
Currently the `exposureKeyModule.postDiagnosisKeys` method submits the exposure keys to the exposure notifications server but it is not adding the revisionToken on the request. This token will be returned from the exposure notification server once the new keys are submitted and it has to be used on subsequent updates of the exposure keys.

This PR saves the `revisionToken` in Realm and uses it in subsequent requests

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://trello.com/c/ogfTrV4b/333-when-the-post-diagnosis-keys-process-ends-and-th-user-shares-the-keys-with-the-exposures-server-we-need-to-store-a-revision-toke

#### How to test:
Verify that `revisionToken` is not sent in the first request and it's added in subsequent requests.