### PR TITLE
Allow onboarding to be reset for qa

### DIFF
--- a/src/Activation/ActivateProximityTracing.tsx
+++ b/src/Activation/ActivateProximityTracing.tsx
@@ -22,7 +22,7 @@ const ActivateProximityTracing: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
 
-  const { setOnboardingToComplete } = useOnboardingContext()
+  const { completeOnboarding } = useOnboardingContext()
   const { exposureNotifications } = usePermissionsContext()
 
   const handleOnPressEnable = () => {
@@ -38,7 +38,7 @@ const ActivateProximityTracing: FunctionComponent = () => {
     if (Platform.OS === "ios") {
       navigation.navigate(ActivationScreens.NotificationPermissions)
     } else {
-      setOnboardingToComplete()
+      completeOnboarding()
     }
   }
 

--- a/src/Activation/NotificationPermissions.tsx
+++ b/src/Activation/NotificationPermissions.tsx
@@ -18,7 +18,7 @@ import { Colors, Spacing, Typography, Buttons } from "../styles"
 const NotificationsPermissions: FunctionComponent = () => {
   const { t } = useTranslation()
   const { notification } = usePermissionsContext()
-  const { setOnboardingToComplete } = useOnboardingContext()
+  const { completeOnboarding } = useOnboardingContext()
 
   const requestPermission = async () => {
     await notification.request()
@@ -26,11 +26,11 @@ const NotificationsPermissions: FunctionComponent = () => {
 
   const handleOnPressEnable = async () => {
     await requestPermission()
-    setOnboardingToComplete()
+    completeOnboarding()
   }
 
   const handleOnPressMaybeLater = () => {
-    setOnboardingToComplete()
+    completeOnboarding()
   }
 
   return (

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native"
 
 import { GlobalText } from "../components/GlobalText"
+import { useOnboardingContext } from "../OnboardingContext"
 import { NativeModule } from "../gaen"
 import { NavigationProp, Screens } from "../navigation"
 
@@ -22,6 +23,7 @@ type ENDebugMenuProps = {
 
 const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
   const [loading, setLoading] = useState(false)
+  const { resetOnboarding } = useOnboardingContext()
 
   useEffect(() => {
     const handleBackPress = () => {
@@ -70,6 +72,11 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
       }
     }
   }
+
+  const handleOnPressRestartOnboarding = () => {
+    resetOnboarding()
+  }
+
   interface DebugMenuListItemProps {
     label: string
     onPress: () => void
@@ -120,6 +127,10 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
               onPress={() => {
                 NativeModule.forceAppCrash()
               }}
+            />
+            <DebugMenuListItem
+              label="Restart Onboarding"
+              onPress={handleOnPressRestartOnboarding}
             />
           </View>
           {__DEV__ ? (

--- a/src/OnboardingContext.tsx
+++ b/src/OnboardingContext.tsx
@@ -11,6 +11,16 @@ export const onboardingHasBeenCompleted = async (): Promise<boolean> => {
   return await StorageUtils.getIsOnboardingComplete()
 }
 
+const OnboardingContext = createContext<OnboardingContextState | undefined>(
+  undefined,
+)
+
+interface OnboardingContextState {
+  onboardingIsComplete: boolean
+  completeOnboarding: () => void
+  resetOnboarding: () => void
+}
+
 interface OnboardingProviderProps {
   userHasCompletedOboarding: boolean
 }
@@ -23,27 +33,23 @@ export const OnboardingProvider: FunctionComponent<OnboardingProviderProps> = ({
     userHasCompletedOboarding,
   )
 
-  const setOnboardingToComplete = () => {
+  const completeOnboarding = () => {
     StorageUtils.setIsOnboardingComplete()
     setOnboardingIsComplete(true)
   }
 
+  const resetOnboarding = () => {
+    StorageUtils.removeIsOnboardingComplete()
+    setOnboardingIsComplete(false)
+  }
+
   return (
     <OnboardingContext.Provider
-      value={{ onboardingIsComplete, setOnboardingToComplete }}
+      value={{ onboardingIsComplete, completeOnboarding, resetOnboarding }}
     >
       {children}
     </OnboardingContext.Provider>
   )
-}
-
-const OnboardingContext = createContext<OnboardingContextState | undefined>(
-  undefined,
-)
-
-interface OnboardingContextState {
-  onboardingIsComplete: boolean
-  setOnboardingToComplete: () => void
 }
 
 export const useOnboardingContext = (): OnboardingContextState => {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -17,6 +17,14 @@ async function setStoreData(key: string, item: string): Promise<void> {
   }
 }
 
+async function removeStoreData(key: string): Promise<void> {
+  try {
+    return await AsyncStorage.removeItem(key)
+  } catch (error) {
+    console.log(error.message)
+  }
+}
+
 const LANG_OVERRIDE = "LANG_OVERRIDE"
 export async function getUserLocaleOverride(): Promise<string | null> {
   return await getStoreData(LANG_OVERRIDE)
@@ -34,4 +42,8 @@ export async function getIsOnboardingComplete(): Promise<boolean> {
 
 export async function setIsOnboardingComplete(): Promise<void> {
   return setStoreData(ONBOARDING_COMPLETE, ONBOARDING_COMPLETE)
+}
+
+export async function removeIsOnboardingComplete(): Promise<void> {
+  return removeStoreData(ONBOARDING_COMPLETE)
 }


### PR DESCRIPTION
Why:
Currently once a user has gone through the onboarding process the only
way to redo the onboarding is to delete and reinstall the app. This is
tedious for programmers and testers. We would like a more streamlined
way to exercise the onboarding flow multiple times.

This commit:
Introduces the logic to reset the onboarding state to the onboarding
provider and adds a button on the debug screen to invoke the logic.

Co-Authored-By: devinjameson <devin@thoughtbot.com>
Co-Authored-By: achen178 <achen178@gmail.com>
