### PR TITLE
Fix bug where BT can't enable on android

### DIFF
--- a/src/Home/useBluetoothStatus.ts
+++ b/src/Home/useBluetoothStatus.ts
@@ -10,6 +10,7 @@ export const useBluetoothStatus = (): boolean => {
       setBTStatus(status)
     }
 
+    fetchBTEnabled()
     AppState.addEventListener(determineOSListener(), () => fetchBTEnabled())
     return AppState.removeEventListener(determineOSListener(), () =>
       fetchBTEnabled(),

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -141,7 +141,7 @@ export const getVersion = async (): Promise<string> => {
 }
 
 export const isBluetoothEnabled = async (): Promise<boolean> => {
-  const bluetoothStatus = deviceInfoModule.isBluetoothEnabled()
+  const bluetoothStatus = await deviceInfoModule.isBluetoothEnabled()
   return bluetoothStatus === true || bluetoothStatus === "true"
 }
 


### PR DESCRIPTION
#### Description:

Why:
There is currently a bug where toggling the BT status on android is not
reflected in the home screen, blocking people from using app features.

This commit:
Fixes an issue where we were not `await`-ing the promise resolution from
the native module.

#### Linked issues:

Fixes: [Trello](https://trello.com/c/dcZu4wmf/338-android-bluetooth-cant-be-enabled)

#### How to test:
- Test that toggling the bluetooth state on both Android and Bluetooth is reflected on the home screen
- Please note that BT must be successfully enabled (it may take a second or so) before switching back to the app in order to successfully be reflected
