### PR TITLE
Use the app or play store link for sharing the app

### DIFF
--- a/example.env.bt
+++ b/example.env.bt
@@ -5,7 +5,10 @@ DISPLAY_SELF_ASSESSMENT=true
 DISPLAY_NAME='PathCheck'
 
 IOS_BUNDLE_ID='org.pathcheck.bt'
+IOS_APP_STORE_URL='https://apps.apple.com/us/app/idXXXXXXXXXX'
+
 ANDROID_APPLICATION_ID='org.pathcheck.pc.bt'
+ANDROID_PLAY_STORE_URL='https://play.google.com/store/apps/details?id=org.pathcheck.pc.bt'
 
 REGION_CODES='US'
 

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -10,11 +10,13 @@ import {
   Image,
   View,
   Share,
+  Platform,
 } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 import { useNavigation } from "@react-navigation/native"
+import env from "react-native-config"
 
 import {
   usePermissionsContext,
@@ -88,9 +90,13 @@ const HomeScreen: FunctionComponent = () => {
     )
   }
 
-  const appDownloadLink = "https://pathcheck.org"
-
   const handleOnPressShare = async () => {
+    const isIOS = Platform.OS === "ios"
+
+    const appDownloadLink = isIOS
+      ? env.IOS_APP_STORE_URL
+      : env.ANDROID_PLAY_STORE_URL
+
     try {
       await Share.share({
         message: t("home.bluetooth.share_message", {


### PR DESCRIPTION
Why?
------
When sharing the app, send the user to the app store to download the app - HA dependent.

#### Linked issues:

[Trello](https://trello.com/c/YVm6ejAI/312-when-i-press-the-share-link-on-the-home-screen-i-would-like-to-get-the-actual-store-link-for-the-application)
[Pathcheck Mobile Resource PR](https://github.com/Path-Check/pathcheck-mobile-resources/pull/11)
