### PR TITLE
Add bugsnag and logs to the key submission process

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, useState, useEffect } from "react"
 import SplashScreen from "react-native-splash-screen"
 import "array-flat-polyfill"
 import env from "react-native-config"
+import Bugsnag from "@bugsnag/react-native"
 
 import MainNavigator from "./src/navigation/MainNavigator"
 import { ErrorBoundary } from "./src/ErrorBoundaries"
@@ -12,6 +13,8 @@ import {
 } from "./src/OnboardingContext"
 import { PermissionsProvider } from "./src/PermissionsContext"
 import { initializei18next, loadUserLocale } from "./src/locales/languages"
+
+Bugsnag.start()
 
 const App: FunctionComponent = () => {
   const [isLoading, setIsLoading] = useState(true)

--- a/__mocks__/@bugsnag/react-native.js
+++ b/__mocks__/@bugsnag/react-native.js
@@ -1,0 +1,7 @@
+const Bugsnag = {
+  addMetadata: jest.fn(),
+  leaveBreadcrumb: jest.fn(),
+  notify: jest.fn(),
+}
+
+export default Bugsnag

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,6 +10,9 @@ project.ext.envConfigFiles = [
 ]
 
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
+
+apply from: "../../node_modules/@bugsnag/react-native/bugsnag-react-native.gradle"
+
 /**
  * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
  * and bundleReleaseJsAndAssets).

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-
     <uses-permission android:name="android.permission.BLUETOOTH" />
 
     <application
@@ -14,6 +13,10 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher"
         android:theme="@style/AppTheme">
+
+        <meta-data android:name="com.bugsnag.android.API_KEY"
+             android:value="3950fbb2e58f6b77c75ac53b8559aad8"/>
+
         <uses-library
             android:name="org.apache.http.legacy"
             android:required="false" />

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/MainApplication.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/MainApplication.java
@@ -9,6 +9,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.jakewharton.threetenabp.AndroidThreeTen;
+import com.bugsnag.android.Bugsnag;
 
 import org.pathcheck.covidsafepaths.bridge.ExposureNotificationsPackage;
 
@@ -56,6 +57,7 @@ public class MainApplication extends Application implements ReactApplication {
         SoLoader.init(this, /* native exopackage */ false);
         Realm.init(this);
         initializeFlipper(this); // Remove this line if you don't want Flipper enabled
