### PR TITLE
Update Bluetooth status on home screen on toggle

### DIFF
--- a/src/Home/Home.spec.tsx
+++ b/src/Home/Home.spec.tsx
@@ -13,8 +13,8 @@ import "@testing-library/jest-native/extend-expect"
 import Home from "./Home"
 import { PermissionsContext, ENPermissionStatus } from "../PermissionsContext"
 import { PermissionStatus } from "../permissionStatus"
-import { isBluetoothEnabled } from "../gaen/nativeModule"
 import { isPlatformiOS } from "../utils/index"
+import { useBluetoothStatus } from "./useBluetoothStatus"
 
 jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
@@ -34,12 +34,13 @@ jest.mock("../More/useApplicationInfo", () => {
     },
   }
 })
+jest.mock("./useBluetoothStatus.ts")
 
 describe("Home", () => {
   describe("When the enPermissionStatus is enabled and authorized and Bluetooth is on", () => {
     it("renders an active message", async () => {
-      const isBluetoothOn = "true"
-      ;(isBluetoothEnabled as jest.Mock).mockResolvedValueOnce(isBluetoothOn)
+      const isBluetoothOn = true
+      ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
       const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
       const permissionProviderValue = createPermissionProviderValue(
@@ -81,8 +82,8 @@ describe("Home", () => {
 
   describe("When the enPermissionStatus is not enabled and not authorized", () => {
     it("renders an inactive message and a disabled message for proximity tracing", async () => {
-      const isBluetoothOn = "true"
-      ;(isBluetoothEnabled as jest.Mock).mockResolvedValueOnce(isBluetoothOn)
+      const isBluetoothOn = true
+      ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
       const enPermissionStatus: ENPermissionStatus = [
         "UNAUTHORIZED",
@@ -117,9 +118,9 @@ describe("Home", () => {
   })
 
   describe("When Bluetooth is off", () => {
-    it("renders an inactive message and a disabled message for bluetooth", () => {
-      const isBluetoothOn = "false"
-      ;(isBluetoothEnabled as jest.Mock).mockResolvedValueOnce(isBluetoothOn)
+    it("renders an inactive message and a disabled message for bluetooth", async () => {
+      const isBluetoothOn = false
+      ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
       const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
       const permissionProviderValue = createPermissionProviderValue(
@@ -137,6 +138,7 @@ describe("Home", () => {
       const bluetoothStatusContainer = getByTestId(
         "home-bluetooth-status-container",
       )
+
       const bluetoothDisabledText = within(bluetoothStatusContainer).getByText(
         "Disabled",
       )
@@ -152,8 +154,8 @@ describe("Home", () => {
   describe("When Bluetooth is disabled", () => {
     it("it prompts the user to enable Bluetooth", async () => {
       expect.assertions(1)
-      const isBluetoothOn = "false"
-      ;(isBluetoothEnabled as jest.Mock).mockResolvedValueOnce(isBluetoothOn)
+      const isBluetoothOn = false
+      ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
       const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
       const permissionProviderValue = createPermissionProviderValue(

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useState } from "react"
+import React, { FunctionComponent } from "react"
 import {
   ScrollView,
   Alert,
@@ -21,7 +21,6 @@ import {
   ENPermissionStatus,
 } from "../PermissionsContext"
 import { useStatusBarEffect, Stacks } from "../navigation"
-import { isBluetoothEnabled } from "../gaen/nativeModule"
 import { useApplicationInfo } from "../More/useApplicationInfo"
 import { GlobalText } from "../components/GlobalText"
 import { Button } from "../components/Button"
@@ -36,6 +35,7 @@ import {
   Outlines,
   Iconography,
 } from "../styles"
+import { useBluetoothStatus } from "./useBluetoothStatus"
 
 const HomeScreen: FunctionComponent = () => {
   const { t } = useTranslation()
@@ -48,16 +48,7 @@ const HomeScreen: FunctionComponent = () => {
   const { applicationName } = useApplicationInfo()
   const insets = useSafeAreaInsets()
   useStatusBarEffect("light-content")
-
-  const [btStatus, setBTStatus] = useState(false)
-  const fetchBTStatus = async () => {
-    const status = await isBluetoothEnabled()
-    setBTStatus(status === "true")
-  }
-
-  useEffect(() => {
-    fetchBTStatus()
-  }, [])
+  const btStatus = useBluetoothStatus()
 
   const isEnabled = enablement === "ENABLED"
   const isAuthorized = authorization === "AUTHORIZED"

--- a/src/Home/useBluetoothStatus.ts
+++ b/src/Home/useBluetoothStatus.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react"
+import { Platform, AppState } from "react-native"
+import { isBluetoothEnabled } from "../gaen/nativeModule"
+
+export const useBluetoothStatus = (): boolean => {
+  const [btStatus, setBTStatus] = useState(false)
+  useEffect(() => {
+    const fetchBTEnabled = async () => {
+      const status = await fetchBTStatus()
+      setBTStatus(status)
+    }
+
+    AppState.addEventListener(determineOSListener(), () => fetchBTEnabled())
+    return AppState.removeEventListener(determineOSListener(), () =>
+      fetchBTEnabled(),
+    )
+  }, [])
+
+  return btStatus
+}
+
+const fetchBTStatus = async (): Promise<boolean> => {
+  return isBluetoothEnabled()
+}
+
+type ListenerMethod = "focus" | "change"
+const determineOSListener = (): ListenerMethod => {
+  return Platform.select({
+    ios: "change",
+    android: "focus",
+    default: "change",
+  })
+}

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -140,8 +140,9 @@ export const getVersion = async (): Promise<string> => {
   return deviceInfoModule.getVersion()
 }
 
-export const isBluetoothEnabled = async (): Promise<string> => {
-  return deviceInfoModule.isBluetoothEnabled()
+export const isBluetoothEnabled = async (): Promise<boolean> => {
+  const bluetoothStatus = deviceInfoModule.isBluetoothEnabled()
+  return bluetoothStatus === true || bluetoothStatus === "true"
 }
 
 // Debug Module


### PR DESCRIPTION
#### Description:
Why:
As a user, who has been prompted to enable bluetooth, I want to see my
new bluetooth status reflected in the home screen so that I know it is
working.

This commit:
Introduces the AppState listener from react native. When an iOS user
foregrounds the app (in order to activate bluetooth in their settings),
or an Android user focuses the app (in order to either activate their
bluetooth settings, or use the notification menu to toggle bluetooth),
the app will now refetch the bluetooth status and set it into state.

This also fixes a bug I experienced where the status was not being
properly set on Android, because `isBluetoothEnabled` returned a
boolean, and we were checking if `status === 'true'`

#### Linked issues:

Fixes [Trello](https://trello.com/c/ZPXtZnvi/320-when-i-do-not-have-bluetooth-enabled-and-the-app-tells-me-to-turn-it-on-i-want-to-see-that-turning-it-on-is-reflected-in-the-app)

#### Screenshots:
![Aug-12-2020 13-00-38](https://user-images.githubusercontent.com/21161427/90044644-e6e48900-dc9b-11ea-976e-f165c5705c58.gif)


#### How to test:
- With your bluetooth off, open the app on your device
- Turn your bluetooth on, and wait for it to activate
- revisit the app
- Expect the bluetooth status to have updated

Notes:
- I am unable to test this on an iPhone, as I do not have an iPhone and the simulator does not support bluetooth
- There is an edge case where if a user toggles their bluetooth settings and then quickly revisits the app, the bluetooth might not be active by the time they revisit the app, since it can take a second or two to activate. If we want to address this issue, we will have to create a native event emitter that will emit the updated bluetooth status regardless of application state.