### PR TITLE
Introduce staging configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,6 +92,8 @@ apply from: "../../node_modules/@bugsnag/react-native/bugsnag-react-native.gradl
 project.ext.react = [
     entryFile: "index.js",
     bundleInDebug: false,
+    bundleInStaging: true,
+    devDisabledInStaging: true,
     enableHermes: false,  // clean and rebuild if changing
 ]
 
@@ -201,6 +203,10 @@ android {
             def outputSuffix = project.hasProperty('outputSuffix') ? '-' + project.outputSuffix : ''
             setProperty("archivesBaseName", project.archivesBaseName.concat(outputSuffix))
         }
+        staging {
+            // Same gradle configuration as release, it will use a different env file
+            initWith release
+        }
     }
 }
 
@@ -237,6 +243,7 @@ dependencies {
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/"
         debugImplementation files(hermesPath + "hermes-debug.aar")
+        stagingImplementation files(hermesPath + "hermes-release.aar")
         releaseImplementation files(hermesPath + "hermes-release.aar")
     } else {
         implementation jscFlavor

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'realm-android'
 
 project.ext.envConfigFiles = [
     debug: ".env.bt",
+    staging: ".env.bt.staging",
     release: ".env.bt.release",
 ]
 

--- a/bin/dev_setup.sh
+++ b/bin/dev_setup.sh
@@ -104,6 +104,7 @@ fi
 printf "$spacer"
 if [ ! -f .env.bt ]; then
   cp example.env.bt .env.bt
+  cp example.env.bt .env.bt.staging
   cp example.env.bt .env.bt.release
 fi
 

--- a/bin/fetch_ha_env.sh
+++ b/bin/fetch_ha_env.sh
@@ -38,15 +38,20 @@ def fetch_env
   puts "...fetching .env for #{HA_LABEL}"
 
   dev_env_source = ".env.bt"
+  staging_env_source = ".env.bt.staging"
   release_env_source = ".env.bt.release"
 
   dev_env_url =
   "https://#{token}@raw.githubusercontent.com/Path-Check/pathcheck-mobile-resources/master/environment/#{HA_LABEL}/.env.bt"
 
+  staging_env_url =
+  "https://#{token}@raw.githubusercontent.com/Path-Check/pathcheck-mobile-resources/master/environment/#{HA_LABEL}/.env.bt.staging"
+
   release_env_url =
   "https://#{token}@raw.githubusercontent.com/Path-Check/pathcheck-mobile-resources/master/environment/#{HA_LABEL}/.env.bt.release"
 
   fetch_and_write_file(dev_env_source, dev_env_url)
+  fetch_and_write_file(staging_env_source, staging_env_url)
   fetch_and_write_file(release_env_source, release_env_url)
 
   puts "finished fetching .env for #{HA_LABEL}"

--- a/ios/COVIDSafePaths.xcodeproj/xcshareddata/xcschemes/BT_Adhoc.xcscheme
+++ b/ios/COVIDSafePaths.xcodeproj/xcshareddata/xcschemes/BT_Adhoc.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &quot;.env.bt&quot; &gt; /tmp/envfile   # use .env&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "C53FD07D24719AD1006D3268"
+                     BuildableName = "BT.app"
+                     BlueprintName = "BT"
+                     ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C53FD07D24719AD1006D3268"
+               BuildableName = "BT.app"
+               BlueprintName = "BT"
+               ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release-BT"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "GPS.app"
+            BlueprintName = "GPS"
+            ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C5AA24D124768FFF00BA0A99"
+               BuildableName = "BTTests.xctest"
+               BlueprintName = "BTTests"
+               ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release-BT"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release-BT"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C53FD07D24719AD1006D3268"
+            BuildableName = "BT.app"
+            BlueprintName = "BT"
+            ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release-BT">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release-BT"
+      customArchiveName = "BT"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/COVIDSafePaths.xcodeproj/xcshareddata/xcschemes/BT_Production.xcscheme
+++ b/ios/COVIDSafePaths.xcodeproj/xcshareddata/xcschemes/BT_Production.xcscheme
@@ -41,7 +41,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release-GPS"
+      buildConfiguration = "Release-BT"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/ios/COVIDSafePaths.xcodeproj/xcshareddata/xcschemes/BT_Staging.xcscheme
+++ b/ios/COVIDSafePaths.xcodeproj/xcshareddata/xcschemes/BT_Staging.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo &quot;.env.bt.staging&quot; &gt; /tmp/envfile   # use .env.bt.staging&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "C53FD07D24719AD1006D3268"
+                     BuildableName = "BT.app"
+                     BlueprintName = "BT"
+                     ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C53FD07D24719AD1006D3268"
+               BuildableName = "BT.app"
+               BlueprintName = "BT"
+               ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release-GPS"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "GPS.app"
+            BlueprintName = "GPS"
+            ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C5AA24D124768FFF00BA0A99"
+               BuildableName = "BTTests.xctest"
+               BlueprintName = "BTTests"
+               ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release-BT"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release-BT"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C53FD07D24719AD1006D3268"
+            BuildableName = "BT.app"
+            BlueprintName = "BT"
+            ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release-BT">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release-BT"
+      customArchiveName = "BT"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/More/Menu.tsx
+++ b/src/More/Menu.tsx
@@ -58,13 +58,15 @@ const MenuScreen: FunctionComponent = () => {
           lastItem
         />
       </View>
-      <View style={style.section}>
-        <SettingsListItem
-          label="EN Debug Menu"
-          onPress={() => navigation.navigate(MoreStackScreens.ENDebugMenu)}
-          lastItem
-        />
-      </View>
+      {__DEV__ ? (
+        <View style={style.section}>
+          <SettingsListItem
+            label="EN Debug Menu"
+            onPress={() => navigation.navigate(MoreStackScreens.ENDebugMenu)}
+            lastItem
+          />
+        </View>
+      ) : null}
     </ScrollView>
   )
 }

