### PR TITLE
Refactor PermissionsContext

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
@@ -16,8 +16,8 @@ describe("CodeInputScreen", () => {
   describe("when the user has exposure notifications enabled", () => {
     it("shows the CodeInputForm", () => {
       const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-        authorization: true,
-        enablement: true,
+        authorized: true,
+        enabled: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
         isENAuthorizedAndEnabled,
@@ -41,8 +41,8 @@ describe("CodeInputScreen", () => {
   describe("when the user does not have exposure notifications enabled", () => {
     it("shows the EnableExposureNotifications screen", () => {
       const isEnAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-        authorization: true,
-        enablement: false,
+        authorized: true,
+        enabled: false,
       }
       const permissionProviderValue = createPermissionProviderValue(
         isEnAuthorizedAndEnabled,

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
@@ -6,7 +6,7 @@ import CodeInputScreen from "./CodeInputScreen"
 import { AffectedUserProvider } from "../AffectedUserContext"
 import {
   PermissionsContext,
-  ENPermissionStatus,
+  ENActivationStatus,
 } from "../../PermissionsContext"
 import { PermissionStatus } from "../../permissionStatus"
 
@@ -15,7 +15,10 @@ jest.mock("@react-navigation/native")
 describe("CodeInputScreen", () => {
   describe("when the user has exposure notifications enabled", () => {
     it("shows the CodeInputForm", () => {
-      const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
+      const enPermissionStatus: ENActivationStatus = {
+        authorization: true,
+        enablement: true,
+      }
       const permissionProviderValue = createPermissionProviderValue(
         enPermissionStatus,
       )
@@ -37,7 +40,10 @@ describe("CodeInputScreen", () => {
 
   describe("when the user does not have exposure notifications enabled", () => {
     it("shows the EnableExposureNotifications screen", () => {
-      const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "DISABLED"]
+      const enPermissionStatus: ENActivationStatus = {
+        authorization: true,
+        enablement: false,
+      }
       const permissionProviderValue = createPermissionProviderValue(
         enPermissionStatus,
       )
@@ -59,7 +65,7 @@ describe("CodeInputScreen", () => {
 })
 
 const createPermissionProviderValue = (
-  enPermissionStatus: ENPermissionStatus,
+  enActivationStatus: ENActivationStatus,
 ) => {
   return {
     notification: {
@@ -68,7 +74,7 @@ const createPermissionProviderValue = (
       request: () => {},
     },
     exposureNotifications: {
-      status: enPermissionStatus,
+      status: enActivationStatus,
       check: () => {},
       request: () => {},
     },

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
@@ -6,7 +6,7 @@ import CodeInputScreen from "./CodeInputScreen"
 import { AffectedUserProvider } from "../AffectedUserContext"
 import {
   PermissionsContext,
-  ENActivationStatus,
+  ENAuthorizationEnablementStatus,
 } from "../../PermissionsContext"
 import { PermissionStatus } from "../../permissionStatus"
 
@@ -15,12 +15,12 @@ jest.mock("@react-navigation/native")
 describe("CodeInputScreen", () => {
   describe("when the user has exposure notifications enabled", () => {
     it("shows the CodeInputForm", () => {
-      const enPermissionStatus: ENActivationStatus = {
+      const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
         authorization: true,
         enablement: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
-        enPermissionStatus,
+        isENAuthorizedAndEnabled,
       )
 
       const { getByTestId, queryByTestId } = render(
@@ -40,12 +40,12 @@ describe("CodeInputScreen", () => {
 
   describe("when the user does not have exposure notifications enabled", () => {
     it("shows the EnableExposureNotifications screen", () => {
-      const enPermissionStatus: ENActivationStatus = {
+      const isEnAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
         authorization: true,
         enablement: false,
       }
       const permissionProviderValue = createPermissionProviderValue(
-        enPermissionStatus,
+        isEnAuthorizedAndEnabled,
       )
 
       const { getByTestId, queryByTestId } = render(
@@ -65,7 +65,7 @@ describe("CodeInputScreen", () => {
 })
 
 const createPermissionProviderValue = (
-  enActivationStatus: ENActivationStatus,
+  isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus,
 ) => {
   return {
     notification: {
@@ -74,7 +74,7 @@ const createPermissionProviderValue = (
       request: () => {},
     },
     exposureNotifications: {
-      status: enActivationStatus,
+      status: isENAuthorizedAndEnabled,
       check: () => {},
       request: () => {},
     },

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -10,7 +10,7 @@ import { Colors } from "../../styles"
 const CodeInputScreen: FunctionComponent = () => {
   const { exposureNotifications } = usePermissionsContext()
 
-  const isEnabled = exposureNotifications.status.authorization
+  const isEnabled = exposureNotifications.status.enablement
 
   return (
     <View style={style.container}>

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -10,7 +10,7 @@ import { Colors } from "../../styles"
 const CodeInputScreen: FunctionComponent = () => {
   const { exposureNotifications } = usePermissionsContext()
 
-  const isEnabled = exposureNotifications.status.enablement
+  const isEnabled = exposureNotifications.status.enabled
 
   return (
     <View style={style.container}>

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react"
 import { View, StyleSheet } from "react-native"
 
-import { usePermissionsContext, ENEnablement } from "../../PermissionsContext"
+import { usePermissionsContext } from "../../PermissionsContext"
 import CodeInputForm from "./CodeInputForm"
 import EnableExposureNotifications from "./EnableExposureNotifications"
 
@@ -10,11 +10,7 @@ import { Colors } from "../../styles"
 const CodeInputScreen: FunctionComponent = () => {
   const { exposureNotifications } = usePermissionsContext()
 
-  const hasExposureNotificationsEnabled = (): boolean => {
-    const enabledState: ENEnablement = "ENABLED"
-    return exposureNotifications.status[1] === enabledState
-  }
-  const isEnabled = hasExposureNotificationsEnabled()
+  const isEnabled = exposureNotifications.status.authorization
 
   return (
     <View style={style.container}>

--- a/src/Home/Home.spec.tsx
+++ b/src/Home/Home.spec.tsx
@@ -40,14 +40,14 @@ jest.mock("../More/useApplicationInfo", () => {
 jest.mock("./useBluetoothStatus.ts")
 
 describe("Home", () => {
-  describe("When the exposure notification permissions are enabled and authorized and Bluetooth is on", () => {
+  describe("When the exposure notification permissions are enabled and the app is authorized and Bluetooth is on", () => {
     it("renders an active message", async () => {
       const isBluetoothOn = true
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
       const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-        authorization: true,
-        enablement: true,
+        authorized: true,
+        enabled: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
         isENAuthorizedAndEnabled,
@@ -86,14 +86,14 @@ describe("Home", () => {
     })
   })
 
-  describe("When the exposure notification permissions are not enabled and not authorized", () => {
+  describe("When the exposure notification permissions are not enabled and the app is not authorized", () => {
     it("renders an inactive message and a disabled message for proximity tracing", async () => {
       const isBluetoothOn = true
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
       const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-        authorization: false,
-        enablement: false,
+        authorized: false,
+        enabled: false,
       }
       const permissionProviderValue = createPermissionProviderValue(
         isENAuthorizedAndEnabled,
@@ -129,8 +129,8 @@ describe("Home", () => {
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
       const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-        authorization: true,
-        enablement: true,
+        authorized: true,
+        enabled: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
         isENAuthorizedAndEnabled,
@@ -167,8 +167,8 @@ describe("Home", () => {
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
       const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-        authorization: true,
-        enablement: true,
+        authorized: true,
+        enabled: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
         isENAuthorizedAndEnabled,
@@ -204,8 +204,8 @@ describe("Home", () => {
       ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigationSpy })
 
       const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-        authorization: true,
-        enablement: true,
+        authorized: true,
+        enabled: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
         isENAuthorizedAndEnabled,
@@ -233,8 +233,8 @@ describe("Home", () => {
 
         const requestPermission = jest.fn()
         const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-          authorization: true,
-          enablement: false,
+          authorized: true,
+          enabled: false,
         }
         const permissionProviderValue = createPermissionProviderValue(
           isENAuthorizedAndEnabled,
@@ -268,8 +268,8 @@ describe("Home", () => {
         })
 
         const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-          authorization: true,
-          enablement: true,
+          authorized: true,
+          enabled: true,
         }
         const permissionProviderValue = createPermissionProviderValue(
           isENAuthorizedAndEnabled,
@@ -299,8 +299,8 @@ describe("Home", () => {
           ;(isPlatformiOS as jest.Mock).mockReturnValueOnce(true)
 
           const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
-            authorization: false,
-            enablement: false,
+            authorized: false,
+            enabled: false,
           }
           const permissionProviderValue = createPermissionProviderValue(
             isENAuthorizedAndEnabled,

--- a/src/Home/Home.spec.tsx
+++ b/src/Home/Home.spec.tsx
@@ -11,10 +11,11 @@ import { useSafeAreaInsets } from "react-native-safe-area-context"
 import "@testing-library/jest-native/extend-expect"
 
 import Home from "./Home"
-import { PermissionsContext, ENPermissionStatus } from "../PermissionsContext"
+import { PermissionsContext, ENActivationStatus } from "../PermissionsContext"
 import { PermissionStatus } from "../permissionStatus"
 import { isPlatformiOS } from "../utils/index"
 import { useBluetoothStatus } from "./useBluetoothStatus"
+import { request } from "react-native-permissions"
 
 jest.mock("@react-navigation/native")
 
@@ -42,9 +43,12 @@ describe("Home", () => {
       const isBluetoothOn = true
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
-      const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
+      const enActivationStatus: ENActivationStatus = {
+        authorization: true,
+        enablement: true,
+      }
       const permissionProviderValue = createPermissionProviderValue(
-        enPermissionStatus,
+        enActivationStatus,
       )
 
       const { getByTestId } = render(
@@ -85,12 +89,12 @@ describe("Home", () => {
       const isBluetoothOn = true
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
-      const enPermissionStatus: ENPermissionStatus = [
-        "UNAUTHORIZED",
-        "DISABLED",
-      ]
+      const enActivationStatus: ENActivationStatus = {
+        authorization: false,
+        enablement: false,
+      }
       const permissionProviderValue = createPermissionProviderValue(
-        enPermissionStatus,
+        enActivationStatus,
       )
 
       const { getByTestId } = render(
@@ -122,9 +126,12 @@ describe("Home", () => {
       const isBluetoothOn = false
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
-      const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
+      const enActivationStatus: ENActivationStatus = {
+        authorization: true,
+        enablement: true,
+      }
       const permissionProviderValue = createPermissionProviderValue(
-        enPermissionStatus,
+        enActivationStatus,
       )
 
       const { getByTestId } = render(
@@ -157,9 +164,12 @@ describe("Home", () => {
       const isBluetoothOn = false
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
-      const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
+      const enActivationStatus: ENActivationStatus = {
+        authorization: true,
+        enablement: true,
+      }
       const permissionProviderValue = createPermissionProviderValue(
-        enPermissionStatus,
+        enActivationStatus,
       )
 
       const { getByTestId } = render(
@@ -191,9 +201,12 @@ describe("Home", () => {
       const navigationSpy = jest.fn()
       ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigationSpy })
 
-      const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
+      const enActivationStatus: ENActivationStatus = {
+        authorization: true,
+        enablement: true,
+      }
       const permissionProviderValue = createPermissionProviderValue(
-        enPermissionStatus,
+        enActivationStatus,
       )
 
       const { getByTestId } = render(
@@ -216,13 +229,13 @@ describe("Home", () => {
       it("requests exposure notification to be enabled", async () => {
         expect.assertions(1)
 
-        const enPermissionStatus: ENPermissionStatus = [
-          "AUTHORIZED",
-          "DISABLED",
-        ]
         const requestPermission = jest.fn()
+        const enActivationStatus: ENActivationStatus = {
+          authorization: true,
+          enablement: false,
+        }
         const permissionProviderValue = createPermissionProviderValue(
-          enPermissionStatus,
+          enActivationStatus,
           requestPermission,
         )
 
@@ -252,9 +265,12 @@ describe("Home", () => {
           navigate: navigationSpy,
         })
 
-        const enPermissionStatus: ENPermissionStatus = ["AUTHORIZED", "ENABLED"]
+        const enActivationStatus: ENActivationStatus = {
+          authorization: true,
+          enablement: true,
+        }
         const permissionProviderValue = createPermissionProviderValue(
-          enPermissionStatus,
+          enActivationStatus,
         )
 
         const { getByTestId } = render(
@@ -280,12 +296,12 @@ describe("Home", () => {
           expect.assertions(1)
           ;(isPlatformiOS as jest.Mock).mockReturnValueOnce(true)
 
-          const enPermissionStatus: ENPermissionStatus = [
-            "UNAUTHORIZED",
-            "DISABLED",
-          ]
+          const enActivationStatus: ENActivationStatus = {
+            authorization: false,
+            enablement: false,
+          }
           const permissionProviderValue = createPermissionProviderValue(
-            enPermissionStatus,
+            enActivationStatus,
           )
 
           const { getByTestId } = render(
@@ -314,7 +330,7 @@ describe("Home", () => {
 })
 
 const createPermissionProviderValue = (
-  enPermissionStatus: ENPermissionStatus,
+  enActivationStatus: ENActivationStatus,
   requestPermission: () => void = () => {},
 ) => {
   return {
@@ -324,7 +340,7 @@ const createPermissionProviderValue = (
       request: () => {},
     },
     exposureNotifications: {
-      status: enPermissionStatus,
+      status: enActivationStatus,
       check: () => {},
       request: requestPermission,
     },

--- a/src/Home/Home.spec.tsx
+++ b/src/Home/Home.spec.tsx
@@ -11,11 +11,13 @@ import { useSafeAreaInsets } from "react-native-safe-area-context"
 import "@testing-library/jest-native/extend-expect"
 
 import Home from "./Home"
-import { PermissionsContext, ENActivationStatus } from "../PermissionsContext"
+import {
+  PermissionsContext,
+  ENAuthorizationEnablementStatus,
+} from "../PermissionsContext"
 import { PermissionStatus } from "../permissionStatus"
 import { isPlatformiOS } from "../utils/index"
 import { useBluetoothStatus } from "./useBluetoothStatus"
-import { request } from "react-native-permissions"
 
 jest.mock("@react-navigation/native")
 
@@ -38,17 +40,17 @@ jest.mock("../More/useApplicationInfo", () => {
 jest.mock("./useBluetoothStatus.ts")
 
 describe("Home", () => {
-  describe("When the enPermissionStatus is enabled and authorized and Bluetooth is on", () => {
+  describe("When the exposure notification permissions are enabled and authorized and Bluetooth is on", () => {
     it("renders an active message", async () => {
       const isBluetoothOn = true
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
-      const enActivationStatus: ENActivationStatus = {
+      const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
         authorization: true,
         enablement: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
-        enActivationStatus,
+        isENAuthorizedAndEnabled,
       )
 
       const { getByTestId } = render(
@@ -84,17 +86,17 @@ describe("Home", () => {
     })
   })
 
-  describe("When the enPermissionStatus is not enabled and not authorized", () => {
+  describe("When the exposure notification permissions are not enabled and not authorized", () => {
     it("renders an inactive message and a disabled message for proximity tracing", async () => {
       const isBluetoothOn = true
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
-      const enActivationStatus: ENActivationStatus = {
+      const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
         authorization: false,
         enablement: false,
       }
       const permissionProviderValue = createPermissionProviderValue(
-        enActivationStatus,
+        isENAuthorizedAndEnabled,
       )
 
       const { getByTestId } = render(
@@ -126,12 +128,12 @@ describe("Home", () => {
       const isBluetoothOn = false
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
-      const enActivationStatus: ENActivationStatus = {
+      const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
         authorization: true,
         enablement: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
-        enActivationStatus,
+        isENAuthorizedAndEnabled,
       )
 
       const { getByTestId } = render(
@@ -164,12 +166,12 @@ describe("Home", () => {
       const isBluetoothOn = false
       ;(useBluetoothStatus as jest.Mock).mockReturnValue(isBluetoothOn)
 
-      const enActivationStatus: ENActivationStatus = {
+      const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
         authorization: true,
         enablement: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
-        enActivationStatus,
+        isENAuthorizedAndEnabled,
       )
 
       const { getByTestId } = render(
@@ -201,12 +203,12 @@ describe("Home", () => {
       const navigationSpy = jest.fn()
       ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigationSpy })
 
-      const enActivationStatus: ENActivationStatus = {
+      const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
         authorization: true,
         enablement: true,
       }
       const permissionProviderValue = createPermissionProviderValue(
-        enActivationStatus,
+        isENAuthorizedAndEnabled,
       )
 
       const { getByTestId } = render(
@@ -225,17 +227,17 @@ describe("Home", () => {
   })
 
   describe("When proximity tracing is disabled", () => {
-    describe("when enPermissionStatus is authorized but not enabled", () => {
+    describe("when exposure notification permissions are authorized but not enabled", () => {
       it("requests exposure notification to be enabled", async () => {
         expect.assertions(1)
 
         const requestPermission = jest.fn()
-        const enActivationStatus: ENActivationStatus = {
+        const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
           authorization: true,
           enablement: false,
         }
         const permissionProviderValue = createPermissionProviderValue(
-          enActivationStatus,
+          isENAuthorizedAndEnabled,
           requestPermission,
         )
 
@@ -265,12 +267,12 @@ describe("Home", () => {
           navigate: navigationSpy,
         })
 
-        const enActivationStatus: ENActivationStatus = {
+        const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
           authorization: true,
           enablement: true,
         }
         const permissionProviderValue = createPermissionProviderValue(
-          enActivationStatus,
+          isENAuthorizedAndEnabled,
         )
 
         const { getByTestId } = render(
@@ -290,18 +292,18 @@ describe("Home", () => {
       })
     })
 
-    describe("when enPermissionStatus is unauthorized", () => {
+    describe("when exposure notification permissions are unauthorized", () => {
       describe("when the platform is iOS", () => {
         it("shows an unauthorized alert", async () => {
           expect.assertions(1)
           ;(isPlatformiOS as jest.Mock).mockReturnValueOnce(true)
 
-          const enActivationStatus: ENActivationStatus = {
+          const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = {
             authorization: false,
             enablement: false,
           }
           const permissionProviderValue = createPermissionProviderValue(
-            enActivationStatus,
+            isENAuthorizedAndEnabled,
           )
 
           const { getByTestId } = render(
@@ -330,7 +332,7 @@ describe("Home", () => {
 })
 
 const createPermissionProviderValue = (
-  enActivationStatus: ENActivationStatus,
+  isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus,
   requestPermission: () => void = () => {},
 ) => {
   return {
@@ -340,7 +342,7 @@ const createPermissionProviderValue = (
       request: () => {},
     },
     exposureNotifications: {
-      status: enActivationStatus,
+      status: isENAuthorizedAndEnabled,
       check: () => {},
       request: requestPermission,
     },

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -50,8 +50,8 @@ const HomeScreen: FunctionComponent = () => {
   useStatusBarEffect("light-content")
   const btStatus = useBluetoothStatus()
 
-  const isAuthorized = exposureNotifications.status.authorization
-  const isEnabled = exposureNotifications.status.enablement
+  const isAuthorized = exposureNotifications.status.authorized
+  const isEnabled = exposureNotifications.status.enabled
   const isEnabledAndAuthorized = isEnabled && isAuthorized
 
   const showUnauthorizedAlert = () => {

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -18,10 +18,7 @@ import { SvgXml } from "react-native-svg"
 import { useNavigation } from "@react-navigation/native"
 import env from "react-native-config"
 
-import {
-  usePermissionsContext,
-  ENPermissionStatus,
-} from "../PermissionsContext"
+import { usePermissionsContext } from "../PermissionsContext"
 import { Screens, useStatusBarEffect, Stacks, HomeScreens } from "../navigation"
 import { useApplicationInfo } from "../More/useApplicationInfo"
 import { GlobalText } from "../components/GlobalText"
@@ -48,17 +45,13 @@ const HomeScreen: FunctionComponent = () => {
   const languageName = getLocalNames()[localeCode]
   const navigation = useNavigation()
   const { exposureNotifications } = usePermissionsContext()
-  const [
-    authorization,
-    enablement,
-  ]: ENPermissionStatus = exposureNotifications.status
   const { applicationName } = useApplicationInfo()
   const insets = useSafeAreaInsets()
   useStatusBarEffect("light-content")
   const btStatus = useBluetoothStatus()
 
-  const isEnabled = enablement === "ENABLED"
-  const isAuthorized = authorization === "AUTHORIZED"
+  const isAuthorized = exposureNotifications.status.authorization
+  const isEnabled = exposureNotifications.status.enablement
   const isEnabledAndAuthorized = isEnabled && isAuthorized
 
   const showUnauthorizedAlert = () => {

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -17,10 +17,18 @@ import gaenStrategy from "./gaen"
 
 export type ENAuthorizationStatus = `UNAUTHORIZED` | `AUTHORIZED`
 export type ENEnablementStatus = `DISABLED` | `ENABLED`
-type ENPermissionStatus = [ENAuthorizationStatus, ENEnablementStatus]
-export type ENActivationStatus = { authorization: boolean; enablement: boolean }
+export type ENPermissionStatus = [ENAuthorizationStatus, ENEnablementStatus]
+const initialENPermissionStatus: ENPermissionStatus = [
+  "UNAUTHORIZED",
+  "DISABLED",
+]
 
-const initialENStatus: ENPermissionStatus = ["UNAUTHORIZED", "DISABLED"]
+export type ENActivationStatus = { authorization: boolean; enablement: boolean }
+const initialENActivationStatus: ENActivationStatus = {
+  authorization: false,
+  enablement: false,
+}
+
 const { permissionStrategy } = gaenStrategy
 
 interface PermissionsContextState {
@@ -43,7 +51,7 @@ const initialState = {
     request: () => {},
   },
   exposureNotifications: {
-    status: { authorization: false, enablement: false },
+    status: initialENActivationStatus,
     check: () => {},
     request: () => {},
   },
@@ -63,7 +71,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
   const [
     exposureNotificationsPermission,
     setExposureNotificationsPermission,
-  ] = useState<ENPermissionStatus>(initialENStatus)
+  ] = useState<ENPermissionStatus>(initialENPermissionStatus)
 
   const [notificationPermission, setNotificationPermission] = useState(
     PermissionStatus.UNKNOWN,
@@ -120,15 +128,20 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
     return status
   }
 
-  console.log(exposureNotificationsPermission)
+  const toActivationStatus = (
+    enAuthorizationStatus: ENAuthorizationStatus,
+    enEnablementStatus: ENEnablementStatus,
+  ): ENActivationStatus => {
+    const isENAuthorized = enAuthorizationStatus === "AUTHORIZED"
+    const isENEnabled = enEnablementStatus === "ENABLED"
 
-  const isENAuthorized = exposureNotificationsPermission[0] === "AUTHORIZED"
-  const isENEnabled = exposureNotificationsPermission[1] === "ENABLED"
-
-  const enActivationStatus = {
-    authorization: isENAuthorized,
-    enablement: isENEnabled,
+    return { authorization: isENAuthorized, enablement: isENEnabled }
   }
+
+  const enActivationStatus: ENActivationStatus = toActivationStatus(
+    exposureNotificationsPermission[0],
+    exposureNotificationsPermission[1],
+  )
 
   return (
     <PermissionsContext.Provider

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -13,12 +13,12 @@ import {
 } from "react-native-permissions"
 
 import { PermissionStatus, statusToEnum } from "./permissionStatus"
-
-export type ENAuthorization = `UNAUTHORIZED` | `AUTHORIZED`
-export type ENEnablement = `DISABLED` | `ENABLED`
 import gaenStrategy from "./gaen"
 
-export type ENPermissionStatus = [ENAuthorization, ENEnablement]
+export type ENAuthorizationStatus = `UNAUTHORIZED` | `AUTHORIZED`
+export type ENEnablementStatus = `DISABLED` | `ENABLED`
+type ENPermissionStatus = [ENAuthorizationStatus, ENEnablementStatus]
+export type ENActivationStatus = { authorization: boolean; enablement: boolean }
 
 const initialENStatus: ENPermissionStatus = ["UNAUTHORIZED", "DISABLED"]
 const { permissionStrategy } = gaenStrategy
@@ -30,7 +30,7 @@ interface PermissionsContextState {
     request: () => void
   }
   exposureNotifications: {
-    status: ENPermissionStatus
+    status: ENActivationStatus
     check: () => void
     request: () => void
   }
@@ -43,7 +43,7 @@ const initialState = {
     request: () => {},
   },
   exposureNotifications: {
-    status: initialENStatus,
+    status: { authorization: false, enablement: false },
     check: () => {},
     request: () => {},
   },
@@ -120,6 +120,16 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
     return status
   }
 
+  console.log(exposureNotificationsPermission)
+
+  const isENAuthorized = exposureNotificationsPermission[0] === "AUTHORIZED"
+  const isENEnabled = exposureNotificationsPermission[1] === "ENABLED"
+
+  const enActivationStatus = {
+    authorization: isENAuthorized,
+    enablement: isENEnabled,
+  }
+
   return (
     <PermissionsContext.Provider
       value={{
@@ -129,7 +139,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
           request: requestNotificationPermission,
         },
         exposureNotifications: {
-          status: exposureNotificationsPermission,
+          status: enActivationStatus,
           check: checkENPermission,
           request: requestENPermission,
         },

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -23,17 +23,20 @@ const initialENPermissionStatus: ENPermissionStatus = [
   "DISABLED",
 ]
 
-const toActivationStatus = (
+const toAuthorizationEnablementStatus = (
   enPermissionStatus: ENPermissionStatus,
-): ENActivationStatus => {
+): ENAuthorizationEnablementStatus => {
   const isENAuthorized = enPermissionStatus[0] === "AUTHORIZED"
   const isENEnabled = enPermissionStatus[1] === "ENABLED"
 
   return { authorization: isENAuthorized, enablement: isENEnabled }
 }
 
-export type ENActivationStatus = { authorization: boolean; enablement: boolean }
-const initialENActivationStatus: ENActivationStatus = toActivationStatus(
+export type ENAuthorizationEnablementStatus = {
+  authorization: boolean
+  enablement: boolean
+}
+const initialENAuthorizationEnablementStatus: ENAuthorizationEnablementStatus = toAuthorizationEnablementStatus(
   initialENPermissionStatus,
 )
 
@@ -46,7 +49,7 @@ interface PermissionsContextState {
     request: () => void
   }
   exposureNotifications: {
-    status: ENActivationStatus
+    status: ENAuthorizationEnablementStatus
     check: () => void
     request: () => void
   }
@@ -59,7 +62,7 @@ const initialState = {
     request: () => {},
   },
   exposureNotifications: {
-    status: initialENActivationStatus,
+    status: initialENAuthorizationEnablementStatus,
     check: () => {},
     request: () => {},
   },
@@ -136,7 +139,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
     return status
   }
 
-  const enActivationStatus: ENActivationStatus = toActivationStatus(
+  const isENAuthorizedAndEnabled: ENAuthorizationEnablementStatus = toAuthorizationEnablementStatus(
     exposureNotificationsPermissionStatus,
   )
 
@@ -149,7 +152,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
           request: requestNotificationPermission,
         },
         exposureNotifications: {
-          status: enActivationStatus,
+          status: isENAuthorizedAndEnabled,
           check: checkENPermission,
           request: requestENPermission,
         },

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -23,11 +23,19 @@ const initialENPermissionStatus: ENPermissionStatus = [
   "DISABLED",
 ]
 
-export type ENActivationStatus = { authorization: boolean; enablement: boolean }
-const initialENActivationStatus: ENActivationStatus = {
-  authorization: false,
-  enablement: false,
+const toActivationStatus = (
+  enPermissionStatus: ENPermissionStatus,
+): ENActivationStatus => {
+  const isENAuthorized = enPermissionStatus[0] === "AUTHORIZED"
+  const isENEnabled = enPermissionStatus[1] === "ENABLED"
+
+  return { authorization: isENAuthorized, enablement: isENEnabled }
 }
+
+export type ENActivationStatus = { authorization: boolean; enablement: boolean }
+const initialENActivationStatus: ENActivationStatus = toActivationStatus(
+  initialENPermissionStatus,
+)
 
 const { permissionStrategy } = gaenStrategy
 
@@ -69,8 +77,8 @@ export interface PermissionStrategy {
 
 const PermissionsProvider: FunctionComponent = ({ children }) => {
   const [
-    exposureNotificationsPermission,
-    setExposureNotificationsPermission,
+    exposureNotificationsPermissionStatus,
+    setExposureNotificationsPermissionStatus,
   ] = useState<ENPermissionStatus>(initialENPermissionStatus)
 
   const [notificationPermission, setNotificationPermission] = useState(
@@ -79,7 +87,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
 
   const checkENPermission = useCallback(() => {
     const handleNativeResponse = (status: ENPermissionStatus) => {
-      setExposureNotificationsPermission(status)
+      setExposureNotificationsPermissionStatus(status)
     }
     permissionStrategy.check(handleNativeResponse)
   }, [])
@@ -92,7 +100,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
     AppState.addEventListener("change", handleAppStateChange)
     const subscription = permissionStrategy.statusSubscription(
       (status: ENPermissionStatus) => {
-        setExposureNotificationsPermission(status)
+        setExposureNotificationsPermissionStatus(status)
       },
     )
 
@@ -128,19 +136,8 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
     return status
   }
 
-  const toActivationStatus = (
-    enAuthorizationStatus: ENAuthorizationStatus,
-    enEnablementStatus: ENEnablementStatus,
-  ): ENActivationStatus => {
-    const isENAuthorized = enAuthorizationStatus === "AUTHORIZED"
-    const isENEnabled = enEnablementStatus === "ENABLED"
-
-    return { authorization: isENAuthorized, enablement: isENEnabled }
-  }
-
   const enActivationStatus: ENActivationStatus = toActivationStatus(
-    exposureNotificationsPermission[0],
-    exposureNotificationsPermission[1],
+    exposureNotificationsPermissionStatus,
   )
 
   return (

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -29,12 +29,15 @@ const toAuthorizationEnablementStatus = (
   const isENAuthorized = enPermissionStatus[0] === "AUTHORIZED"
   const isENEnabled = enPermissionStatus[1] === "ENABLED"
 
-  return { authorization: isENAuthorized, enablement: isENEnabled }
+  return {
+    authorized: isENAuthorized,
+    enabled: isENEnabled,
+  }
 }
 
 export type ENAuthorizationEnablementStatus = {
-  authorization: boolean
-  enablement: boolean
+  authorized: boolean
+  enabled: boolean
 }
 const initialENAuthorizationEnablementStatus: ENAuthorizationEnablementStatus = toAuthorizationEnablementStatus(
   initialENPermissionStatus,

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -15,8 +15,8 @@ import {
 import { PermissionStatus, statusToEnum } from "./permissionStatus"
 import gaenStrategy from "./gaen"
 
-export type ENAuthorizationStatus = `UNAUTHORIZED` | `AUTHORIZED`
-export type ENEnablementStatus = `DISABLED` | `ENABLED`
+type ENAuthorizationStatus = `UNAUTHORIZED` | `AUTHORIZED`
+type ENEnablementStatus = `DISABLED` | `ENABLED`
 export type ENPermissionStatus = [ENAuthorizationStatus, ENEnablementStatus]
 const initialENPermissionStatus: ENPermissionStatus = [
   "UNAUTHORIZED",
@@ -39,8 +39,6 @@ export type ENAuthorizationEnablementStatus = {
 const initialENAuthorizationEnablementStatus: ENAuthorizationEnablementStatus = toAuthorizationEnablementStatus(
   initialENPermissionStatus,
 )
-
-const { permissionStrategy } = gaenStrategy
 
 interface PermissionsContextState {
   notification: {
@@ -87,6 +85,8 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
   const [notificationPermission, setNotificationPermission] = useState(
     PermissionStatus.UNKNOWN,
   )
+
+  const { permissionStrategy } = gaenStrategy
 
   const checkENPermission = useCallback(() => {
     const handleNativeResponse = (status: ENPermissionStatus) => {

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -4,7 +4,7 @@ import {
   EventSubscription,
 } from "react-native"
 
-import { ENActivationStatus } from "../PermissionsContext"
+import { ENPermissionStatus } from "../PermissionsContext"
 import { ExposureInfo, Posix } from "../exposure"
 import { ENDiagnosisKey } from "../More/ENLocalDiagnosisKeyScreen"
 import { ExposureKey } from "../exposureKey"
@@ -28,7 +28,7 @@ export const subscribeToExposureEvents = (
 }
 
 export const subscribeToEnabledStatusEvents = (
-  cb: (status: ENActivationStatus) => void,
+  cb: (status: ENPermissionStatus) => void,
 ): EventSubscription => {
   const ExposureEvents = new NativeEventEmitter(
     NativeModules.ExposureEventEmitter,
@@ -44,15 +44,15 @@ export const subscribeToEnabledStatusEvents = (
   )
 }
 
-const toStatus = (data: string[]): ENActivationStatus => {
+const toStatus = (data: string[]): ENPermissionStatus => {
   const networkAuthorization = data[0]
   const networkEnablement = data[1]
-  const result: ENActivationStatus = { authorization: false, enablement: false }
+  const result: ENPermissionStatus = ["UNAUTHORIZED", "DISABLED"]
   if (networkAuthorization === "AUTHORIZED") {
-    result.authorization = true
+    result[0] = "AUTHORIZED"
   }
   if (networkEnablement === "ENABLED") {
-    result.enablement = true
+    result[1] = "ENABLED"
   }
   return result
 }
@@ -67,7 +67,7 @@ export const requestAuthorization = async (
 }
 
 export const getCurrentENPermissionsStatus = async (
-  cb: (status: ENActivationStatus) => void,
+  cb: (status: ENPermissionStatus) => void,
 ): Promise<void> => {
   permissionsModule.getCurrentENPermissionsStatus((data: string[]) => {
     const status = toStatus(data)

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -4,7 +4,7 @@ import {
   EventSubscription,
 } from "react-native"
 
-import { ENPermissionStatus } from "../PermissionsContext"
+import { ENActivationStatus } from "../PermissionsContext"
 import { ExposureInfo, Posix } from "../exposure"
 import { ENDiagnosisKey } from "../More/ENLocalDiagnosisKeyScreen"
 import { ExposureKey } from "../exposureKey"
@@ -28,7 +28,7 @@ export const subscribeToExposureEvents = (
 }
 
 export const subscribeToEnabledStatusEvents = (
-  cb: (status: ENPermissionStatus) => void,
+  cb: (status: ENActivationStatus) => void,
 ): EventSubscription => {
   const ExposureEvents = new NativeEventEmitter(
     NativeModules.ExposureEventEmitter,
@@ -44,15 +44,15 @@ export const subscribeToEnabledStatusEvents = (
   )
 }
 
-const toStatus = (data: string[]): ENPermissionStatus => {
+const toStatus = (data: string[]): ENActivationStatus => {
   const networkAuthorization = data[0]
   const networkEnablement = data[1]
-  const result: ENPermissionStatus = ["UNAUTHORIZED", "DISABLED"]
+  const result: ENActivationStatus = { authorization: false, enablement: false }
   if (networkAuthorization === "AUTHORIZED") {
-    result[0] = "AUTHORIZED"
+    result.authorization = true
   }
   if (networkEnablement === "ENABLED") {
-    result[1] = "ENABLED"
+    result.enablement = true
   }
   return result
 }
@@ -67,7 +67,7 @@ export const requestAuthorization = async (
 }
 
 export const getCurrentENPermissionsStatus = async (
-  cb: (status: ENPermissionStatus) => void,
+  cb: (status: ENActivationStatus) => void,
 ): Promise<void> => {
   permissionsModule.getCurrentENPermissionsStatus((data: string[]) => {
     const status = toStatus(data)


### PR DESCRIPTION
Why: prior to this commit, the PermissionsContext was exposing the `ENPermissionStatus` directly, which has a type of `[ENAuthorization, ENEnablement]`, which in turn have types:

```
type ENAuthorization = `UNAUTHORIZED` | `AUTHORIZED`
type ENEnablement = `DISABLED` | `ENABLED`
```

This resulted in complexity at the view layer because we had to import various types from the `PermissionsContext` and, for example, check to see if the `ENAuthorization === "AUTHORIZED"` or `ENEnablement === "DISABLED"`.

This commit instead exposes an `ENAuthorizationEnablementStatus`, of type `{ authorization: boolean, enablement: boolean }`.

The result of this is that we can check if exposure notifications are authorized with `exposureNotifications.status.authorization`, or if they are enabled with `exposureNotifications.status.enablement`.