### PR TITLE
Create and implement gradient variables

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -41,19 +41,14 @@ export const Button: FunctionComponent<ButtonProps> = ({
   const { t } = useTranslation()
 
   const determineGradient = (): string[] => {
-    const baseGradient = [Colors.primary125, Colors.primary100]
-    const disabledGradient = [Colors.secondary75, Colors.secondary75]
-    const invertedGradient = [Colors.secondary100, Colors.white]
-    const invertedDisabledGradient = [Colors.neutral100, Colors.neutral30]
-
     if (invert && (disabled || loading)) {
-      return invertedDisabledGradient
+      return Colors.gradientNeutral75
     } else if (invert && !(disabled || loading)) {
-      return invertedGradient
+      return Colors.gradientPrimary10
     } else if (!invert && (disabled || loading)) {
-      return disabledGradient
+      return [Colors.secondary75, Colors.secondary75]
     } else {
-      return baseGradient
+      return Colors.gradientPrimary110
     }
   }
 

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -35,8 +35,14 @@ export const danger75 = "#ff7d7d"
 export const danger100 = "#ff5656"
 export const success100 = "#41dca4"
 export const warning25 = "#f9edcc"
-export const warning50 = "#f8f8ff"
-export const warning100 = "#e5e7fa"
+export const warning50 = "#ffdc6f"
+export const warning100 = "#ffc000"
+
+// Gradients
+export const gradientPrimary10 = ["#ececff", "#ffffff"]
+export const gradientPrimary100 = ["#3a4cd7", "#6979f8"]
+export const gradientPrimary110 = ["#4051db", "#6e50e4"]
+export const gradientNeutral75 = ["#3c475b", "#9ba0aa"]
 
 // Transparent
 export const transparent = "rgba(0, 0, 0, 0)"


### PR DESCRIPTION
Why:
The current app does not implement the proper gradients for buttons as per the design files. To keep consistency within the code base, gradient variables were added into the color styles file. 

This commit:
- Adds gradient variables within the color styles
- Fixes two color declarations that were incorrect

#### Screenshots:
![Simulator Screen Shot - iPhone 8 - 2020-08-18 at 17 59 46](https://user-images.githubusercontent.com/32882075/90570212-3f74c400-e17d-11ea-9b1c-b52db29a7ac1.png)
