### PR TITLE
Shorten exposure list screen title

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -231,6 +231,7 @@
   "screen_titles": {
     "about": "About",
     "debug": "Debug",
+    "exposures": "Exposures",
     "exposure_history": "Exposure History",
     "legal": "Legal",
     "report_issue": "Report an Issue"

--- a/src/navigation/MoreStack.tsx
+++ b/src/navigation/MoreStack.tsx
@@ -52,6 +52,7 @@ const MoreStack: FunctionComponent = () => {
       <Stack.Screen
         name={MoreStackScreens.ExposureListDebugScreen}
         component={ExposureListDebugScreen}
+        options={{ headerTitle: t("screen_titles.exposures") }}
       />
       <Stack.Screen
         name={MoreStackScreens.ENLocalDiagnosisKey}


### PR DESCRIPTION
Why:
The exposure list debug screen title was too long and had no spaces.

Co-Authored-By: devinjameson <devin@thoughtbot.com>