### PR TITLE
add update for iOS configuration in configure_builds script

### DIFF
--- a/bin/configure_builds.sh
+++ b/bin/configure_builds.sh
@@ -178,12 +178,74 @@ def update_bundle_identifiers
   end
 end
 
+################################# iOS Specific Configuration ##########################################
+
+def get_current_ios_en_api_version
+  output = read_value_from_plist(
+    file_path: PLIST_PATH,
+    key: 'ENAPIVersion'
+  )
+  return output if output
+  exit 1
+end
+
+def update_ios_en_api_version(new_en_api_version)
+  puts "Updating ios en api version from #{get_current_ios_en_api_version} to #{new_en_api_version}"
+  return if update_value_on_plist(
+    file_path: PLIST_PATH,
+    key: 'ENAPIVersion',
+    value: new_en_api_version
+  )
+  exit 1
+end
+
+def get_current_ios_en_region
+  output = read_value_from_plist(
+    file_path: PLIST_PATH,
+    key: 'ENDeveloperRegion'
+  )
+  return output if output
+  exit 1
+end
+
+def update_ios_en_region(new_en_region)
+  puts "Updating ios en region from #{get_current_ios_en_region} to #{new_en_region}"
+  return if update_value_on_plist(
+    file_path: PLIST_PATH,
+    key: 'ENDeveloperRegion',
+    value: new_en_region
+  )
+  exit 1
+end
+
+IOS_EN_REGION_KEY = "EN_DEVELOPER_REGION"
+IOS_EN_API_VERSION_KEY = "EN_API_VERSION"
+
+def update_ios_configuration
+  environment = Dotenv.parse(File.open(ENV_FILE))
+  ios_en_region = environment.fetch(IOS_EN_REGION_KEY, false)
+  ios_en_version = environment.fetch(IOS_EN_API_VERSION_KEY, 1)
+
+  update_ios_en_api_version(ios_en_version)
+  if ios_en_region
+    update_ios_en_region(ios_en_region)
+  else
+    failure_message "EN region is required"
+    exit 1
+  end
+end
+
+
 if File.exist?(ENV_FILE)
   update_application_display_name
   puts "✅ Display Names Updated"
   update_bundle_identifiers
   puts "✅ Bundle Identifiers Updated"
+  update_ios_configuration
+  puts "✅ iOS Configuration Updated"
 else
   failure_message "#{ENV_FILE} not found on the root folder, environment file is needed"
   exit 1
 end
+
+

--- a/ios/BT/Info.plist
+++ b/ios/BT/Info.plist
@@ -27,6 +27,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ENAPIVersion</key>
+	<string>1</string>
+	<key>ENDeveloperRegion</key>
+	<string>PC</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
#### Description:

Update configure_build script to update iOS info.plist with required ENDeveloperRegion and ENAPIVersion as required by apple

#### Linked issues:

https://trello.com/c/9eW8zgpi/326-ios-endeveloperregion-enapiversion-for-infoplist


#### How to test:

run ./bin/set_ha.sh and set a HA and check that the Info.plist is proplerly updated