### PR TITLE
Add configuration context

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,7 @@ import {
   OnboardingProvider,
   onboardingHasBeenCompleted,
 } from "./src/OnboardingContext"
+import { ConfigurationProvider } from "./src/ConfigurationContext"
 import { PermissionsProvider } from "./src/PermissionsContext"
 import { initializei18next, loadUserLocale } from "./src/locales/languages"
 
@@ -39,13 +40,17 @@ const App: FunctionComponent = () => {
     <>
       {!isLoading ? (
         <ErrorBoundary>
-          <OnboardingProvider userHasCompletedOboarding={onboardingIsComplete}>
-            <PermissionsProvider>
-              <ExposureProvider>
-                <MainNavigator />
-              </ExposureProvider>
-            </PermissionsProvider>
-          </OnboardingProvider>
+          <ConfigurationProvider>
+            <OnboardingProvider
+              userHasCompletedOboarding={onboardingIsComplete}
+            >
+              <PermissionsProvider>
+                <ExposureProvider>
+                  <MainNavigator />
+                </ExposureProvider>
+              </PermissionsProvider>
+            </OnboardingProvider>
+          </ConfigurationProvider>
         </ErrorBoundary>
       ) : null}
     </>

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
@@ -1,12 +1,12 @@
 import React, { FunctionComponent, useState, useEffect } from "react"
-import { View, Text, Button, Platform } from "react-native"
+import { View, Text, Button } from "react-native"
 import { useNavigation } from "@react-navigation/native"
-import env from "react-native-config"
 
 import { useStatusBarEffect, Screens } from "../../navigation"
 import { useAffectedUserContext } from "../AffectedUserContext"
 import PublishConsentForm from "./PublishConsentForm"
 import { useExposureContext } from "../../ExposureContext"
+import { useConfigurationContext } from "../../ConfigurationContext"
 
 const PublishConsentScreen: FunctionComponent = () => {
   useStatusBarEffect("light-content")
@@ -14,10 +14,7 @@ const PublishConsentScreen: FunctionComponent = () => {
   const { storeRevisionToken, getRevisionToken } = useExposureContext()
   const navigation = useNavigation()
   const { certificate, hmacKey, exposureKeys } = useAffectedUserContext()
-  const appPackageName = Platform.select({
-    ios: env.IOS_BUNDLE_ID,
-    android: env.ANDROID_APPLICATION_ID,
-  }) as string
+  const { appPackageName, regionCodes } = useConfigurationContext()
 
   useEffect(() => {
     getRevisionToken().then((token) => {
@@ -34,7 +31,7 @@ const PublishConsentScreen: FunctionComponent = () => {
         storeRevisionToken={storeRevisionToken}
         revisionToken={revisionToken}
         appPackageName={appPackageName}
-        regionCodes={env.REGION_CODES.split(",")}
+        regionCodes={regionCodes}
       />
     )
   } else {

--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -1,0 +1,73 @@
+import React, { FunctionComponent, createContext, useContext } from "react"
+import { Platform } from "react-native"
+import env from "react-native-config"
+
+export interface Configuration {
+  appDownloadLink: string
+  appPackageName: string
+  displayReportAnIssue: boolean
+  displaySelfAssessment: boolean
+  healthAuthorityAdviceUrl: string
+  healthAuthorityName: string
+  healthAuthorityPrivacyPolicyUrl: string
+  regionCodes: string[]
+}
+
+const initialState = {
+  appDownloadLink: "",
+  appPackageName: "",
+  displayReportAnIssue: false,
+  displaySelfAssessment: false,
+  healthAuthorityAdviceUrl: "",
+  healthAuthorityName: "",
+  healthAuthorityPrivacyPolicyUrl: "",
+  regionCodes: [],
+}
+
+const ConfigurationContext = createContext<Configuration>(initialState)
+
+const ConfigurationProvider: FunctionComponent = ({ children }) => {
+  const {
+    AUTHORITY_ADVICE_URL: healthAuthorityAdviceUrl,
+    GAEN_AUTHORITY_NAME: healthAuthorityName,
+    PRIVACY_POLICY_URL: healthAuthorityPrivacyPolicyUrl,
+  } = env
+  const displaySelfAssessment = env.DISPLAY_SELF_ASSESSMENT === "true"
+  const displayReportAnIssue = env.DISPLAY_REPORT_AN_ISSUE === "true"
+  const appDownloadLink = Platform.select({
+    ios: env.IOS_APP_STORE_URL,
+    android: env.ANDROID_PLAY_STORE_URL,
+  }) as string
+  const appPackageName = Platform.select({
+    ios: env.IOS_BUNDLE_ID,
+    android: env.ANDROID_APPLICATION_ID,
+  }) as string
+  const regionCodes = env.REGION_CODES.split(",")
+
+  return (
+    <ConfigurationContext.Provider
+      value={{
+        appDownloadLink,
+        appPackageName,
+        displayReportAnIssue,
+        displaySelfAssessment,
+        healthAuthorityAdviceUrl,
+        healthAuthorityName,
+        healthAuthorityPrivacyPolicyUrl,
+        regionCodes,
+      }}
+    >
+      {children}
+    </ConfigurationContext.Provider>
+  )
+}
+
+const useConfigurationContext = (): Configuration => {
+  const context = useContext(ConfigurationContext)
+  if (context === undefined) {
+    throw new Error("ConfigurationContext must be used with a provider")
+  }
+  return context
+}
+
+export { ConfigurationContext, ConfigurationProvider, useConfigurationContext }

--- a/src/ExposureHistory/ExposureDetail.spec.tsx
+++ b/src/ExposureHistory/ExposureDetail.spec.tsx
@@ -5,12 +5,7 @@ import { DateTimeUtils } from "../utils"
 import { factories } from "../factories"
 import ExposureDetail from "./ExposureDetail"
 import { useRoute } from "@react-navigation/native"
-
-jest.mock("react-native-config", () => {
-  return {
-    AUTHORITY_ADVICE_URL: "https://www.health.state.mn.us/",
-  }
-})
+import { ConfigurationContext } from "../ConfigurationContext"
 
 jest.mock("@react-navigation/native")
 describe("ExposureDetail", () => {
@@ -62,13 +57,21 @@ describe("ExposureDetail", () => {
 
   describe("when the health authority provides a link", () => {
     it("directs the user to the health authority link", () => {
+      const healthAuthorityAdviceUrl = "https://www.health.state.mn.us/"
       const openURLSpy = jest.spyOn(Linking, "openURL")
-      const { getByLabelText } = render(<ExposureDetail />)
+      const { getByLabelText } = render(
+        <ConfigurationContext.Provider
+          value={factories.configurationContext.build({
+            healthAuthorityAdviceUrl,
+          })}
+        >
+          <ExposureDetail />
+        </ConfigurationContext.Provider>,
+      )
       const nextStepsButton = getByLabelText("Next Steps")
-      const authorityAdviceUrl = "https://www.health.state.mn.us/"
       fireEvent.press(nextStepsButton)
 
-      expect(openURLSpy).toHaveBeenCalledWith(authorityAdviceUrl)
+      expect(openURLSpy).toHaveBeenCalledWith(healthAuthorityAdviceUrl)
     })
   })
 })

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent, useState, useEffect } from "react"
-import env from "react-native-config"
 import { View, ScrollView, StyleSheet, Linking } from "react-native"
 import { RouteProp, useRoute, useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
@@ -14,6 +13,7 @@ import { ExposureDatum, exposureWindowBucket } from "../exposure"
 
 import { Colors, Iconography, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
+import { useConfigurationContext } from "../ConfigurationContext"
 
 const ExposureDetail: FunctionComponent = () => {
   const navigation = useNavigation()
@@ -22,15 +22,14 @@ const ExposureDetail: FunctionComponent = () => {
   >()
   useStatusBarEffect("light-content")
   const { t } = useTranslation()
+  const {
+    healthAuthorityName,
+    healthAuthorityAdviceUrl,
+  } = useConfigurationContext()
 
   const [connectivity, setConnectivity] = useState<boolean | null | undefined>(
     true,
   )
-
-  const {
-    GAEN_AUTHORITY_NAME: healthAuthorityName,
-    AUTHORITY_ADVICE_URL: healthAuthorityLink,
-  } = env
 
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener((state) => {
@@ -63,8 +62,8 @@ const ExposureDetail: FunctionComponent = () => {
   }
 
   const handleOnPressNextStep = () => {
-    healthAuthorityLink
-      ? Linking.openURL(healthAuthorityLink)
+    healthAuthorityAdviceUrl
+      ? Linking.openURL(healthAuthorityAdviceUrl)
       : navigation.navigate(Screens.SelfAssessment)
   }
 

--- a/src/ExposureHistory/History/NoExposures.tsx
+++ b/src/ExposureHistory/History/NoExposures.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent } from "react"
-import env from "react-native-config"
 import { Linking, View, StyleSheet, TouchableOpacity } from "react-native"
 import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
@@ -7,11 +6,8 @@ import { useTranslation } from "react-i18next"
 import { GlobalText } from "../../components/GlobalText"
 import { Colors, Typography, Spacing, Outlines } from "../../styles"
 import { Icons } from "../../assets"
+import { useConfigurationContext } from "../../ConfigurationContext"
 
-const {
-  GAEN_AUTHORITY_NAME: healthAuthorityName,
-  AUTHORITY_ADVICE_URL: healthAuthorityLink,
-} = env
 const NoExposures: FunctionComponent = () => {
   const { t } = useTranslation()
   return (
@@ -31,9 +27,13 @@ const NoExposures: FunctionComponent = () => {
 
 const HealthGuidelines: FunctionComponent = () => {
   const { t } = useTranslation()
+  const {
+    healthAuthorityName,
+    healthAuthorityAdviceUrl,
+  } = useConfigurationContext()
 
   const handleOnPressHALink = () => {
-    Linking.openURL(healthAuthorityLink)
+    Linking.openURL(healthAuthorityAdviceUrl)
   }
 
   return (
@@ -41,7 +41,7 @@ const HealthGuidelines: FunctionComponent = () => {
       <GlobalText style={style.cardHeaderText}>
         {t("exposure_history.protect_yourself_and_others")}
       </GlobalText>
-      {Boolean(healthAuthorityLink) && (
+      {Boolean(healthAuthorityAdviceUrl) && (
         <>
           <GlobalText style={style.cardSubheaderText}>
             {t("exposure_history.review_guidance_from_ha", {

--- a/src/Home/Home.spec.tsx
+++ b/src/Home/Home.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Alert } from "react-native"
+import { Alert, Share } from "react-native"
 import {
   render,
   waitFor,
@@ -18,6 +18,8 @@ import {
 import { PermissionStatus } from "../permissionStatus"
 import { isPlatformiOS } from "../utils/index"
 import { useBluetoothStatus } from "./useBluetoothStatus"
+import { factories } from "../factories"
+import { ConfigurationContext } from "../ConfigurationContext"
 
 jest.mock("@react-navigation/native")
 
@@ -40,6 +42,32 @@ jest.mock("../More/useApplicationInfo", () => {
 jest.mock("./useBluetoothStatus.ts")
 
 describe("Home", () => {
+  it("allows users to share the application", () => {
+    const configuration = factories.configurationContext.build()
+    const permissionProviderValue = createPermissionProviderValue({
+      authorized: true,
+      enabled: true,
+    })
+
+    const shareSpy = jest.spyOn(Share, "share")
+
+    const { getByLabelText } = render(
+      <ConfigurationContext.Provider value={configuration}>
+        <PermissionsContext.Provider value={permissionProviderValue}>
+          <Home />
+        </PermissionsContext.Provider>
+      </ConfigurationContext.Provider>,
+    )
+
+    fireEvent.press(
+      getByLabelText("Share the app and help protect yourself and others."),
+    )
+
+    expect(shareSpy).toHaveBeenCalledWith({
+      message: `Check out this app ${mockedApplicationName}, which can help us contain COVID-19! ${configuration.appDownloadLink}`,
+    })
+  })
+
   describe("When the exposure notification permissions are enabled and the app is authorized and Bluetooth is on", () => {
     it("renders an active message", async () => {
       const isBluetoothOn = true

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -16,7 +16,6 @@ import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 import { useNavigation } from "@react-navigation/native"
-import env from "react-native-config"
 
 import { usePermissionsContext } from "../PermissionsContext"
 import { Screens, useStatusBarEffect, Stacks, HomeScreens } from "../navigation"
@@ -36,6 +35,7 @@ import {
   Iconography,
 } from "../styles"
 import { useBluetoothStatus } from "./useBluetoothStatus"
+import { useConfigurationContext } from "../ConfigurationContext"
 
 const HomeScreen: FunctionComponent = () => {
   const {
@@ -49,6 +49,7 @@ const HomeScreen: FunctionComponent = () => {
   const insets = useSafeAreaInsets()
   useStatusBarEffect("light-content")
   const btStatus = useBluetoothStatus()
+  const configuration = useConfigurationContext()
 
   const isAuthorized = exposureNotifications.status.authorized
   const isEnabled = exposureNotifications.status.enabled
@@ -101,17 +102,11 @@ const HomeScreen: FunctionComponent = () => {
   }
 
   const handleOnPressShare = async () => {
-    const isIOS = Platform.OS === "ios"
-
-    const appDownloadLink = isIOS
-      ? env.IOS_APP_STORE_URL
-      : env.ANDROID_PLAY_STORE_URL
-
     try {
       await Share.share({
         message: t("home.bluetooth.share_message", {
           applicationName,
-          appDownloadLink,
+          appDownloadLink: configuration.appDownloadLink,
         }),
       })
     } catch (error) {
@@ -205,6 +200,7 @@ const HomeScreen: FunctionComponent = () => {
           <TouchableOpacity
             style={style.shareContainer}
             onPress={handleOnPressShare}
+            accessibilityLabel={t("home.bluetooth.share")}
           >
             <View style={style.shareImageContainer}>
               <Image source={Images.HugEmoji} style={style.shareImage} />

--- a/src/More/About.spec.tsx
+++ b/src/More/About.spec.tsx
@@ -3,6 +3,8 @@ import { render } from "@testing-library/react-native"
 
 import AboutScreen from "./About"
 import { useApplicationInfo } from "./useApplicationInfo"
+import { ConfigurationContext } from "../ConfigurationContext"
+import { factories } from "../factories"
 
 jest.mock("./useApplicationInfo")
 describe("About", () => {
@@ -46,5 +48,29 @@ describe("About", () => {
     const { getByText } = render(<AboutScreen />)
 
     expect(getByText(`${mockOsName} v${mockOsVersion}`)).toBeDefined()
+  })
+
+  it("shows the screen description with the app name and the authority", () => {
+    const healthAuthorityName = "authority name"
+    const applicationName = "applicationName"
+
+    ;(useApplicationInfo as jest.Mock).mockReturnValueOnce({
+      applicationName,
+      versionInfo: "versionInfo",
+    })
+
+    const { getByText } = render(
+      <ConfigurationContext.Provider
+        value={factories.configurationContext.build({ healthAuthorityName })}
+      >
+        <AboutScreen />
+      </ConfigurationContext.Provider>,
+    )
+
+    expect(
+      getByText(
+        `The ${applicationName} app is made available by ${healthAuthorityName}`,
+      ),
+    ).toBeDefined()
   })
 })

--- a/src/More/About.tsx
+++ b/src/More/About.tsx
@@ -1,18 +1,18 @@
 import React, { FunctionComponent } from "react"
 import { useTranslation } from "react-i18next"
 import { Platform, ScrollView, StyleSheet, View } from "react-native"
-import env from "react-native-config"
 
 import { GlobalText } from "../components/GlobalText"
 
 import { Colors, Spacing, Typography } from "../styles"
 import { useApplicationInfo } from "./useApplicationInfo"
+import { useConfigurationContext } from "../ConfigurationContext"
 
 export const AboutScreen: FunctionComponent = () => {
   const { t } = useTranslation()
   const osInfo = `${Platform.OS} v${Platform.Version}`
   const { applicationName, versionInfo } = useApplicationInfo()
-  const { GAEN_AUTHORITY_NAME: healthAuthorityName } = env
+  const { healthAuthorityName } = useConfigurationContext()
 
   return (
     <ScrollView

--- a/src/More/Legal.spec.tsx
+++ b/src/More/Legal.spec.tsx
@@ -1,18 +1,21 @@
 import React from "react"
 import "react-native"
-import { render, waitFor } from "@testing-library/react-native"
+import { render, waitFor, fireEvent } from "@testing-library/react-native"
 import "@testing-library/jest-native/extend-expect"
 import { useNavigation, useFocusEffect } from "@react-navigation/native"
 import { useApplicationName } from "./useApplicationInfo"
 
-import LegalScreen from "./Legal"
+import Legal from "./Legal"
+import { Linking } from "react-native"
+import { ConfigurationContext } from "../ConfigurationContext"
+import { factories } from "../factories"
 
 jest.mock("@react-navigation/native")
 jest.mock("./useApplicationInfo")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 ;(useFocusEffect as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 
-describe("LicensesScreen", () => {
+describe("Legal", () => {
   it("shows the name of the application", async () => {
     const applicationName = "application name"
 
@@ -20,10 +23,53 @@ describe("LicensesScreen", () => {
       applicationName,
     })
 
-    const { getByText } = render(<LegalScreen />)
+    const { getByText } = render(<Legal />)
 
     await waitFor(() => {
       expect(getByText(applicationName)).toBeDefined()
+    })
+  })
+
+  it("shows the authority name of the application", () => {
+    const healthAuthorityName = "authority name"
+
+    ;(useApplicationName as jest.Mock).mockReturnValueOnce({
+      applicationName: "applicationName",
+    })
+    const { getByText } = render(
+      <ConfigurationContext.Provider
+        value={factories.configurationContext.build({ healthAuthorityName })}
+      >
+        <Legal />
+      </ConfigurationContext.Provider>,
+    )
+
+    expect(getByText(healthAuthorityName)).toBeDefined()
+  })
+
+  it("navigates to the authority privacy policy url", async () => {
+    const healthAuthorityPrivacyPolicyUrl = "authorityPrivacyPolicyUrl"
+
+    ;(useApplicationName as jest.Mock).mockReturnValueOnce({
+      applicationName: "applicationName",
+    })
+
+    const openURLSpy = jest.spyOn(Linking, "openURL")
+
+    const { getByLabelText } = render(
+      <ConfigurationContext.Provider
+        value={factories.configurationContext.build({
+          healthAuthorityPrivacyPolicyUrl,
+        })}
+      >
+        <Legal />
+      </ConfigurationContext.Provider>,
+    )
+
+    fireEvent.press(getByLabelText("Privacy Policy"))
+
+    await waitFor(() => {
+      expect(openURLSpy).toHaveBeenCalledWith(healthAuthorityPrivacyPolicyUrl)
     })
   })
 })

--- a/src/More/Legal.tsx
+++ b/src/More/Legal.tsx
@@ -2,25 +2,23 @@ import React, { FunctionComponent } from "react"
 import { Linking, StyleSheet, TouchableOpacity, View } from "react-native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
-import env from "react-native-config"
+
 import { useApplicationName } from "./useApplicationInfo"
-
 import { GlobalText } from "../components/GlobalText"
-
 import { Colors, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
+import { useConfigurationContext } from "../ConfigurationContext"
 
-const Licenses: FunctionComponent = () => {
+const Legal: FunctionComponent = () => {
   const { t } = useTranslation()
   const { applicationName } = useApplicationName()
-
   const {
-    PRIVACY_POLICY_URL: privacyPolicyUrl,
-    GAEN_AUTHORITY_NAME: healthAuthorityName,
-  } = env
+    healthAuthorityName,
+    healthAuthorityPrivacyPolicyUrl,
+  } = useConfigurationContext()
 
   const handleOnPressLink = () => {
-    Linking.openURL(privacyPolicyUrl)
+    Linking.openURL(healthAuthorityPrivacyPolicyUrl)
   }
 
   return (
@@ -29,7 +27,10 @@ const Licenses: FunctionComponent = () => {
         {applicationName}
       </GlobalText>
       <GlobalText style={style.contentText}>{healthAuthorityName}</GlobalText>
-      <TouchableOpacity onPress={handleOnPressLink}>
+      <TouchableOpacity
+        onPress={handleOnPressLink}
+        accessibilityLabel={t("label.privacy_policy")}
+      >
         <GlobalText style={style.privacyPolicyText}>
           {t("label.privacy_policy")}
         </GlobalText>
@@ -60,4 +61,4 @@ const style = StyleSheet.create({
   },
 })
 
-export default Licenses
+export default Legal

--- a/src/SelfAssessment/endScreens/Share.spec.tsx
+++ b/src/SelfAssessment/endScreens/Share.spec.tsx
@@ -1,20 +1,17 @@
 import { fireEvent, render } from "@testing-library/react-native"
 import React from "react"
 import { I18nextProvider } from "react-i18next"
+import { useNavigation } from "@react-navigation/native"
 
 import i18n from "../../locales/languages"
-import { AssessmentNavigationContext } from "../Context"
 import { Share } from "./Share"
 
+jest.mock("@react-navigation/native")
 describe("Share", () => {
   it("displays the share screen title and description", () => {
     const { getByText } = render(
       <I18nextProvider i18n={i18n}>
-        <AssessmentNavigationContext.Provider
-          value={{ completeRoute: "MyRoute" }}
-        >
-          <Share />
-        </AssessmentNavigationContext.Provider>
+        <Share />
       </I18nextProvider>,
     )
     expect(getByText("Publish anonymized data")).toBeDefined()
@@ -32,18 +29,15 @@ describe("Share", () => {
   })
 
   it("navigates to the assessment complete screen when tap on the cta", () => {
-    const push = jest.fn()
+    const navigateSpy = jest.fn()
+    ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
     const { getByTestId } = render(
       <I18nextProvider i18n={i18n}>
-        <AssessmentNavigationContext.Provider
-          value={{ completeRoute: "MyRoute" }}
-        >
-          <Share navigation={{ push }} />
-        </AssessmentNavigationContext.Provider>
+        <Share />
       </I18nextProvider>,
     )
     const cta = getByTestId("assessment-button")
     fireEvent.press(cta)
-    expect(push).toHaveBeenCalledWith("AssessmentComplete")
+    expect(navigateSpy).toHaveBeenCalledWith("AssessmentComplete")
   })
 })

--- a/src/SelfAssessment/endScreens/Share.tsx
+++ b/src/SelfAssessment/endScreens/Share.tsx
@@ -1,23 +1,22 @@
-import React from "react"
+import React, { FunctionComponent } from "react"
 import { useTranslation } from "react-i18next"
-import env from "react-native-config"
 import { StyleSheet } from "react-native"
 
 import { AssessmentLayout } from "../AssessmentLayout"
 import InfoText from "../InfoText"
 import { Button } from "../../components/Button"
+import { useConfigurationContext } from "../../ConfigurationContext"
 
 import { Icons } from "../../assets"
 import { Colors } from "../../styles"
+import { useNavigation } from "@react-navigation/native"
 
-const { GAEN_AUTHORITY_NAME: authority } = env
-
-/** @type {React.FunctionComponent<{}>} */
-export const Share = ({ navigation }) => {
+export const Share: FunctionComponent = () => {
   const { t } = useTranslation()
+  const navigation = useNavigation()
+  const { healthAuthorityName } = useConfigurationContext()
 
-  // TODO: Implement share logic
-  const handleButtonPress = () => navigation.push("AssessmentComplete")
+  const handleButtonPress = () => navigation.navigate("AssessmentComplete")
 
   return (
     <AssessmentLayout
@@ -35,7 +34,9 @@ export const Share = ({ navigation }) => {
     >
       <InfoText
         title={t("assessment.share_title")}
-        description={t("assessment.share_description", { authority })}
+        description={t("assessment.share_description", {
+          authority: healthAuthorityName,
+        })}
       />
     </AssessmentLayout>
   )

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -1,0 +1,13 @@
+import { Factory } from "fishery"
+import { Configuration } from "../ConfigurationContext"
+
+export default Factory.define<Configuration>(() => ({
+  appDownloadLink: "appDownloadLink",
+  appPackageName: "appPackageName",
+  displayReportAnIssue: false,
+  displaySelfAssessment: false,
+  healthAuthorityAdviceUrl: "authorityAdviceUrl",
+  healthAuthorityName: "authorityName",
+  healthAuthorityPrivacyPolicyUrl: "authorityPrivacyPolicyUrl",
+  regionCodes: ["REGION"],
+}))

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -3,10 +3,12 @@ import tracingStrategy from "./tracingStrategy"
 import exposureDatum from "./exposureDatum"
 import rawExposure from "./rawExposure"
 import exposureContext from "./exposureContext"
+import configurationContext from "./configurationContext"
 
 export const factories = register({
-  tracingStrategy,
+  configurationContext,
+  exposureContext,
   exposureDatum,
   rawExposure,
-  exposureContext,
+  tracingStrategy,
 })

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -4,7 +4,6 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
 import { useTranslation } from "react-i18next"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { SvgXml } from "react-native-svg"
-import env from "react-native-config"
 
 import ExposureHistoryStack from "./ExposureHistoryStack"
 import SelfAssessmentStack from "./SelfAssessmentStack"
@@ -13,6 +12,7 @@ import MoreStack from "./MoreStack"
 import ReportIssueStack from "./ReportIssueStack"
 
 import { useExposureContext } from "../ExposureContext"
+import { useConfigurationContext } from "../ConfigurationContext"
 
 import { Screens, Stacks } from "./index"
 import { TabBarIcons } from "../assets/svgs/TabBarNav"
@@ -24,8 +24,10 @@ const MainTabNavigator: FunctionComponent = () => {
   const { t } = useTranslation()
   const { userHasNewExposure } = useExposureContext()
   const insets = useSafeAreaInsets()
-  const displaySelfAssessment = env.DISPLAY_SELF_ASSESSMENT === "true"
-  const displayReportAnIssue = env.DISPLAY_REPORT_AN_ISSUE === "true"
+  const {
+    displaySelfAssessment,
+    displayReportAnIssue,
+  } = useConfigurationContext()
 
   const applyBadge = (icon: JSX.Element) => {
     return (


### PR DESCRIPTION
Why:
----
The configuration logic needs several safeguards on the way it is being used across the application, from defensive programming to decisions on how to consume it. Some of the operations are changing rapidly and it is hard to keep up. Also, the `react-native-config` package is very hard to test properly. To sum up:

We need a way to abstract the way we get configuration items for the application. This will be an item subject to changes in the next iterations. A few problems we are facing:

- The complexity of "interpreting" environment is scattered across the codebase
- Some logic is leaking from the environment into the business logic
- If any environment variable triggered a change in behavior testing that becomes cumbersome
- Lack of types from environment variables, everything is a string

How:
----
This is attempting to move that logic from just reading string variables to moving the repeated logic decisions into a domain we can control. Right now is just decisions on what platform dictates what environment variable to load, but if this is a pattern we'll keep using is best to move it to a "testable" and more controlled area. We also anticipate that more "decisions" will be made in the load phase of a configuration.

Caveats:
----
- The `helpers` are not included in this first pass since it would involve passing arguments since these are not components. Still working through the best way to send these configs only used in helpers. Comments welcome!
- We are still missing validation of config for a given HA during build time. That is coming in subsequent PR's as we work through the best way of doing this on CI and Fastlane.

This Commit:
----
- Migrate Home screen to use the new exposure context
- Add region codes and app package name to context
- Move usage of env on about and legal screen
- Move usage of env on the main tab navigator
- Renamed variables to include `helathAuthority`
- Move usage of env on More screens to use configuration context
- Remove env from ExposureHistory screens to use the context
- Remove usage of env from Share screen on self assessment
- Transform self assessment share to typescript