### PR TITLE
(Android) Expose method to check if device supports locationless scanning

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/DeviceInfoModule.java
@@ -76,4 +76,10 @@ public class DeviceInfoModule extends ReactContextBaseJavaModule {
             promise.reject(new Exception("Location manager not found"));
         }
     }
+
+    @ReactMethod
+    public void deviceSupportsLocationlessScanning(final Promise promise) {
+        ExposureNotificationClientWrapper client = ExposureNotificationClientWrapper.get(getReactApplicationContext());
+        promise.resolve(client.deviceSupportsLocationlessScanning());
+    }
 }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
@@ -108,6 +108,10 @@ public class ExposureNotificationClientWrapper {
         return exposureNotificationClient.getExposureWindows();
     }
 
+    public boolean deviceSupportsLocationlessScanning(){
+        return exposureNotificationClient.deviceSupportsLocationlessScanning();
+    }
+
     public void onExposureNotificationStateChanged(@Nullable ReactContext context, boolean enabled) {
         if (enabled) {
             ProvideDiagnosisKeysWorker.schedule(context);


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
New method `exposureNotificationClient.deviceSupportsLocationlessScanning()` has been added in API v1.6 to check if the device needs to have Location enabled to use Exposure Notification.
This PR exposes it to the JS layer

#### Linked issues:
https://trello.com/c/EOccYNcG/354-on-gaen-v16-sdk-on-android-if-locationless-mode-is-not-available-and-location-is-not-enabled-on-the-device-show-on-the-main-scre