### PR TITLE
(Android) Disable bugsnag on release builds

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/MainApplication.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/MainApplication.java
@@ -62,8 +62,8 @@ public class MainApplication extends Application implements ReactApplication {
   @SuppressWarnings("ConstantConditions")
   private void initializeBugsnag() {
     Configuration config = Configuration.load(this);
-    // Only enable bugsnag for debug builds
-    config.setReleaseStage("debug".equals(BuildConfig.BUILD_TYPE) ? "development" : "production");
+    // Disable bugsnag for release builds
+    config.setReleaseStage("release".equals(BuildConfig.BUILD_TYPE) ? "production" : "development");
     Set<String> enabledStages = new HashSet<>();
     enabledStages.add("development");
     config.setEnabledReleaseStages(enabledStages);

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/MainApplication.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/MainApplication.java
@@ -3,6 +3,7 @@ package org.pathcheck.covidsafepaths;
 import android.app.Application;
 import android.content.Context;
 import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
@@ -11,7 +12,9 @@ import com.facebook.soloader.SoLoader;
 import com.jakewharton.threetenabp.AndroidThreeTen;
 import io.realm.Realm;
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.pathcheck.covidsafepaths.bridge.ExposureNotificationsPackage;
 
 public class MainApplication extends Application implements ReactApplication {
@@ -53,7 +56,18 @@ public class MainApplication extends Application implements ReactApplication {
     SoLoader.init(this, /* native exopackage */ false);
     Realm.init(this);
     initializeFlipper(this); // Remove this line if you don't want Flipper enabled
-    Bugsnag.start(this);
+    initializeBugsnag();
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private void initializeBugsnag() {
+    Configuration config = Configuration.load(this);
+    // Only enable bugsnag for debug builds
+    config.setReleaseStage("debug".equals(BuildConfig.BUILD_TYPE) ? "development" : "production");
+    Set<String> enabledStages = new HashSet<>();
+    enabledStages.add("development");
+    config.setEnabledReleaseStages(enabledStages);
+    Bugsnag.start(this, config);
   }
 
   /**


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
This PR disables Bugsnag on release builds.

Bugsnag has the concept of "stages" to identify each environment. We will only notify Bugsnag when using the `development` stage.
https://docs.bugsnag.com/platforms/android/configuration-options/#releasestage
https://docs.bugsnag.com/platforms/android/configuration-options/#enabledreleasestages

I think this is enough to disable it and nothing else is needed on the JS side: 
https://docs.bugsnag.com/platforms/react-native/react-native/#further-configuration.

#### How to test:
If Bugsnag is enabled you will see logs like these:
```
2020-08-24 14:53:24.731 5831-6061/org.pathcheck.covidsafepaths.bt D/Bugsnag: Received NDK message com.bugsnag.android.StateEvent$StartSession@3d68367
2020-08-24 14:53:30.730 5831-5831/org.pathcheck.covidsafepaths.bt D/Bugsnag: Received NDK message com.bugsnag.android.StateEvent$AddBreadcrumb@b0691c9
2020-08-24 14:53:30.751 5831-5831/org.pathcheck.covidsafepaths.bt D/Bugsnag: Received NDK message com.bugsnag.android.StateEvent$AddBreadcrumb@72cbef
2020-08-24 14:53:31.020 5831-5831/org.pathcheck.covidsafepaths.bt D/Bugsnag: Received NDK message com.bugsnag.android.StateEvent$UpdateInForeground@8af66e8
```

That's the information that Bugsnag automatically captures and you won't see those logs if it's disabled.
https://docs.bugsnag.com/platforms/android/#logging-breadcrumbs
https://docs.bugsnag.com/platforms/android/#session-tracking