### PR TITLE
Log unhandled errors from code verification

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -96,12 +96,18 @@ const CodeInputForm: FunctionComponent = () => {
         } else {
           const errorMessage = showCertificateError(certResponse.error)
           Logger.error(
-            `FailedCertificateGenerationWithValidCode${errorMessage}`,
+            `FailedCertificateGenerationWithValidCode${errorMessage}, ${certResponse.message}`,
           )
           setErrorMessage(errorMessage)
         }
       } else {
-        setErrorMessage(showError(response.error))
+        const errorMessage = showError(response.error)
+        if (response.message) {
+          Logger.error(
+            `FailedCodeValidation${errorMessage}, ${response.message}`,
+          )
+        }
+        setErrorMessage(errorMessage)
       }
       setIsLoading(false)
     } catch (e) {

--- a/src/AffectedUserFlow/verificationAPI.spec.ts
+++ b/src/AffectedUserFlow/verificationAPI.spec.ts
@@ -94,8 +94,9 @@ describe("postCode", () => {
     })
 
     it("returns Unknown error for other errors", async () => {
+      const errorMessage = "unknown"
       const jsonResponse = {
-        error: "unknown",
+        error: errorMessage,
       }
       ;(fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
@@ -107,6 +108,7 @@ describe("postCode", () => {
       expect(result).toEqual({
         kind: "failure",
         error: "Unknown",
+        message: errorMessage,
       })
     })
   })
@@ -186,8 +188,9 @@ describe("postTokenAndHmac", () => {
     })
 
     it("returns Unknown error for other errors", async () => {
+      const errorMessage = "unknown"
       const jsonResponse = {
-        error: "unknown",
+        error: errorMessage,
       }
       ;(fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
@@ -199,6 +202,7 @@ describe("postTokenAndHmac", () => {
       expect(result).toEqual({
         kind: "failure",
         error: "Unknown",
+        message: errorMessage,
       })
     })
   })

--- a/src/AffectedUserFlow/verificationAPI.ts
+++ b/src/AffectedUserFlow/verificationAPI.ts
@@ -19,6 +19,7 @@ interface NetworkSuccess<T> {
 interface NetworkFailure<U> {
   kind: "failure"
   error: U
+  message?: string
 }
 
 export type NetworkResponse<T, U = "Unknown"> =
@@ -72,7 +73,7 @@ export const postCode = async (
         case "verification code used":
           return { kind: "failure", error: "VerificationCodeUsed" }
         default:
-          return { kind: "failure", error: "Unknown" }
+          return { kind: "failure", error: "Unknown", message: json.error }
       }
     }
   } catch (e) {
@@ -120,7 +121,7 @@ export const postTokenAndHmac = async (
           return { kind: "failure", error: "TokenMetaDataMismatch" }
         }
         default: {
-          return { kind: "failure", error: "Unknown" }
+          return { kind: "failure", error: "Unknown", message: json.error }
         }
       }
     }


### PR DESCRIPTION
Why:
----
Some of the server responses verifying and generating the certificates are new to us, we need to gain visibility on the messages to best know how to present a helpful error to users.

This Commit:
----
- Log message from the server if it is not being parsed by our API responders
