### PR TITLE
(Android) Show notification when Simulate Exposure is pressed

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
+import org.pathcheck.covidsafepaths.exposurenotifications.common.NotificationHelper;
 import org.pathcheck.covidsafepaths.exposurenotifications.dto.RNDiagnosisKey;
 import org.pathcheck.covidsafepaths.exposurenotifications.nearby.ProvideDiagnosisKeysWorker;
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.RealmSecureStorageBte;
@@ -79,7 +80,8 @@ public class DebugMenuModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void simulateExposure(Promise promise) {
-    promise.reject(new Exception("Not implemented"));
+    NotificationHelper.showPossibleExposureNotification(getReactApplicationContext());
+    promise.resolve(null);
   }
 
   @ReactMethod


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
This PR shows an exposure notification when `Simulate Exposure` is pressed in the debug menu.
It makes easier to test how the notification icon looks and it won't have any impact in the current flow (it doesn't insert anything in the database)