### PR TITLE
Send AppCenter destinations as a parameter

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -79,7 +79,7 @@ platform :android do
       owner_name: "PathCheck",
       app_name: options[:appName],
       notify_testers: false,
-      destinations: "Collaborators",
+      destinations: options[:destinations],
       release_notes: changeLogs,
       file: options[:apkPath]
     )

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -26,7 +26,7 @@ platform :ios do
         owner_name: "PathCheck",
         app_name: options[:appName],
         notify_testers: false,
-        destinations: "Collaborators",
+        destinations: options[:destinations],        
         release_notes: changeLogs,
         file: options[:ipa_path]
       )


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
QA team is not getting new builds because the group is not added as a destination in each release.
This PR allows us to configure the `destinations` array from Bitrise