### PR TITLE
Enable testers to go through AffectedUserFlow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import {
   OnboardingProvider,
   onboardingHasBeenCompleted,
 } from "./src/OnboardingContext"
+import { TestModeProvider } from "./src/TestModeContext"
 import { PermissionsProvider } from "./src/PermissionsContext"
 import { initializei18next, loadUserLocale } from "./src/locales/languages"
 
@@ -36,13 +37,17 @@ const App: FunctionComponent = () => {
     <>
       {!isLoading ? (
         <ErrorBoundary>
-          <OnboardingProvider userHasCompletedOboarding={onboardingIsComplete}>
-            <PermissionsProvider>
-              <ExposureProvider>
-                <MainNavigator />
-              </ExposureProvider>
-            </PermissionsProvider>
-          </OnboardingProvider>
+          <TestModeProvider>
+            <OnboardingProvider
+              userHasCompletedOboarding={onboardingIsComplete}
+            >
+              <PermissionsProvider>
+                <ExposureProvider>
+                  <MainNavigator />
+                </ExposureProvider>
+              </PermissionsProvider>
+            </OnboardingProvider>
+          </TestModeProvider>
         </ErrorBoundary>
       ) : null}
     </>

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from "@react-navigation/native"
 
 import CodeInputForm from "./CodeInputForm"
 import { AffectedUserProvider } from "../AffectedUserContext"
+import { TestModeProvider } from "../../TestModeContext"
 import * as API from "../verificationAPI"
 import * as Hmac from "../hmac"
 import { Screens } from "../../navigation"
@@ -16,9 +17,11 @@ jest.mock("@react-navigation/native")
 describe("CodeInputForm", () => {
   it("initializes with an empty code form", () => {
     const { getByTestId } = render(
-      <AffectedUserProvider>
-        <CodeInputForm />
-      </AffectedUserProvider>,
+      <TestModeProvider>
+        <AffectedUserProvider>
+          <CodeInputForm />
+        </AffectedUserProvider>
+      </TestModeProvider>,
     )
 
     expect(getByTestId("affected-user-code-input-form")).not.toBeNull()
@@ -29,9 +32,11 @@ describe("CodeInputForm", () => {
     const navigateSpy = jest.fn()
     ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
     const { getByLabelText } = render(
-      <AffectedUserProvider>
-        <CodeInputForm />
-      </AffectedUserProvider>,
+      <TestModeProvider>
+        <AffectedUserProvider>
+          <CodeInputForm />
+        </AffectedUserProvider>
+      </TestModeProvider>,
     )
 
     fireEvent.press(getByLabelText("Cancel"))
@@ -75,11 +80,13 @@ describe("CodeInputForm", () => {
       const exposureContext = factories.exposureContext.build()
 
       const { getByTestId, getByLabelText } = render(
-        <ExposureContext.Provider value={exposureContext}>
-          <AffectedUserProvider>
-            <CodeInputForm />
-          </AffectedUserProvider>
-        </ExposureContext.Provider>,
+        <TestModeProvider>
+          <ExposureContext.Provider value={exposureContext}>
+            <AffectedUserProvider>
+              <CodeInputForm />
+            </AffectedUserProvider>
+          </ExposureContext.Provider>
+        </TestModeProvider>,
       )
       fireEvent.changeText(getByTestId("code-input"), code)
       fireEvent.press(getByLabelText("Next"))
@@ -120,11 +127,13 @@ describe("CodeInputForm", () => {
         .mockResolvedValueOnce(failureCertificateResponse)
 
       const { getByTestId, getByLabelText, getByText } = render(
-        <ExposureContext.Provider value={factories.exposureContext.build()}>
-          <AffectedUserProvider>
-            <CodeInputForm />
-          </AffectedUserProvider>
-        </ExposureContext.Provider>,
+        <TestModeProvider>
+          <ExposureContext.Provider value={factories.exposureContext.build()}>
+            <AffectedUserProvider>
+              <CodeInputForm />
+            </AffectedUserProvider>
+          </ExposureContext.Provider>
+        </TestModeProvider>,
       )
       fireEvent.changeText(getByTestId("code-input"), "12345678")
       fireEvent.press(getByLabelText("Next"))
@@ -146,9 +155,11 @@ describe("CodeInputForm", () => {
       jest.spyOn(API, "postCode").mockResolvedValueOnce(wrongTokenResponse)
 
       const { getByTestId, getByLabelText, getByText } = render(
-        <AffectedUserProvider>
-          <CodeInputForm />
-        </AffectedUserProvider>,
+        <TestModeProvider>
+          <AffectedUserProvider>
+            <CodeInputForm />
+          </AffectedUserProvider>
+        </TestModeProvider>,
       )
       fireEvent.changeText(getByTestId("code-input"), "12345678")
       fireEvent.press(getByLabelText("Next"))
@@ -167,9 +178,11 @@ describe("CodeInputForm", () => {
       jest.spyOn(API, "postCode").mockResolvedValueOnce(wrongTokenResponse)
 
       const { getByTestId, getByLabelText, getByText } = render(
-        <AffectedUserProvider>
-          <CodeInputForm />
-        </AffectedUserProvider>,
+        <TestModeProvider>
+          <AffectedUserProvider>
+            <CodeInputForm />
+          </AffectedUserProvider>
+        </TestModeProvider>,
       )
       fireEvent.changeText(getByTestId("code-input"), "12345678")
       fireEvent.press(getByLabelText("Next"))
@@ -190,9 +203,11 @@ describe("CodeInputForm", () => {
       jest.spyOn(API, "postCode").mockResolvedValueOnce(wrongTokenResponse)
 
       const { getByTestId, getByLabelText, getByText } = render(
-        <AffectedUserProvider>
-          <CodeInputForm />
-        </AffectedUserProvider>,
+        <TestModeProvider>
+          <AffectedUserProvider>
+            <CodeInputForm />
+          </AffectedUserProvider>
+        </TestModeProvider>,
       )
       fireEvent.changeText(getByTestId("code-input"), "12345678")
       fireEvent.press(getByLabelText("Next"))

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -6,11 +6,13 @@ import {
   TouchableOpacity,
   TextInput,
   View,
+  Button as RNButton,
   Keyboard,
 } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
+import { isTester } from "../../utils"
 
 import { GlobalText } from "../../components/GlobalText"
 import { Button } from "../../components/Button"
@@ -18,7 +20,7 @@ import { useAffectedUserContext } from "../AffectedUserContext"
 import * as API from "../verificationAPI"
 import { calculateHmac } from "../hmac"
 import { useExposureContext } from "../../ExposureContext"
-import { Screens } from "../../navigation"
+import { Screens, AffectedUserFlowScreens } from "../../navigation"
 
 import { Icons } from "../../assets"
 import {
@@ -63,6 +65,10 @@ const CodeInputForm: FunctionComponent = () => {
     navigation.navigate(Screens.Home)
   }
 
+  const handleOnPressNextScreen = () => {
+    navigation.navigate(AffectedUserFlowScreens.AffectedUserPublishConsent)
+  }
+
   const handleOnPressSubmit = async () => {
     setIsLoading(true)
     setErrorMessage(defaultErrorMessage)
@@ -80,7 +86,9 @@ const CodeInputForm: FunctionComponent = () => {
           const certificate = certResponse.body.certificate
           setExposureSubmissionCredentials(certificate, hmacKey)
           Keyboard.dismiss()
-          navigation.navigate(Screens.AffectedUserPublishConsent)
+          navigation.navigate(
+            AffectedUserFlowScreens.AffectedUserPublishConsent,
+          )
         } else {
           setErrorMessage(showCertificateError(certResponse.error))
         }
@@ -201,6 +209,13 @@ const CodeInputForm: FunctionComponent = () => {
         customButtonStyle={style.button}
         hasRightArrow
       />
+      {isTester && (
+        <RNButton
+          title="Go to next screen"
+          onPress={handleOnPressNextScreen}
+          color={Colors.danger100}
+        />
+      )}
     </View>
   )
 }

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -211,7 +211,7 @@ const CodeInputForm: FunctionComponent = () => {
       />
       {isTester && (
         <RNButton
-          title="Go to next screen"
+          title={t("common.go_to_next_screen")}
           onPress={handleOnPressNextScreen}
           color={Colors.danger100}
         />

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -12,7 +12,7 @@ import {
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
-import { isTester } from "../../utils"
+import { useTestModeContext } from "../../TestModeContext"
 
 import { GlobalText } from "../../components/GlobalText"
 import { Button } from "../../components/Button"
@@ -40,6 +40,7 @@ const CodeInputForm: FunctionComponent = () => {
   const navigation = useNavigation()
   const strategy = useExposureContext()
   const { setExposureSubmissionCredentials } = useAffectedUserContext()
+  const { testModeEnabled } = useTestModeContext()
 
   const [code, setCode] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -209,7 +210,7 @@ const CodeInputForm: FunctionComponent = () => {
         customButtonStyle={style.button}
         hasRightArrow
       />
-      {isTester && (
+      {testModeEnabled && (
         <RNButton
           title={t("common.go_to_next_screen")}
           onPress={handleOnPressNextScreen}

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
@@ -4,6 +4,7 @@ import "@testing-library/jest-native/extend-expect"
 
 import CodeInputScreen from "./CodeInputScreen"
 import { AffectedUserProvider } from "../AffectedUserContext"
+import { TestModeProvider } from "../../TestModeContext"
 import {
   PermissionsContext,
   ENPermissionStatus,
@@ -21,11 +22,13 @@ describe("CodeInputScreen", () => {
       )
 
       const { getByTestId, queryByTestId } = render(
-        <PermissionsContext.Provider value={permissionProviderValue}>
-          <AffectedUserProvider>
-            <CodeInputScreen />
-          </AffectedUserProvider>
-        </PermissionsContext.Provider>,
+        <TestModeProvider>
+          <PermissionsContext.Provider value={permissionProviderValue}>
+            <AffectedUserProvider>
+              <CodeInputScreen />
+            </AffectedUserProvider>
+          </PermissionsContext.Provider>
+        </TestModeProvider>,
       )
 
       expect(getByTestId("affected-user-code-input-form")).not.toBeNull()
@@ -43,11 +46,13 @@ describe("CodeInputScreen", () => {
       )
 
       const { getByTestId, queryByTestId } = render(
-        <PermissionsContext.Provider value={permissionProviderValue}>
-          <AffectedUserProvider>
-            <CodeInputScreen />
-          </AffectedUserProvider>
-        </PermissionsContext.Provider>,
+        <TestModeProvider>
+          <PermissionsContext.Provider value={permissionProviderValue}>
+            <AffectedUserProvider>
+              <CodeInputScreen />
+            </AffectedUserProvider>
+          </PermissionsContext.Provider>
+        </TestModeProvider>,
       )
 
       expect(queryByTestId("affected-user-code-input-form")).toBeNull()

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -1,14 +1,26 @@
-import React, { FunctionComponent } from "react"
-import { View, StyleSheet } from "react-native"
+import React, { useState, FunctionComponent } from "react"
+import { View, StyleSheet, Button as RNButton } from "react-native"
+import { useTranslation } from "react-i18next"
 
 import { usePermissionsContext, ENEnablement } from "../../PermissionsContext"
 import CodeInputForm from "./CodeInputForm"
 import EnableExposureNotifications from "./EnableExposureNotifications"
+import { useTestModeContext } from "../../TestModeContext"
 
 import { Colors } from "../../styles"
 
 const CodeInputScreen: FunctionComponent = () => {
+  const [
+    testerHasRequestedNextScreen,
+    setTesterHasRequestedNextScreen,
+  ] = useState(false)
+  const { t } = useTranslation()
   const { exposureNotifications } = usePermissionsContext()
+  const { testModeEnabled } = useTestModeContext()
+
+  const handleOnPressNextScreen = () => {
+    setTesterHasRequestedNextScreen(true)
+  }
 
   const hasExposureNotificationsEnabled = (): boolean => {
     const enabledState: ENEnablement = "ENABLED"
@@ -18,7 +30,18 @@ const CodeInputScreen: FunctionComponent = () => {
 
   return (
     <View style={style.container}>
-      {isEnabled ? <CodeInputForm /> : <EnableExposureNotifications />}
+      {isEnabled || testerHasRequestedNextScreen ? (
+        <CodeInputForm />
+      ) : (
+        <EnableExposureNotifications />
+      )}
+      {testModeEnabled && !testerHasRequestedNextScreen && (
+        <RNButton
+          title={t("common.go_to_next_screen")}
+          onPress={handleOnPressNextScreen}
+          color={Colors.danger100}
+        />
+      )}
     </View>
   )
 }

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -9,13 +9,14 @@ import { isTester } from "../../utils"
 import { Colors } from "../../styles"
 
 const CodeInputScreen: FunctionComponent = () => {
-  const [testerRequestsNextScreen, setTesterRequestsNextScreen] = useState(
-    false,
-  )
+  const [
+    testerHasRequestedNextScreen,
+    setTesterHasRequestedNextScreen,
+  ] = useState(false)
   const { exposureNotifications } = usePermissionsContext()
 
   const handleOnPressNextScreen = () => {
-    setTesterRequestsNextScreen(true)
+    setTesterHasRequestedNextScreen(true)
   }
 
   const hasExposureNotificationsEnabled = (): boolean => {
@@ -26,12 +27,12 @@ const CodeInputScreen: FunctionComponent = () => {
 
   return (
     <View style={style.container}>
-      {isEnabled || testerRequestsNextScreen ? (
+      {isEnabled || testerHasRequestedNextScreen ? (
         <CodeInputForm />
       ) : (
         <EnableExposureNotifications />
       )}
-      {isTester && testerRequestsNextScreen === false && (
+      {isTester && testerHasRequestedNextScreen === false && (
         <RNButton
           title="Go to next screen"
           onPress={handleOnPressNextScreen}

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -35,7 +35,7 @@ const CodeInputScreen: FunctionComponent = () => {
       ) : (
         <EnableExposureNotifications />
       )}
-      {testModeEnabled && testerHasRequestedNextScreen === false && (
+      {testModeEnabled && !testerHasRequestedNextScreen && (
         <RNButton
           title={t("common.go_to_next_screen")}
           onPress={handleOnPressNextScreen}

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -1,14 +1,22 @@
-import React, { FunctionComponent } from "react"
-import { View, StyleSheet } from "react-native"
+import React, { useState, FunctionComponent } from "react"
+import { View, StyleSheet, Button as RNButton } from "react-native"
 
 import { usePermissionsContext, ENEnablement } from "../../PermissionsContext"
 import CodeInputForm from "./CodeInputForm"
 import EnableExposureNotifications from "./EnableExposureNotifications"
+import { isTester } from "../../utils"
 
 import { Colors } from "../../styles"
 
 const CodeInputScreen: FunctionComponent = () => {
+  const [testerRequestsNextScreen, setTesterRequestsNextScreen] = useState(
+    false,
+  )
   const { exposureNotifications } = usePermissionsContext()
+
+  const handleOnPressNextScreen = () => {
+    setTesterRequestsNextScreen(true)
+  }
 
   const hasExposureNotificationsEnabled = (): boolean => {
     const enabledState: ENEnablement = "ENABLED"
@@ -18,7 +26,18 @@ const CodeInputScreen: FunctionComponent = () => {
 
   return (
     <View style={style.container}>
-      {isEnabled ? <CodeInputForm /> : <EnableExposureNotifications />}
+      {isEnabled || testerRequestsNextScreen ? (
+        <CodeInputForm />
+      ) : (
+        <EnableExposureNotifications />
+      )}
+      {isTester && testerRequestsNextScreen === false && (
+        <RNButton
+          title="Go to next screen"
+          onPress={handleOnPressNextScreen}
+          color={Colors.danger100}
+        />
+      )}
     </View>
   )
 }

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next"
 import { usePermissionsContext, ENEnablement } from "../../PermissionsContext"
 import CodeInputForm from "./CodeInputForm"
 import EnableExposureNotifications from "./EnableExposureNotifications"
-import { isTester } from "../../utils"
+import { useTestModeContext } from "../../TestModeContext"
 
 import { Colors } from "../../styles"
 
@@ -16,6 +16,7 @@ const CodeInputScreen: FunctionComponent = () => {
   ] = useState(false)
   const { t } = useTranslation()
   const { exposureNotifications } = usePermissionsContext()
+  const { testModeEnabled } = useTestModeContext()
 
   const handleOnPressNextScreen = () => {
     setTesterHasRequestedNextScreen(true)
@@ -34,7 +35,7 @@ const CodeInputScreen: FunctionComponent = () => {
       ) : (
         <EnableExposureNotifications />
       )}
-      {isTester && testerHasRequestedNextScreen === false && (
+      {testModeEnabled && testerHasRequestedNextScreen === false && (
         <RNButton
           title={t("common.go_to_next_screen")}
           onPress={handleOnPressNextScreen}

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -1,26 +1,14 @@
-import React, { useState, FunctionComponent } from "react"
-import { View, StyleSheet, Button as RNButton } from "react-native"
-import { useTranslation } from "react-i18next"
+import React, { FunctionComponent } from "react"
+import { View, StyleSheet } from "react-native"
 
 import { usePermissionsContext, ENEnablement } from "../../PermissionsContext"
 import CodeInputForm from "./CodeInputForm"
 import EnableExposureNotifications from "./EnableExposureNotifications"
-import { useTestModeContext } from "../../TestModeContext"
 
 import { Colors } from "../../styles"
 
 const CodeInputScreen: FunctionComponent = () => {
-  const [
-    testerHasRequestedNextScreen,
-    setTesterHasRequestedNextScreen,
-  ] = useState(false)
-  const { t } = useTranslation()
   const { exposureNotifications } = usePermissionsContext()
-  const { testModeEnabled } = useTestModeContext()
-
-  const handleOnPressNextScreen = () => {
-    setTesterHasRequestedNextScreen(true)
-  }
 
   const hasExposureNotificationsEnabled = (): boolean => {
     const enabledState: ENEnablement = "ENABLED"
@@ -30,18 +18,7 @@ const CodeInputScreen: FunctionComponent = () => {
 
   return (
     <View style={style.container}>
-      {isEnabled || testerHasRequestedNextScreen ? (
-        <CodeInputForm />
-      ) : (
-        <EnableExposureNotifications />
-      )}
-      {testModeEnabled && !testerHasRequestedNextScreen && (
-        <RNButton
-          title={t("common.go_to_next_screen")}
-          onPress={handleOnPressNextScreen}
-          color={Colors.danger100}
-        />
-      )}
+      {isEnabled ? <CodeInputForm /> : <EnableExposureNotifications />}
     </View>
   )
 }

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, FunctionComponent } from "react"
 import { View, StyleSheet, Button as RNButton } from "react-native"
+import { useTranslation } from "react-i18next"
 
 import { usePermissionsContext, ENEnablement } from "../../PermissionsContext"
 import CodeInputForm from "./CodeInputForm"
@@ -13,6 +14,7 @@ const CodeInputScreen: FunctionComponent = () => {
     testerHasRequestedNextScreen,
     setTesterHasRequestedNextScreen,
   ] = useState(false)
+  const { t } = useTranslation()
   const { exposureNotifications } = usePermissionsContext()
 
   const handleOnPressNextScreen = () => {
@@ -34,7 +36,7 @@ const CodeInputScreen: FunctionComponent = () => {
       )}
       {isTester && testerHasRequestedNextScreen === false && (
         <RNButton
-          title="Go to next screen"
+          title={t("common.go_to_next_screen")}
           onPress={handleOnPressNextScreen}
           color={Colors.danger100}
         />

--- a/src/AffectedUserFlow/Complete.tsx
+++ b/src/AffectedUserFlow/Complete.tsx
@@ -9,7 +9,7 @@ import { Button } from "../components/Button"
 import { Screens } from "../navigation"
 
 import { Images } from "../assets"
-import { Layout, Spacing, Typography } from "../styles"
+import { Colors, Layout, Spacing, Typography } from "../styles"
 
 export const ExportComplete: FunctionComponent = () => {
   useStatusBarEffect("dark-content")
@@ -37,6 +37,7 @@ const style = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
+    backgroundColor: Colors.primaryLightBackground,
     paddingTop: Layout.oneTwentiethHeight,
     paddingBottom: Spacing.xxHuge,
     paddingHorizontal: Spacing.large,

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -6,6 +6,7 @@ import { useNavigation } from "@react-navigation/native"
 import PublishConsentForm from "./PublishConsentForm"
 import { Screens } from "../../navigation"
 import { ExposureContext } from "../../ExposureContext"
+import { TestModeProvider } from "../../TestModeContext"
 import { factories } from "../../factories"
 import { Alert } from "react-native"
 
@@ -16,9 +17,11 @@ describe("PublishConsentScreen", () => {
     const navigateSpy = jest.fn()
     ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
     const { getByLabelText } = render(
-      <ExposureContext.Provider value={factories.exposureContext.build()}>
-        <PublishConsentForm hmacKey="hmacKey" certificate="certificate" />
-      </ExposureContext.Provider>,
+      <TestModeProvider>
+        <ExposureContext.Provider value={factories.exposureContext.build()}>
+          <PublishConsentForm hmacKey="hmacKey" certificate="certificate" />
+        </ExposureContext.Provider>
+      </TestModeProvider>,
     )
 
     fireEvent.press(getByLabelText("Cancel"))
@@ -28,9 +31,11 @@ describe("PublishConsentScreen", () => {
 
   it("displays the consent title and body", () => {
     const { getByText } = render(
-      <ExposureContext.Provider value={factories.exposureContext.build()}>
-        <PublishConsentForm hmacKey="hmacKey" certificate="certificate" />
-      </ExposureContext.Provider>,
+      <TestModeProvider>
+        <ExposureContext.Provider value={factories.exposureContext.build()}>
+          <PublishConsentForm hmacKey="hmacKey" certificate="certificate" />
+        </ExposureContext.Provider>
+      </TestModeProvider>,
     )
 
     expect(getByText("Notify others in your community")).toBeDefined()
@@ -64,9 +69,11 @@ describe("PublishConsentScreen", () => {
       })
 
       const { getByLabelText } = render(
-        <ExposureContext.Provider value={exposureContext}>
-          <PublishConsentForm hmacKey={hmacKey} certificate={certificate} />
-        </ExposureContext.Provider>,
+        <TestModeProvider>
+          <ExposureContext.Provider value={exposureContext}>
+            <PublishConsentForm hmacKey={hmacKey} certificate={certificate} />
+          </ExposureContext.Provider>
+        </TestModeProvider>,
       )
 
       fireEvent.press(getByLabelText("I Understand and Consent"))
@@ -92,9 +99,11 @@ describe("PublishConsentScreen", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
 
       const { getByLabelText } = render(
-        <ExposureContext.Provider value={exposureContext}>
-          <PublishConsentForm hmacKey={hmacKey} certificate={certificate} />
-        </ExposureContext.Provider>,
+        <TestModeProvider>
+          <ExposureContext.Provider value={exposureContext}>
+            <PublishConsentForm hmacKey={hmacKey} certificate={certificate} />
+          </ExposureContext.Provider>
+        </TestModeProvider>,
       )
 
       fireEvent.press(getByLabelText("I Understand and Consent"))

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -11,7 +11,7 @@ import {
 import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
-import { isTester } from "../../utils"
+import { useTestModeContext } from "../../TestModeContext"
 
 import { Button } from "../../components/Button"
 import { GlobalText } from "../../components/GlobalText"
@@ -44,6 +44,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
   const strategy = useExposureContext()
   const navigation = useNavigation()
   const { t } = useTranslation()
+  const { testModeEnabled } = useTestModeContext()
   const [isLoading, setIsLoading] = useState(false)
   const handleOnPressConfirm = async () => {
     setIsLoading(true)
@@ -143,7 +144,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
               onPress={handleOnPressConfirm}
               customButtonStyle={style.button}
             />
-            {isTester && (
+            {testModeEnabled && (
               <RNButton
                 title={t("common.go_to_next_screen")}
                 onPress={handleOnPressNextScreen}

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -145,7 +145,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
             />
             {isTester && (
               <RNButton
-                title="Go to next screen"
+                title={t("common.go_to_next_screen")}
                 onPress={handleOnPressNextScreen}
                 color={Colors.danger100}
               />

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -5,11 +5,13 @@ import {
   Alert,
   TouchableOpacity,
   StyleSheet,
+  Button as RNButton,
   View,
 } from "react-native"
 import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
+import { isTester } from "../../utils"
 
 import { Button } from "../../components/Button"
 import { GlobalText } from "../../components/GlobalText"
@@ -66,6 +68,10 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
 
   const handleOnPressProtectPrivacy = () => {
     navigation.navigate(AffectedUserFlowScreens.ProtectPrivacy)
+  }
+
+  const handleOnPressNextScreen = () => {
+    navigation.navigate(AffectedUserFlowScreens.AffectedUserComplete)
   }
 
   return (
@@ -137,6 +143,13 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
               onPress={handleOnPressConfirm}
               customButtonStyle={style.button}
             />
+            {isTester && (
+              <RNButton
+                title="Go to next screen"
+                onPress={handleOnPressNextScreen}
+                color={Colors.danger100}
+              />
+            )}
           </ScrollView>
           <TouchableOpacity
             style={style.bottomButtonContainer}

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.spec.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from "@testing-library/react-native"
 import { useNavigation } from "@react-navigation/native"
 
 import { AffectedUserContext } from "../AffectedUserContext"
+import { TestModeProvider } from "../../TestModeContext"
 import PublishConsentScreen from "./PublishConsentScreen"
 
 jest.mock("@react-navigation/native")
@@ -11,15 +12,17 @@ describe("PublishConsentScreen", () => {
   describe("when the context contains hmacKey and certificate", () => {
     it("renders the PublishConsentForm", () => {
       const { queryByText, getByTestId } = render(
-        <AffectedUserContext.Provider
-          value={{
-            hmacKey: "hmacKey",
-            certificate: "certificate",
-            setExposureSubmissionCredentials: jest.fn(),
-          }}
-        >
-          <PublishConsentScreen />
-        </AffectedUserContext.Provider>,
+        <TestModeProvider>
+          <AffectedUserContext.Provider
+            value={{
+              hmacKey: "hmacKey",
+              certificate: "certificate",
+              setExposureSubmissionCredentials: jest.fn(),
+            }}
+          >
+            <PublishConsentScreen />
+          </AffectedUserContext.Provider>
+        </TestModeProvider>,
       )
 
       expect(queryByText("Invalid State")).toBeNull()
@@ -32,15 +35,17 @@ describe("PublishConsentScreen", () => {
       const navigateSpy = jest.fn()
       ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
       const { getByText } = render(
-        <AffectedUserContext.Provider
-          value={{
-            hmacKey: null,
-            certificate: null,
-            setExposureSubmissionCredentials: jest.fn(),
-          }}
-        >
-          <PublishConsentScreen />
-        </AffectedUserContext.Provider>,
+        <TestModeProvider>
+          <AffectedUserContext.Provider
+            value={{
+              hmacKey: null,
+              certificate: null,
+              setExposureSubmissionCredentials: jest.fn(),
+            }}
+          >
+            <PublishConsentScreen />
+          </AffectedUserContext.Provider>
+        </TestModeProvider>,
       )
 
       expect(getByText("Invalid State")).toBeDefined()

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
@@ -1,23 +1,35 @@
-import React, { FunctionComponent } from "react"
-import { View, Text, Button } from "react-native"
+import React, { FunctionComponent, useEffect } from "react"
+import { StyleSheet, View, Text, Button as RNButton } from "react-native"
 import { useNavigation } from "@react-navigation/native"
+import { isTester } from "../../utils"
 
 import { useStatusBarEffect, Screens } from "../../navigation"
 import { useAffectedUserContext } from "../AffectedUserContext"
 import PublishConsentForm from "./PublishConsentForm"
 
 const PublishConsentScreen: FunctionComponent = () => {
-  useStatusBarEffect("light-content")
+  useStatusBarEffect("dark-content")
   const navigation = useNavigation()
-  const { certificate, hmacKey } = useAffectedUserContext()
+  const {
+    certificate,
+    hmacKey,
+    setExposureSubmissionCredentials,
+  } = useAffectedUserContext()
+
+  useEffect(() => {
+    {
+      isTester &&
+        setExposureSubmissionCredentials("fakeCertificate", "fakeHmac")
+    }
+  })
 
   if (hmacKey && certificate) {
     return <PublishConsentForm hmacKey={hmacKey} certificate={certificate} />
   } else {
     return (
-      <View>
+      <View style={style.container}>
         <Text>Invalid State</Text>
-        <Button
+        <RNButton
           onPress={() => {
             navigation.navigate(Screens.Home)
           }}
@@ -27,5 +39,13 @@ const PublishConsentScreen: FunctionComponent = () => {
     )
   }
 }
+
+const style = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+})
 
 export default PublishConsentScreen

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useEffect } from "react"
 import { StyleSheet, View, Text, Button as RNButton } from "react-native"
 import { useNavigation } from "@react-navigation/native"
-import { isTester } from "../../utils"
+import { useTestModeContext } from "../../TestModeContext"
 
 import { useStatusBarEffect, Screens } from "../../navigation"
 import { useAffectedUserContext } from "../AffectedUserContext"
@@ -10,6 +10,7 @@ import PublishConsentForm from "./PublishConsentForm"
 const PublishConsentScreen: FunctionComponent = () => {
   useStatusBarEffect("dark-content")
   const navigation = useNavigation()
+  const { testModeEnabled } = useTestModeContext()
   const {
     certificate,
     hmacKey,
@@ -18,7 +19,7 @@ const PublishConsentScreen: FunctionComponent = () => {
 
   useEffect(() => {
     {
-      isTester &&
+      testModeEnabled &&
         setExposureSubmissionCredentials("fakeCertificate", "fakeHmac")
     }
   })

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
@@ -18,10 +18,8 @@ const PublishConsentScreen: FunctionComponent = () => {
   } = useAffectedUserContext()
 
   useEffect(() => {
-    {
-      testModeEnabled &&
-        setExposureSubmissionCredentials("fakeCertificate", "fakeHmac")
-    }
+    testModeEnabled &&
+      setExposureSubmissionCredentials("fakeCertificate", "fakeHmac")
   })
 
   if (hmacKey && certificate) {

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -98,6 +98,8 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
     )
   }
 
+  const testModeText = "Test Mode"
+
   return (
     <>
       {loading ? (
@@ -131,14 +133,8 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
                 NativeModule.forceAppCrash()
               }}
             />
-            <DebugMenuListItem
-              label="Restart Onboarding"
-              onPress={handleOnPressRestartOnboarding}
-            />
-            <TouchableOpacity style={style.listItem}>
-              <GlobalText style={style.listItemText}>
-                {"Toggle Test Mode"}
-              </GlobalText>
+            <TouchableOpacity style={style.listItemWithSwitch}>
+              <GlobalText style={style.listItemText}>{testModeText}</GlobalText>
               <Switch
                 trackColor={{
                   false: Colors.neutral110,
@@ -146,8 +142,14 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
                 }}
                 onValueChange={toggleTestModeEnabled}
                 value={testModeEnabled}
+                style={style.switch}
               />
             </TouchableOpacity>
+            <DebugMenuListItem
+              label="Restart Onboarding"
+              onPress={handleOnPressRestartOnboarding}
+              itemStyle={style.lastListItem}
+            />
           </View>
           {__DEV__ ? (
             <View style={style.section}>
@@ -203,6 +205,16 @@ const style = StyleSheet.create({
     paddingVertical: Spacing.medium,
     borderBottomWidth: Outlines.hairline,
     borderColor: Colors.secondary75,
+  },
+  listItemWithSwitch: {
+    justifyContent: "space-between",
+    flexDirection: "row",
+    paddingVertical: Spacing.medium,
+    borderBottomWidth: Outlines.hairline,
+    borderColor: Colors.secondary75,
+  },
+  switch: {
+    marginRight: Spacing.xSmall,
   },
   listItemText: {
     ...Typography.mainContent,

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -3,6 +3,7 @@ import {
   View,
   ViewStyle,
   TouchableOpacity,
+  Switch,
   StyleSheet,
   Alert,
   BackHandler,
@@ -14,6 +15,7 @@ import { GlobalText } from "../components/GlobalText"
 import { useOnboardingContext } from "../OnboardingContext"
 import { NativeModule } from "../gaen"
 import { NavigationProp, Screens } from "../navigation"
+import { useTestModeContext } from "../TestModeContext"
 
 import { Colors, Spacing, Typography, Outlines } from "../styles"
 
@@ -24,6 +26,7 @@ type ENDebugMenuProps = {
 const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
   const [loading, setLoading] = useState(false)
   const { resetOnboarding } = useOnboardingContext()
+  const { testModeEnabled, toggleTestModeEnabled } = useTestModeContext()
 
   useEffect(() => {
     const handleBackPress = () => {
@@ -132,6 +135,19 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
               label="Restart Onboarding"
               onPress={handleOnPressRestartOnboarding}
             />
+            <TouchableOpacity style={style.listItem}>
+              <GlobalText style={style.listItemText}>
+                {"Toggle Test Mode"}
+              </GlobalText>
+              <Switch
+                trackColor={{
+                  false: Colors.neutral110,
+                  true: Colors.success100,
+                }}
+                onValueChange={toggleTestModeEnabled}
+                value={testModeEnabled}
+              />
+            </TouchableOpacity>
           </View>
           {__DEV__ ? (
             <View style={style.section}>
@@ -176,7 +192,6 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
 
 const style = StyleSheet.create({
   section: {
-    flex: 1,
     backgroundColor: Colors.primaryLightBackground,
     paddingHorizontal: Spacing.small,
     marginBottom: Spacing.medium,
@@ -185,7 +200,6 @@ const style = StyleSheet.create({
     borderColor: Colors.secondary75,
   },
   listItem: {
-    flex: 1,
     paddingVertical: Spacing.medium,
     borderBottomWidth: Outlines.hairline,
     borderColor: Colors.secondary75,

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -207,8 +207,9 @@ const style = StyleSheet.create({
     borderColor: Colors.secondary75,
   },
   listItemWithSwitch: {
-    justifyContent: "space-between",
     flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     paddingVertical: Spacing.medium,
     borderBottomWidth: Outlines.hairline,
     borderColor: Colors.secondary75,

--- a/src/TestModeContext.tsx
+++ b/src/TestModeContext.tsx
@@ -1,0 +1,39 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  FunctionComponent,
+} from "react"
+
+const TestModeContext = createContext<TestModeContextState | undefined>(
+  undefined,
+)
+
+interface TestModeContextState {
+  testModeEnabled: boolean
+  toggleTestModeEnabled: () => void
+}
+
+export const TestModeProvider: FunctionComponent = ({ children }) => {
+  const [testModeEnabled, setTestModeEnabled] = useState(false)
+
+  const toggleTestModeEnabled = () => {
+    setTestModeEnabled(!testModeEnabled)
+  }
+
+  return (
+    <TestModeContext.Provider
+      value={{ testModeEnabled, toggleTestModeEnabled }}
+    >
+      {children}
+    </TestModeContext.Provider>
+  )
+}
+
+export const useTestModeContext = (): TestModeContextState => {
+  const context = useContext(TestModeContext)
+  if (context === undefined) {
+    throw new Error("TestModeContext must be used with a provider")
+  }
+  return context
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,6 +47,7 @@
     "disabled": "Disabled",
     "done": "Done",
     "enabled": "Enabled",
+    "go_to_next_screen":"Go to next screen",
     "maybe_later": "Maybe later",
     "next": "Next",
     "no_thanks": "No thanks",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,7 +47,7 @@
     "disabled": "Disabled",
     "done": "Done",
     "enabled": "Enabled",
-    "go_to_next_screen":"Go to next screen",
+    "go_to_next_screen": "Go to next screen",
     "maybe_later": "Maybe later",
     "next": "Next",
     "no_thanks": "No thanks",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,4 @@
 import { Platform } from "react-native"
-import env from "react-native-config"
 
 import * as DateTimeUtils from "./dateTime"
 import * as StorageUtils from "./storage"
@@ -12,14 +11,4 @@ const isPlatformAndroid = (): boolean => {
   return Platform.OS === "android"
 }
 
-const isTester = (): boolean => {
-  return env.DEV === "TRUE"
-}
-
-export {
-  DateTimeUtils,
-  StorageUtils,
-  isPlatformiOS,
-  isPlatformAndroid,
-  isTester,
-}
+export { DateTimeUtils, StorageUtils, isPlatformiOS, isPlatformAndroid }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { Platform } from "react-native"
+import env from "react-native-config"
 
 import * as DateTimeUtils from "./dateTime"
 import * as StorageUtils from "./storage"
@@ -11,4 +12,14 @@ const isPlatformAndroid = (): boolean => {
   return Platform.OS === "android"
 }
 
-export { DateTimeUtils, StorageUtils, isPlatformiOS, isPlatformAndroid }
+const isTester = (): boolean => {
+  return env.DEV === "TRUE"
+}
+
+export {
+  DateTimeUtils,
+  StorageUtils,
+  isPlatformiOS,
+  isPlatformAndroid,
+  isTester,
+}


### PR DESCRIPTION
Why: as a tester, I would like to be able to test the AffectedUserFlow without actually submitting a verification code.

This commit:
- Creates a TestModeContext that holds the test mode state
- Adds buttons to the AffectedUserFlow, that are only visible in test mode, which enable a tester to see each screen

![testmode](https://user-images.githubusercontent.com/39350030/90672730-91245980-e224-11ea-8268-d5fafd5127f2.gif)