### PR TITLE
Add empty state text to exposure list debug screen

### DIFF
--- a/src/More/ExposureListDebugScreen.spec.tsx
+++ b/src/More/ExposureListDebugScreen.spec.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import "@testing-library/jest-native/extend-expect"
+import ExposureListDebugScreen from "./ExposureListDebugScreen"
+import { ExposureContext } from "../ExposureContext"
+import { factories } from "../factories"
+
+describe("ExposureListDebugScreen", () => {
+  describe("when there are no exposures", () => {
+    it("Displays a helpful message", () => {
+      const exposureProviderValue = factories.exposureContext.build()
+      const { getByText } = render(
+        <ExposureContext.Provider value={exposureProviderValue}>
+          <ExposureListDebugScreen />
+        </ExposureContext.Provider>,
+      )
+
+      expect(getByText("No exposure data to display")).toBeDefined()
+    })
+  })
+
+  describe("when there is one or more exposure", () => {
+    it("displays a list of exposures", () => {
+      const exposure1 = factories.exposureDatum.build({
+        id: "123",
+      })
+      const exposure2 = factories.exposureDatum.build({
+        id: "456",
+      })
+      const exposureProviderValue = factories.exposureContext.build({
+        exposureInfo: [exposure1, exposure2],
+      })
+
+      const { getAllByTestId } = render(
+        <ExposureContext.Provider value={exposureProviderValue}>
+          <ExposureListDebugScreen />
+        </ExposureContext.Provider>,
+      )
+
+      expect(getAllByTestId("exposure-list-debug-item")).toHaveLength(2)
+    })
+  })
+})

--- a/src/More/ExposureListDebugScreen.tsx
+++ b/src/More/ExposureListDebugScreen.tsx
@@ -1,95 +1,45 @@
-import React, { useEffect, useState } from "react"
-import {
-  Alert,
-  BackHandler,
-  FlatList,
-  StyleSheet,
-  View,
-  Text,
-  NativeModules,
-} from "react-native"
+import React, { useEffect, FunctionComponent } from "react"
+import { FlatList, StyleSheet, View, Text } from "react-native"
 
 import { GlobalText } from "../components/GlobalText"
-import { NavigationProp } from "../navigation"
 
 import dayjs from "dayjs"
-import { RawExposure } from "../gaen/dataConverters"
 
-import { Typography } from "../styles"
+import { Typography, Spacing, Outlines, Colors } from "../styles"
+import { useExposureContext } from "../ExposureContext"
 
