### PR TITLE
Add a validation to AffectedUser CodeInput form

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
@@ -202,5 +202,17 @@ describe("CodeInputForm", () => {
         expect(getByText("Try a different code")).toBeDefined()
       })
     })
+
+    it("informs of a formatting error", async () => {
+      const { getByTestId, getByLabelText, getByText } = render(
+        <AffectedUserProvider>
+          <CodeInputForm />
+        </AffectedUserProvider>,
+      )
+      fireEvent.changeText(getByTestId("code-input"), "1234-678")
+
+      expect(getByLabelText("Next")).toBeDisabled()
+      expect(getByText("Invalid format")).toBeDefined()
+    })
   })
 })

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -49,10 +49,16 @@ const CodeInputForm: FunctionComponent = () => {
   const [isFocused, setIsFocused] = useState(false)
 
   const codeLength = 8
+  const codeIsInvalidLength = code.length !== codeLength
+  const codeContainsNonDigitChars = (code: string) => !code.match(/^\d+$/)
 
-  const handleOnChangeText = (code: string) => {
+  const handleOnChangeText = (newCode: string) => {
     setErrorMessage("")
-    setCode(code)
+    if (newCode && codeContainsNonDigitChars(newCode)) {
+      setErrorMessage(t("export.error.invalid_format"))
+    } else {
+      setCode(newCode)
+    }
   }
 
   const handleOnToggleFocus = () => {
@@ -144,7 +150,7 @@ const CodeInputForm: FunctionComponent = () => {
     }
   }
 
-  const isDisabled = code.length !== codeLength
+  const isDisabled = codeIsInvalidLength || codeContainsNonDigitChars(code)
 
   const codeInputFocusedStyle = isFocused && { ...style.codeInputFocused }
   const codeInputStyle = { ...style.codeInput, ...codeInputFocusedStyle }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -82,6 +82,7 @@
     "enable_exposure_notifications_body": "You must enable exposure notifcations to report a positive test result.",
     "enable_exposure_notifications_title": "Enable exposure notifications to continue",
     "error": {
+      "invalid_format": "Invalid format",
       "invalid_code": "Try a different code",
       "unknown_code_verification_error": "Try a different code",
       "verification_code_used": "Verification code has already been used"


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

Validate that the AffectedUser CodeInput is a number.

#### Linked issues:

[Trello](https://trello.com/c/mPffXwd3/379-as-a-user-when-i-enter-a-verification-code-if-that-code-is-not-formated-correctly-only-digits-i-am-told-that-theres-a-formating)