### PR TITLE
Function Signature Mismatch Fix

### DIFF
--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -64,11 +64,12 @@ export const requestAuthorization = async (): Promise<string> => {
   return permissionsModule.requestExposureNotificationAuthorization()
 }
 
-export const getCurrentENPermissionsStatus = async (): Promise<
-  ENPermissionStatus
-> => {
+export const getCurrentENPermissionsStatus = async (
+  cb: (status: ENPermissionStatus) => void,
+): Promise<void> => {
   const response = await permissionsModule.getCurrentENPermissionsStatus()
-  return toStatus(response)
+  cb(toStatus(response))
+  return Promise.resolve()
 }
 
 // Exposure History Module


### PR DESCRIPTION
### Why
To accurately reflect EN permissions state on app launch

### This Commit
This commit fixes a function signature mismatch between `PermissionsContext` and `nativeModule`