### PR TITLE
Use single share app link

### DIFF
--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -34,10 +34,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
   } = env
   const displaySelfAssessment = env.DISPLAY_SELF_ASSESSMENT === "true"
   const displayReportAnIssue = env.DISPLAY_REPORT_AN_ISSUE === "true"
-  const appDownloadLink = Platform.select({
-    ios: env.IOS_APP_STORE_URL,
-    android: env.ANDROID_PLAY_STORE_URL,
-  }) as string
+  const appDownloadLink = env.SHARE_APP_LINK
   const appPackageName = Platform.select({
     ios: env.IOS_BUNDLE_ID,
     android: env.ANDROID_APPLICATION_ID,

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -130,6 +130,8 @@ const HomeScreen: FunctionComponent = () => {
     navigation.navigate(Screens.LanguageSelection)
   }
 
+  const showShareLink = Boolean(configuration.appDownloadLink)
+
   const isProximityTracingOn = isEnabledAndAuthorized
   const isBluetoothOn = btStatus
   const appIsActive = isProximityTracingOn && isBluetoothOn
@@ -197,27 +199,29 @@ const HomeScreen: FunctionComponent = () => {
       </View>
       <SafeAreaView style={bottomContainerStyle}>
         <ScrollView contentContainerStyle={style.bottomContentContainer}>
-          <TouchableOpacity
-            style={style.shareContainer}
-            onPress={handleOnPressShare}
-            accessibilityLabel={t("home.bluetooth.share")}
-          >
-            <View style={style.shareImageContainer}>
-              <Image source={Images.HugEmoji} style={style.shareImage} />
-            </View>
-            <View style={style.shareTextContainer}>
-              <GlobalText style={style.shareText}>
-                {t("home.bluetooth.share")}
-              </GlobalText>
-            </View>
-            <View style={style.shareIconContainer}>
-              <SvgXml
-                xml={Icons.Share}
-                width={Iconography.small}
-                height={Iconography.small}
-              />
-            </View>
-          </TouchableOpacity>
+          {showShareLink ? (
+            <TouchableOpacity
+              style={style.shareContainer}
+              onPress={handleOnPressShare}
+              accessibilityLabel={t("home.bluetooth.share")}
+            >
+              <View style={style.shareImageContainer}>
+                <Image source={Images.HugEmoji} style={style.shareImage} />
+              </View>
+              <View style={style.shareTextContainer}>
+                <GlobalText style={style.shareText}>
+                  {t("home.bluetooth.share")}
+                </GlobalText>
+              </View>
+              <View style={style.shareIconContainer}>
+                <SvgXml
+                  xml={Icons.Share}
+                  width={Iconography.small}
+                  height={Iconography.small}
+                />
+              </View>
+            </TouchableOpacity>
+          ) : null}
           <View style={style.activationStatusSectionContainer}>
             <ActivationStatusSection
               headerText={t("home.bluetooth.bluetooth_header")}


### PR DESCRIPTION
Why:
Currently we are making a distinction between ios and android share
links, which doesnt meet the feature requirements as we do not know the
device of the user in which the app is being shared.

This commit:
Removes the casing on the device platform for the share app link and
replaces the two links in the env file with a single 'SHARE_APP_LINK'

Co-Authored-By: Arthur Gibson <arthur.gibson@pathcheck.org>

### without link
<img width="559" alt="Screen Shot 2020-08-25 at 11 15 16 AM" src="https://user-images.githubusercontent.com/16049495/91214489-0205be80-e6c8-11ea-9bfb-10c005a2dc55.png">


### with link
<img width="559" alt="Screen Shot 2020-08-25 at 11 42 26 AM" src="https://user-images.githubusercontent.com/16049495/91214543-121d9e00-e6c8-11ea-871b-e30256a89fa8.png">