+        Bugsnag.start(this);
     }
 
     /**

--- a/ios/AppDelegate.m
+++ b/ios/AppDelegate.m
@@ -16,6 +16,7 @@
 #import <UserNotifications/UserNotifications.h>
 #import <RNSplashScreen.h>
 #import <BT-Swift.h>
+#import <Bugsnag/Bugsnag.h>
 
 @implementation AppDelegate
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -47,6 +48,7 @@
   [[ExposureManager shared] setup];
 
   [RNSplashScreen showSplash:@"LaunchScreen" inRootView:rootView];
+  [Bugsnag start];
   return YES;
 }
 

--- a/ios/BT/Info.plist
+++ b/ios/BT/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>bugsnag</key>
+	<dict>
+		<key>apiKey</key>
+		<string>3950fbb2e58f6b77c75ac53b8559aad8</string>
+	</dict>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.transistorsoft.fetch</string>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,8 @@
 PODS:
   - Alamofire (4.9.1)
   - boost-for-react-native (1.63.0)
+  - BugsnagReactNative (7.3.2):
+    - React
   - BVLinearGradient (2.5.6):
     - React
   - DoubleConversion (1.1.6)
@@ -287,6 +289,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.9.1)
+  - "BugsnagReactNative (from `../node_modules/@bugsnag/react-native`)"
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -347,6 +350,8 @@ SPEC REPOS:
     - ZIPFoundation
 
 EXTERNAL SOURCES:
+  BugsnagReactNative:
+    :path: "../node_modules/@bugsnag/react-native"
   BVLinearGradient:
     :path: "../node_modules/react-native-linear-gradient"
   DoubleConversion:
@@ -435,6 +440,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
+  BugsnagReactNative: 3e44e73c4ec6b68e46ed1f2163229dd535522990
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     ]
   },
   "dependencies": {
+    "@bugsnag/react-native": "^7.3.2",
     "@react-native-community/async-storage": "^1.8.1",
     "@react-native-community/datetimepicker": "^2.3.2",
     "@react-native-community/masked-view": "^0.1.10",

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
@@ -11,6 +11,7 @@ import { Screens } from "../../navigation"
 import { ExposureContext } from "../../ExposureContext"
 import { factories } from "../../factories"
 
+jest.mock("../../logger.ts")
 jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 describe("CodeInputForm", () => {

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -10,6 +10,7 @@ import { factories } from "../../factories"
 import { Alert } from "react-native"
 
 jest.mock("@react-navigation/native")
+jest.mock("../../logger.ts")
 
 describe("PublishConsentScreen", () => {
   it("navigates to the home screen when user cancels", () => {

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -29,6 +29,7 @@ import {
   Layout,
 } from "../../styles"
 import { useExposureContext } from "../../ExposureContext"
+import Logger from "../../logger"
 
 interface PublishConsentFormProps {
   hmacKey: string
@@ -51,6 +52,11 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
       navigation.navigate(AffectedUserFlowScreens.AffectedUserComplete)
     } catch (e) {
       setIsLoading(false)
+      const errorMessage = e.message
+      Logger.addMetadata("publishKeys", {
+        errorMessage,
+      })
+      Logger.error("Incomplete Key Submission")
       Alert.alert(t("common.something_went_wrong"), e.message)
     }
   }

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.spec.tsx
@@ -1,3 +1,4 @@
+jest.mock("../../logger.ts")
 import React from "react"
 import { render, fireEvent } from "@testing-library/react-native"
 import { useNavigation } from "@react-navigation/native"

--- a/src/AffectedUserFlow/hmac.spec.ts
+++ b/src/AffectedUserFlow/hmac.spec.ts
@@ -2,6 +2,8 @@ import RNSimpleCrypto from "react-native-simple-crypto"
 
 import { calculateHmac } from "./hmac"
 
+jest.mock("../logger.ts")
+
 describe("calculateHmac", () => {
   const mockRandomBytesGeneration = () => {
     const randomBytes = new ArrayBuffer(1)

--- a/src/AffectedUserFlow/hmac.ts
+++ b/src/AffectedUserFlow/hmac.ts
@@ -1,6 +1,7 @@
 import RNSimpleCrypto from "react-native-simple-crypto"
 
 import { ExposureKey } from "../exposureKey"
+import Logger from "../logger"
 
 export const generateKey = async (): Promise<ArrayBuffer> => {
   return await RNSimpleCrypto.utils.randomBytes(32)
@@ -21,6 +22,10 @@ export const calculateHmac = async (
     messageArrayBuffer,
     hmacKey,
   )
+
+  Logger.addMetadata("publishKeys", {
+    serializedKeys: exposureKeyMessage,
+  })
 
   return [
     RNSimpleCrypto.utils.convertArrayBufferToBase64(signatureArrayBuffer),

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,34 @@
+import Bugsnag from "@bugsnag/react-native"
+
+type Loggable = Record<string, unknown>
+
+class Logger {
+  static error(message: string, data?: Loggable): void {
+    if (__DEV__) {
+      console.error(message, data)
+    } else {
+      if (data) {
+        Bugsnag.addMetadata("data", data)
+      }
+      Bugsnag.notify(new Error(message))
+    }
+  }
+
+  static event(message: string, data?: Loggable): void {
+    if (__DEV__) {
+      console.warn(message, data)
+    } else {
+      Bugsnag.leaveBreadcrumb(message, data)
+    }
+  }
+
+  static addMetadata(section: string, data: Loggable): void {
+    if (__DEV__) {
+      console.log(`Adding to the metadata: ${section}`, data)
+    } else {
+      Bugsnag.addMetadata(section, data)
+    }
+  }
+}
+
+export default Logger

--- a/yarn.lock
+++ b/yarn.lock
@@ -648,6 +648,111 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
 
+"@bugsnag/core@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/core/-/core-7.3.0.tgz#5fd6876a161cb28e8b14364d46b2f58c304356e6"
+  integrity sha512-Sa24robOiIpj4AmqHwM+oEZM/QN1P+ixwQtvdLZ/Rc0YJYYh2I+eITAaFGlz9uDao/bsWLNUedq8XyNZd1IxRQ==
+  dependencies:
+    "@bugsnag/cuid" "^3.0.0"
+    "@bugsnag/safe-json-stringify" "^6.0.0"
+    error-stack-parser "^2.0.3"
+    iserror "0.0.2"
+    stack-generator "^2.0.3"
+
+"@bugsnag/cuid@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/cuid/-/cuid-3.0.0.tgz#2ee7642a30aee6dc86f5e7f824653741e42e5c35"
+  integrity sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==
+
+"@bugsnag/delivery-react-native@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/delivery-react-native/-/delivery-react-native-7.3.0.tgz#f3ab98ad9ea9687561cee1a62e3b4f04b1a0a883"
+  integrity sha512-imzBBn4B8P/qg+GWj+c0j5HhjdbqcXVpzdBMbJPQbi1GYco41QHCji5ZQw1VqeNq50bAKTE9v3314F7gAfTZ1w==
+  dependencies:
+    "@bugsnag/core" "^7.3.0"
+
+"@bugsnag/plugin-console-breadcrumbs@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-console-breadcrumbs/-/plugin-console-breadcrumbs-7.3.0.tgz#1f2297e03dac97bd3d633890c89c248810eb0f51"
+  integrity sha512-vGtFAuh3vqYirotOAe/oIzqWmdtQY012A0iAwb5DcNX8Ycn7CQoLSjK1m7cVcFTmLFYkieT/74g8cpb/pmnGYQ==
+  dependencies:
+    "@bugsnag/core" "^7.3.0"
+
+"@bugsnag/plugin-network-breadcrumbs@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-network-breadcrumbs/-/plugin-network-breadcrumbs-7.3.0.tgz#9c9dcb8f6cf0e32fc9b34bdea607ff7059e6399b"
+  integrity sha512-/4iIBygmbb28lCX6Cz+ewt+huzWVKOEtPElHgMhzbw2w+545+mW0L0p3bbezP7Y9hnYtaFba1VN//vA928O6og==
+  dependencies:
+    "@bugsnag/core" "^7.3.0"
+
+"@bugsnag/plugin-react-native-client-sync@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react-native-client-sync/-/plugin-react-native-client-sync-7.3.0.tgz#384e387cd8986e8df236456651a462ce6f50af19"
+  integrity sha512-kzROt7dJ97GhOVhf5NHcGIibzRzz9FSGiijc5dIdsu9EtFsVPNnWIUZH5iJbgWZqV4VzNBeg6c/m6OnvDwlrxg==
+  dependencies:
+    "@bugsnag/core" "^7.3.0"
+    proxyquire "^2.1.0"
+
+"@bugsnag/plugin-react-native-event-sync@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react-native-event-sync/-/plugin-react-native-event-sync-7.3.0.tgz#cf56609ab4ee82432d674617e62cb1192ba319bd"
+  integrity sha512-F/XlsDkh67SObjED8j0pEQG4wuY5pL3B5HS2DnDKqbfwL+oJk7nYs2ioRu+PHj58E1Rn7diVuSt6Un54TpwivQ==
+  dependencies:
+    "@bugsnag/core" "^7.3.0"
+    proxyquire "^2.1.1"
+
+"@bugsnag/plugin-react-native-global-error-handler@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react-native-global-error-handler/-/plugin-react-native-global-error-handler-7.3.0.tgz#0625a6e73a9e6f15386204d41af3a10c6e3955d9"
+  integrity sha512-/0wG7Af/DuWFXfLSfBD4Aw+INkwly8fjRnnGk613U4lczrR7IrEo3q5qhvyruPc6XbxVoaF+zQf+An7UwXJDUw==
+
+"@bugsnag/plugin-react-native-hermes@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react-native-hermes/-/plugin-react-native-hermes-7.3.0.tgz#ab5222123eb2b2b1e5a9cfea86a69e2f063b79f3"
+  integrity sha512-JE/vl9PGFWlxeQPsrAswDJVy58i3B4o74vwD76SOrAH7+PM0YCl91GE6en75mmKCRzymIBZS9KBvHTilzKw1Sw==
+
+"@bugsnag/plugin-react-native-session@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react-native-session/-/plugin-react-native-session-7.3.0.tgz#c6943b107a76e07b86ffdff100108f31e9105ef2"
+  integrity sha512-9QpHR/MyEZ1Ip3RCXmBFCwoWXPzoOnqsP6vzpxiYa+ZBDzJJHlhz1V8gESJqyzVBRT5exz8+TGsOLvyM/nFFmw==
+  dependencies:
+    "@bugsnag/core" "^7.3.0"
+
+"@bugsnag/plugin-react-native-unhandled-rejection@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react-native-unhandled-rejection/-/plugin-react-native-unhandled-rejection-7.3.0.tgz#616e96c64c876eee4aa39a2d2a77f1edba94a9a1"
+  integrity sha512-OhsfHIz0c1zKENBsZZ57XcsqVqsNfj7qU4lVwtPgUd3gVUKNT+YZd7aHE2Pu+FOvsuD4xX+ZpxRT+TNFU5493w==
+
+"@bugsnag/plugin-react@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react/-/plugin-react-7.3.1.tgz#8334e377e89c5da0409fd740d55e89841864ceef"
+  integrity sha512-C8sBjXj6KFPFzfqnu+O6gF5XmSuOj0xYgraQn0BEwFM4ye05QUres8Giza9N+xO7OV2YvIgG3gq6s/AHLadj7g==
+  dependencies:
+    "@bugsnag/core" "^7.3.0"
+
+"@bugsnag/react-native@^7.3.2":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@bugsnag/react-native/-/react-native-7.3.2.tgz#a03b0c04ae2d38409572005c9f696ad56f5fd04c"
+  integrity sha512-XDPz4wnrgRJDqcdfI0K5jS8QgBny7T29XAb2zbONre1HkWr2YRCpKroZhbC0avbw+uaa5Un8iTAXKWxLoQpE7g==
+  dependencies:
+    "@bugsnag/core" "^7.3.0"
+    "@bugsnag/delivery-react-native" "^7.3.0"
+    "@bugsnag/plugin-console-breadcrumbs" "^7.3.0"
+    "@bugsnag/plugin-network-breadcrumbs" "^7.3.0"
+    "@bugsnag/plugin-react" "^7.3.1"
+    "@bugsnag/plugin-react-native-client-sync" "^7.3.0"
+    "@bugsnag/plugin-react-native-event-sync" "^7.3.0"
+    "@bugsnag/plugin-react-native-global-error-handler" "^7.3.0"
+    "@bugsnag/plugin-react-native-hermes" "^7.3.0"
+    "@bugsnag/plugin-react-native-session" "^7.3.0"
+    "@bugsnag/plugin-react-native-unhandled-rejection" "^7.3.0"
+    iserror "^0.0.2"
+
+"@bugsnag/safe-json-stringify@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz#22abdcd83e008c369902976730c34c150148a758"
+  integrity sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -3052,6 +3157,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
+  integrity sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
+  dependencies:
+    stackframe "^1.1.1"
+
 errorhandler@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/errorhandler/-/errorhandler-1.5.1.tgz#b9ba5d17cf90744cd1e851357a6e75bf806a9a91"
@@ -3676,6 +3788,14 @@ file-entry-cache@^5.0.1:
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  integrity sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -4482,6 +4602,11 @@ is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
+is-object@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
+
 is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
@@ -4571,6 +4696,11 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+iserror@0.0.2, iserror@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/iserror/-/iserror-0.0.2.tgz#bd53451fe2f668b9f2402c1966787aaa2c7c0bf5"
+  integrity sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -5602,6 +5732,11 @@ merge-deep@^3.0.2:
     clone-deep "^0.2.4"
     kind-of "^3.0.2"
 
+merge-descriptors@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
 merge-stream@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
@@ -5942,6 +6077,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@~0.5.1:
 mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
+
+module-not-found-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+  integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
 moment@^2.10.6:
   version "2.25.3"
@@ -6646,6 +6786,15 @@ proper-lockfile@^3.0.2:
     retry "^0.12.0"
     signal-exit "^3.0.2"
 
+proxyquire@^2.1.0, proxyquire@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.3.tgz#2049a7eefa10a9a953346a18e54aab2b4268df39"
+  integrity sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.1"
+    resolve "^1.11.1"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -7151,7 +7300,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   dependencies:
@@ -7646,6 +7795,13 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
 
+stack-generator@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.5.tgz#fb00e5b4ee97de603e0773ea78ce944d81596c36"
+  integrity sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==
+  dependencies:
+    stackframe "^1.1.1"
+
 stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
@@ -7656,6 +7812,11 @@ stack-utils@^2.0.2:
   integrity sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+stackframe@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
+  integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
 stacktrace-parser@^0.1.3:
   version "0.1.10"


### PR DESCRIPTION
Why:
----
We are lacking visibility on the data flow during the submission of exposure keys. We need a way to gain insight on what are the errors, on which environment and what are the problems we are having. Namely which exchange is happening among all actors in the process:
- OS and application with keys
- Verification server and application
- Exposure Keys server and application

How:
----
By adding a logs service like `bugsnag` we not only have the ability to log the data flow among all the actors but also gain info on how the users are behaving and what other errors we might be missing.

This Commit:
----
- Install and setup `bugsnag`
- Add `Logger` service object to add relevant metadata to the session and send errors
- Add logs to the submission process and fix tests

Caveat:
----
This first implementation with bugsnag is not uploading symbol files, we'll address that on future iterations. There's a [guide] available.

[guide]: https://docs.bugsnag.com/platforms/react-native/react-native/showing-full-stacktraces/#uploading-source-maps

Co-authored-by: Alejandro Dustet <alejandro@thoughtbot.com>
