### PR TITLE
Use debug signing configuration for staging

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -193,6 +193,10 @@ android {
             signingConfig signingConfigs.debug
             matchingFallbacks = ['debug']
         }
+        staging {
+            // Same gradle configuration as debug, it will use a different env file
+            initWith debug
+        }
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
@@ -202,10 +206,6 @@ android {
             // Differentiate each HA by its APK name
             def outputSuffix = project.hasProperty('outputSuffix') ? '-' + project.outputSuffix : ''
             setProperty("archivesBaseName", project.archivesBaseName.concat(outputSuffix))
-        }
-        staging {
-            // Same gradle configuration as release, it will use a different env file
-            initWith release
         }
     }
 }

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -16,9 +16,12 @@
 default_platform(:android)
 
 platform :android do
-  desc "Runs Android (Native) unit tests"
-  lane :test do
-    gradle(task: "test")
+  desc "Increment version code"
+  lane :release_increment_version_code do |options|
+    increment_version_code(
+      gradle_file_path: "app/build.gradle",
+      version_code: options[:versionCode]
+    )
   end
 
   desc "Build a Debug AAB"
@@ -26,15 +29,16 @@ platform :android do
     gradle(
       task: "assemble",
       build_type: "debug",
-      print_command: false,
+      print_command: false
     )
   end
 
-  desc "Increment version code"
-  lane :release_increment_version_code do |options|
-    increment_version_code(
-      gradle_file_path: "app/build.gradle",
-      version_code: options[:versionCode]
+  desc "Build a Staging APK"
+  lane :staging_apk do |options|
+    gradle(
+      task: "assemble",
+      build_type: "staging",
+      print_command: false
     )
   end
 
@@ -82,21 +86,6 @@ platform :android do
       destinations: options[:destinations],
       release_notes: changeLogs,
       file: options[:apkPath]
-    )
-  end
-
-  desc "Upload to google play store beta track"
-  lane :play_store_bt do
-    validate_play_store_json_key(
-      json_key: "app/json_key.json",
-    )
-
-    upload_to_play_store(
-      track: 'beta',
-      release_status: 'draft',
-      skip_upload_apk: true,
-      package_name: 'org.pathcheck.covidsafepaths.bt',
-      aab: "app/build/outputs/bundle/release/app-release.aab"
     )
   end
 

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -16,21 +16,21 @@ or alternatively using `brew install fastlane`
 
 # Available Actions
 ## Android
-### android test
-```
-fastlane android test
-```
-Runs Android (Native) unit tests
-### android debug_bt
-```
-fastlane android debug_bt
-```
-Build a Debug AAB
 ### android release_increment_version_code
 ```
 fastlane android release_increment_version_code
 ```
 Increment version code
+### android debug_bt
+```
+fastlane android debug_bt
+```
+Build a Debug AAB
+### android staging_apk
+```
+fastlane android staging_apk
+```
+Build a Staging APK
 ### android release_apk
 ```
 fastlane android release_apk
@@ -46,11 +46,6 @@ Build a Release AAB
 fastlane android android_alpha_apk
 ```
 Submit APK to AppCenter
-### android play_store_bt
-```
-fastlane android play_store_bt
-```
-Upload to google play store beta track
 
 ----
 


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
We were using release signing configuration for staging, but it just slows down the process.
This PR uses debug signing configuration and adds a new fastlane command to make staging APKs