### PR TITLE
Native Module to Store and Fetch Revision Token

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureKeyModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureKeyModule.java
@@ -11,6 +11,7 @@ import com.google.android.gms.nearby.Nearby;
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient;
 
 import org.pathcheck.covidsafepaths.MainActivity;
+import org.pathcheck.covidsafepaths.exposurenotifications.storage.RealmSecureStorageBte;
 
 import javax.annotation.Nonnull;
 
@@ -49,5 +50,16 @@ public class ExposureKeyModule  extends ReactContextBaseJavaModule {
         if (activity instanceof MainActivity) {
             ((MainActivity) activity).getExposureKeys(promise);
         }
+    }
+
+    @ReactMethod
+    public void storeRevisionToken(String revisionToken, final Promise promise) {
+        RealmSecureStorageBte.INSTANCE.upsertRevisionToken(revisionToken);
+        promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void getRevisionToken(final Promise promise) {
+        promise.resolve(RealmSecureStorageBte.INSTANCE.getRevisionToken());
     }
 }

--- a/ios/BT/Storage/KeychainService.swift
+++ b/ios/BT/Storage/KeychainService.swift
@@ -1,8 +1,9 @@
 import KeychainAccess
 
-final class KeychainService {
+@objc(KeychainService)
+final class KeychainService: NSObject {
 
-  static let shared = KeychainService()
+  @objc static let shared = KeychainService()
 
   private lazy var keychain = Keychain(service: "\(Bundle.main.bundleIdentifier!).keychainService")
 
@@ -10,7 +11,7 @@ final class KeychainService {
     ReactNativeConfig.env(for: .dev) != nil
   }
 
-  func setRevisionToken(_ token: String) {
+  @objc func setRevisionToken(_ token: String) {
     if isDev {
       keychain[String.revisionTokenDev] = token
     } else {
@@ -18,7 +19,7 @@ final class KeychainService {
     }
   }
 
-  var revisionToken: String {
+  @objc var revisionToken: String {
     return (isDev ? keychain[String.revisionTokenDev] : keychain[String.revisionToken]) ?? .default
   }
 

--- a/ios/BT/bridge/ExposureKeyModule.m
+++ b/ios/BT/bridge/ExposureKeyModule.m
@@ -26,5 +26,22 @@ RCT_REMAP_METHOD(postDiagnosisKeys,
   [[ExposureManager shared] getAndPostDiagnosisKeysWithCertificate:certificate HMACKey:HMACKey resolve:resolve reject:reject];
 }
 
+RCT_REMAP_METHOD(storeRevisionToken,
+                 revisionToken: (NSString *)revisionToken
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [[KeychainService shared] setRevisionToken:revisionToken];
+  resolve(nil);
+}
+
+RCT_REMAP_METHOD(getRevisionToken,
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSString *revisionToken = [[KeychainService shared] revisionToken];
+  resolve(revisionToken);
+}
+
 
 @end

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -125,6 +125,16 @@ export const submitDiagnosisKeys = async (
   return exposureKeyModule.postDiagnosisKeys(certificate, hmacKey)
 }
 
+export const storeRevisionToken = async (
+  revisionToken: string,
+): Promise<void> => {
+  return exposureKeyModule.storeRevisionToken(revisionToken)
+}
+
+export const getRevisionToken = async (): Promise<string> => {
+  return exposureKeyModule.getRevisionToken()
+}
+
 // Device Info Module
 const deviceInfoModule = NativeModules.DeviceInfoModule
 


### PR DESCRIPTION
### Why
We'd like to move the key submission request to the JS layer and only use the native layer for revision token storage.

### This Commit
This commit adds native methods to store and fetch the revision token