-type ENLocalExposureScreenProp = {
-  navigation: NavigationProp
-}
-
-type DebugExposure = {
-  id: string
-  date: string
-}
-
-const ExposureListDebugScreen = ({
-  navigation,
-}: ENLocalExposureScreenProp): JSX.Element => {
-  const initialExposures: DebugExposure[] = []
-
-  const fetchExposures = async () => {
-    try {
-      NativeModules.ExposureHistoryModule.getCurrentExposures(
-        (debugExposure: string) => {
-          const rawExposures: RawExposure[] = JSON.parse(debugExposure)
-          const debugExposures: DebugExposure[] = rawExposures.map((e) => {
-            return { id: e.id, date: dayjs(e.date).toString() }
-          })
-          setExposures(debugExposures)
-        },
-      )
-      setExposures(exposures)
-    } catch (e) {
-      setErrorMessage(e.message)
-    }
-  }
-
-  const [exposures, setExposures] = useState<DebugExposure[]>(initialExposures)
-
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (errorMessage) {
-      showErrorAlert(errorMessage)
-    }
-    const handleBackPress = () => {
-      navigation.goBack()
-      return true
-    }
-
-    BackHandler.addEventListener("hardwareBackPress", handleBackPress)
-
-    return () => {
-      BackHandler.removeEventListener("hardwareBackPress", handleBackPress)
-    }
-  }, [navigation, exposures, errorMessage])
-
-  useEffect(() => {
-    fetchExposures()
+const ExposureListDebugScreen: FunctionComponent = () => {
+  const { exposureInfo, getCurrentExposures } = useExposureContext()
+  const exposures = exposureInfo.map((e) => {
+    return { id: e.id, date: dayjs(e.date).toString() }
   })
+  const showExposures = exposures.length > 0
 
-  const showErrorAlert = (errorMessage: string) => {
-    Alert.alert("Error", errorMessage, [{ text: "OK" }], {
-      cancelable: false,
-    })
-  }
+  useEffect(() => {
+    getCurrentExposures()
+  }, [])
 
   return (
-    <FlatList
-      data={exposures}
-      keyExtractor={(item) => item.id}
-      renderItem={(item) => (
-        <View style={style.flatlistRowView}>
-          <GlobalText style={style.itemText}>
-            <Text>Date: {item.item.date}</Text>
-          </GlobalText>
-        </View>
+    <>
+      {showExposures ? (
+        <FlatList
+          data={exposures}
+          keyExtractor={(item) => item.id}
+          renderItem={(item) => (
+            <View
+              testID={"exposure-list-debug-item"}
+              style={style.flatlistRowView}
+            >
+              <GlobalText style={style.itemText}>
+                <Text>Date: {item.item.date}</Text>
+              </GlobalText>
+            </View>
+          )}
+        />
+      ) : (
+        <Text style={style.noExposureText}>No exposure data to display</Text>
       )}
-    />
+    </>
   )
 }
 
@@ -98,15 +48,19 @@ const style = StyleSheet.create({
   flatlistRowView: {
     flexDirection: "row",
     justifyContent: "space-between",
-    paddingTop: 7,
-    paddingBottom: 5,
-    borderBottomWidth: 1,
-    borderColor: "#999999",
+    paddingTop: Spacing.xxxSmall,
+    paddingBottom: Spacing.xxxSmall,
+    borderBottomWidth: Outlines.hairline,
+    borderColor: Colors.lightGray,
   },
   itemText: {
     ...Typography.tertiaryContent,
-    padding: 10,
+    padding: Spacing.xSmall,
     maxWidth: "90%",
+  },
+  noExposureText: {
+    ...Typography.header5,
+    padding: Spacing.medium,
   },
 })
 

--- a/src/exposure.ts
+++ b/src/exposure.ts
@@ -1,8 +1,10 @@
 import { DateTimeUtils } from "./utils"
 
 export type Posix = number
+type UUID = string
 
 export interface ExposureDatum {
+  id: UUID
   date: Posix
   duration: number
 }

--- a/src/factories/exposureDatum.tsx
+++ b/src/factories/exposureDatum.tsx
@@ -4,9 +4,10 @@ import { DateTimeUtils } from "../utils"
 
 import { ExposureDatum } from "../exposure"
 
-export default Factory.define<ExposureDatum>(() => {
+export default Factory.define<ExposureDatum>(({ sequence }) => {
   const defaultDate = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(2))
   return {
+    id: sequence.toString(),
     date: defaultDate,
     duration: 300000,
     totalRiskScore: 4,

--- a/src/gaen/dataConverter.spec.ts
+++ b/src/gaen/dataConverter.spec.ts
@@ -30,6 +30,7 @@ describe("toExposureInfo", () => {
       const expected: ExposureDatum = {
         date: DateTimeUtils.beginningOfDay(twoDaysAgo),
         duration: duration,
+        id: "ABCD-EFGH",
       }
 
       const result = toExposureInfo(rawExposures)
@@ -66,6 +67,7 @@ describe("toExposureInfo", () => {
       const expected: ExposureDatum = {
         date: DateTimeUtils.beginningOfDay(today),
         duration: duration1 + duration2 + duration3,
+        id: "raw-exposure-1",
       }
 
       const result = toExposureInfo(rawExposures)

--- a/src/gaen/dataConverters.ts
+++ b/src/gaen/dataConverters.ts
@@ -23,6 +23,7 @@ export const toExposureInfo = (
 const toExposureDatum = (r: RawExposure): ExposureDatum => {
   const beginningOfDay = (date: Posix) => dayjs(date).startOf("day")
   return {
+    id: r.id,
     date: beginningOfDay(r.date).valueOf(),
     duration: r.duration,
   }


### PR DESCRIPTION
#### Description:
Why:
As a tester, I want to be clearly told when there are no exposures to
view in the debug menu, so that I know that it is working as expected.

This commit:
Adds empty state text to alert a debug menu user that when the device
has no current exposures. It also adds a test for this screen, and
refactors the debug screen to use the exposure information that we are
already storing in app context instead of re-fetching them.


#### Linked issues:

Fixes: [Trello](uhttps://trello.com/c/fQzc2wFR/298-as-a-tester-when-i-go-to-the-show-exposures-debug-screen-and-there-are-no-exposures-i-see-some-no-exposures-indicatorrl)

#### Screenshots:

![Simulator Screen Shot - iPhone 11 - 2020-08-13 at 12 48 55](https://user-images.githubusercontent.com/21161427/90163067-989abd00-dd63-11ea-94cf-ca2f394f7012.png)
![Simulator Screen Shot - iPhone 11 - 2020-08-13 at 13 34 29](https://user-images.githubusercontent.com/21161427/90167512-bbc86b00-dd69-11ea-98ef-a02111308581.png)



#### How to test:
- Open the app and clear exposures
- visit the "See exposures" screen
- Expect to see "no exposures" text
- Simulate exposure
- Return to the "See exposures" screen
- Expect to see the new simulated exposure

