### PR TITLE
Use the application name consistently

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -439,7 +439,7 @@ SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 3ef4a7f62e7db01092f9d517d2ebc0d0677c4a37
   FBReactNativeSpec: dc7fa9088f0f2a998503a352b0554d69a4391c5a
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4

--- a/src/Onboarding/ProtectPrivacy.tsx
+++ b/src/Onboarding/ProtectPrivacy.tsx
@@ -10,9 +10,9 @@ import {
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
-import env from "react-native-config"
 
 import { GlobalText } from "../components/GlobalText"
+import { useApplicationName } from "../More/useApplicationInfo"
 import { useStatusBarEffect } from "../navigation"
 
 import { Layout, Typography, Spacing, Colors, Iconography } from "../styles"
@@ -27,7 +27,7 @@ const ProtectPrivacy: FunctionComponent<ProtectPrivacyProps> = ({
 }) => {
   const navigation = useNavigation()
   const { t } = useTranslation()
-  const applicationName = env.IN_APP_NAME
+  const { applicationName } = useApplicationName()
   useStatusBarEffect("dark-content")
 
   const headerContainerConditionalStyle = modalStyle && {

--- a/src/Onboarding/Welcome.tsx
+++ b/src/Onboarding/Welcome.tsx
@@ -2,11 +2,11 @@ import React, { FunctionComponent } from "react"
 import { Image, StyleSheet, View, TouchableOpacity } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
-import env from "react-native-config"
 
 import { GlobalText } from "../components/GlobalText"
 import { getLocalNames } from "../locales/languages"
 import { Button } from "../components"
+import { useApplicationName } from "../More/useApplicationInfo"
 
 import { Images } from "../assets"
 import { Spacing, Colors, Typography, Outlines } from "../styles"
@@ -19,7 +19,7 @@ const Welcome: FunctionComponent = () => {
     i18n: { language: localeCode },
   } = useTranslation()
   const languageName = getLocalNames()[localeCode]
-  const appName = env.IN_APP_NAME || "PathCheck"
+  const { applicationName } = useApplicationName()
   useStatusBarEffect("dark-content")
 
   return (
@@ -40,7 +40,7 @@ const Welcome: FunctionComponent = () => {
         <GlobalText style={style.mainText}>
           {t("label.launch_screen1_header")}
         </GlobalText>
-        <GlobalText style={style.mainText}>{appName}</GlobalText>
+        <GlobalText style={style.mainText}>{applicationName}</GlobalText>
       </View>
       <Button
         label={t("label.launch_get_started")}


### PR DESCRIPTION
Why:
----
We have an IN_APP_NAME variable that will not be necessary, the app name should be uniform. For more context, the welcome message will become its own configuration and the IN_APP_NAME on the privacy part will be removed. This goes with a [PR] on the resources repo

This Commit:
----
- Removes usage of the IN_APP_NAME environment variable

[PR]: https://github.com/Path-Check/pathcheck-mobile-resources/pull/13
