### PR TITLE
Remove eula from activation stack

### DIFF
--- a/src/Activation/AcceptEula.tsx
+++ b/src/Activation/AcceptEula.tsx
@@ -70,6 +70,10 @@ const AcceptEula: FunctionComponent = () => {
     loadEula()
   }, [eulaPath])
 
+  const handleOnPressNext = () => {
+    navigation.navigate(ActivationScreens.ActivateProximityTracing)
+  }
+
   const checkboxIcon = boxChecked
     ? Icons.CheckboxChecked
     : Icons.CheckboxUnchecked
@@ -110,9 +114,7 @@ const AcceptEula: FunctionComponent = () => {
           </GlobalText>
         </TouchableOpacity>
         <Button
-          onPress={() =>
-            navigation.navigate(ActivationScreens.ActivateProximityTracing)
-          }
+          onPress={handleOnPressNext}
           disabled={!boxChecked}
           label={t("common.continue")}
         />

--- a/src/Onboarding/ValueProposition.tsx
+++ b/src/Onboarding/ValueProposition.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from "@react-navigation/native"
 
 import OnboardingScreen from "./OnboardingScreen"
 
-import { ActivationScreens, Stacks } from "../navigation"
+import { Stacks, ActivationScreens } from "../navigation"
 import { Images } from "../assets"
 
 const ValueProposition: FunctionComponent = () => {
@@ -22,7 +22,7 @@ const ValueProposition: FunctionComponent = () => {
   const onboardingScreenActions = {
     primaryButtonOnPress: () =>
       navigation.navigate(Stacks.Activation, {
-        screen: ActivationScreens.AcceptEula,
+        screen: ActivationScreens.ActivateProximityTracing,
       }),
   }
 

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -11,7 +11,6 @@ import { useTranslation } from "react-i18next"
 import { GlobalText } from "../components"
 import { Stacks, ActivationScreen, ActivationScreens } from "./index"
 
-import AcceptEula from "../Activation/AcceptEula"
 import ActivateProximityTracing from "../Activation/ActivateProximityTracing"
 import NotificationPermissions from "../Activation/NotificationPermissions"
 
@@ -28,31 +27,36 @@ const ActivationStack: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
 
-  type ActivationStep =
-    | "ActivateProximityTracing"
-    | "NotificationPermissions"
-    | "AcceptEula"
+  interface ActivationStep {
+    screenName: ActivationScreen
+    component: FunctionComponent
+  }
 
-  const HeaderRight = (step: ActivationStep) => {
-    const determineStepText = () => {
-      const totalSteps = Platform.OS === "ios" ? 3 : 2
+  const activateProximityTracing: ActivationStep = {
+    screenName: ActivationScreens.ActivateProximityTracing,
+    component: ActivateProximityTracing,
+  }
 
-      switch (step) {
-        case "AcceptEula":
-          return t("onboarding.step", { currentStep: 1, totalSteps })
-        case "ActivateProximityTracing":
-          return t("onboarding.step", { currentStep: 2, totalSteps })
-        case "NotificationPermissions":
-          return t("onboarding.step", { currentStep: 3, totalSteps })
-        default:
-          return t("onboarding.step", { currentStep: 1, totalSteps })
-      }
-    }
+  const notificationPermissions: ActivationStep = {
+    screenName: ActivationScreens.NotificationPermissions,
+    component: NotificationPermissions,
+  }
 
+  const activationStepsIOS: ActivationStep[] = [
+    activateProximityTracing,
+    notificationPermissions,
+  ]
+
+  const activationStepsAndroid: ActivationStep[] = [activateProximityTracing]
+
+  const activationSteps =
+    Platform.OS === "ios" ? activationStepsIOS : activationStepsAndroid
+
+  const HeaderRight = (currentStep: number, totalSteps: number) => {
     return (
       <View style={style.headerRight}>
         <GlobalText style={style.headerRightText}>
-          {determineStepText()}
+          {t("onboarding.step", { currentStep, totalSteps })}
         </GlobalText>
         <TouchableOpacity
           onPress={() => navigation.navigate(Stacks.Onboarding)}
@@ -79,27 +83,20 @@ const ActivationStack: FunctionComponent = () => {
 
   return (
     <Stack.Navigator screenOptions={screenOptions}>
-      <Stack.Screen
-        name={ActivationScreens.AcceptEula}
-        component={AcceptEula}
-        options={{
-          headerRight: () => HeaderRight("AcceptEula"),
-        }}
-      />
-      <Stack.Screen
-        name={ActivationScreens.ActivateProximityTracing}
-        component={ActivateProximityTracing}
-        options={{
-          headerRight: () => HeaderRight("ActivateProximityTracing"),
-        }}
-      />
-      <Stack.Screen
-        name={ActivationScreens.NotificationPermissions}
-        component={NotificationPermissions}
-        options={{
-          headerRight: () => HeaderRight("NotificationPermissions"),
-        }}
-      />
+      {activationSteps.map((step, idx) => {
+        const currentStep = idx + 1
+        return (
+          <Stack.Screen
+            name={step.screenName}
+            component={step.component}
+            key={`activation-screen-${step.screenName}`}
+            options={{
+              headerRight: () =>
+                HeaderRight(currentStep, activationSteps.length),
+            }}
+          />
+        )
+      })}
     </Stack.Navigator>
   )
 }


### PR DESCRIPTION
Why:
We would like to suppress the EULA for now until the product
requirements for it can be fully defined.

This commit:
Refactors the activation stack and removes the eula screen. We kept the
eula component in the repo as we expect to be reintroducing it in an
upcoming iteration.