--- a/src/More/Menu.tsx
+++ b/src/More/Menu.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet, ScrollView, TouchableOpacity } from "react-native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 import { useNavigation } from "@react-navigation/native"
+import env from "react-native-config"
 
 import { getLocalNames } from "../locales/languages"
 import { GlobalText } from "../components/GlobalText"
@@ -19,6 +20,7 @@ const MenuScreen: FunctionComponent = () => {
   } = useTranslation()
   const languageName = getLocalNames()[localeCode]
   useStatusBarEffect("light-content")
+  const showDebugMenu = env.DEV === "true" || env.STAGING === "true"
 
   const handleOnPressSelectLanguage = () => {
     navigation.navigate(Screens.LanguageSelection)
@@ -58,7 +60,7 @@ const MenuScreen: FunctionComponent = () => {
           lastItem
         />
       </View>
-      {__DEV__ ? (
+      {showDebugMenu ? (
         <View style={style.section}>
           <SettingsListItem
             label="EN Debug Menu"

--- a/src/More/Menu.tsx
+++ b/src/More/Menu.tsx
@@ -20,7 +20,7 @@ const MenuScreen: FunctionComponent = () => {
   } = useTranslation()
   const languageName = getLocalNames()[localeCode]
   useStatusBarEffect("light-content")
-  const showDebugMenu = env.DEV === "true" || env.STAGING === "true"
+  const showDebugMenu = env.DEV === "true"
 
   const handleOnPressSelectLanguage = () => {
     navigation.navigate(Screens.LanguageSelection)


### PR DESCRIPTION
### Why
We'd like to suppress the debug menu for release builds, and also ensure that builds are not pointed to the release environment during testing

### This Commit
This commit introduces a `STAGING` env configuration that suppresses the debug menu and points to the dev server, as well as an `Adhoc` scheme for `iOS` that uses the `.env.bt` configuration