### PR TITLE
Update font sizes for general legibility and accessibility

### DIFF
--- a/src/ErrorScreen.tsx
+++ b/src/ErrorScreen.tsx
@@ -65,7 +65,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xxSmall,
   },
   error: {
-    ...Typography.tertiaryContent,
+    ...Typography.description,
     color: Colors.white,
   },
 })

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -156,7 +156,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xxSmall,
   },
   contentText: {
-    ...Typography.tertiaryContent,
+    ...Typography.description,
     color: Colors.neutral100,
   },
   exposureWindowContainer: {
@@ -178,7 +178,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xxSmall,
   },
   bottomSubheaderText: {
-    ...Typography.tertiaryContent,
+    ...Typography.description,
     color: Colors.neutral100,
     marginBottom: Spacing.medium,
   },
@@ -200,7 +200,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xSmall,
   },
   recommendationText: {
-    ...Typography.tinyFont,
+    ...Typography.smallFont,
     color: Colors.primaryText,
   },
   buttonContainer: {

--- a/src/More/ENLocalDiagnosisKeyScreen.tsx
+++ b/src/More/ENLocalDiagnosisKeyScreen.tsx
@@ -96,7 +96,7 @@ const style = StyleSheet.create({
     borderColor: "#999999",
   },
   itemText: {
-    ...Typography.tertiaryContent,
+    ...Typography.description,
     padding: 10,
     maxWidth: "90%",
   },

--- a/src/More/ExposureListDebugScreen.tsx
+++ b/src/More/ExposureListDebugScreen.tsx
@@ -54,7 +54,7 @@ const style = StyleSheet.create({
     borderColor: Colors.neutral75,
   },
   itemText: {
-    ...Typography.tertiaryContent,
+    ...Typography.description,
     padding: Spacing.xSmall,
     maxWidth: "90%",
   },

--- a/src/SelfAssessment/Agreement.tsx
+++ b/src/SelfAssessment/Agreement.tsx
@@ -59,7 +59,7 @@ const AgreementFooter: FunctionComponent<AgreementFooterProps> = ({
 const style = StyleSheet.create({
   typographyStyle: {
     paddingTop: 10,
-    ...Typography.tertiaryContent,
+    ...Typography.description,
     color: Colors.white,
   },
 })

--- a/src/styles/forms.ts
+++ b/src/styles/forms.ts
@@ -21,9 +21,9 @@ export const textInputFormField: TextStyle = {
 }
 
 export const required: TextStyle = {
-  fontSize: Typography.xxSmall,
+  fontSize: Typography.xSmall,
   color: Colors.primaryText,
-  marginTop: Spacing.xxSmall,
+  marginTop: Spacing.xSmall,
 }
 
 export const checkboxIcon: ImageStyle = {

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -3,8 +3,6 @@ import { TextStyle } from "react-native"
 import * as Colors from "./colors"
 
 // Font Size
-export const xxxSmall = 10
-export const xxSmall = 11
 export const xSmall = 12
 export const small = 13
 export const medium = 15
@@ -14,8 +12,6 @@ export const xxLarge = 24
 export const xxxLarge = 28
 
 // Line Height
-export const xxxSmallLineHeight = 10
-export const xxSmallLineHeight = 12
 export const xSmallLineHeight = 14
 export const smallLineHeight = 18
 export const mediumLineHeight = 22
@@ -72,12 +68,6 @@ export const monospace: TextStyle = {
 }
 
 // Standard Font Types
-export const tinyFont: TextStyle = {
-  ...base,
-  fontSize: xxxSmall,
-  lineHeight: xxxSmallLineHeight,
-}
-
 export const xSmallFont: TextStyle = {
   ...base,
   fontSize: xSmall,
@@ -169,13 +159,8 @@ export const secondaryContent: TextStyle = {
   color: Colors.neutral140,
 }
 
-export const tertiaryContent: TextStyle = {
-  ...smallFont,
-  color: Colors.primary100,
-}
-
 export const description: TextStyle = {
-  ...smallFont,
+  ...mediumFont,
   color: Colors.primaryText,
 }
 


### PR DESCRIPTION
Why: prior to this commit, some of our smallest text sizes were too small.

This commit updates our text sizes so that the smallest fonts are still easy to read at
base accessibility settings.

Co-Authored-By: Alex Chen <achen178@gmail.com>

## Before
<img width="337" alt="Screen Shot 2020-08-20 at 12 01 31 PM" src="https://user-images.githubusercontent.com/39350030/90796125-eae85a80-e2dc-11ea-847a-d52d5fe6903a.png">

## After
<img width="366" alt="Screen Shot 2020-08-20 at 12 01 27 PM" src="https://user-images.githubusercontent.com/39350030/90796120-e9b72d80-e2dc-11ea-9fa8-3e71845a930d.png">