### PR TITLE
Clean up keychain service.

### DIFF
--- a/ios/BT/Extensions/Foundation/String+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/String+Extensions.swift
@@ -6,7 +6,6 @@ extension String {
 
   // API
   static let revisionToken = "revisionToken"
-  static let revisionTokenDev = "revisionTokenDev"
 
   // EN
   static let notAuthorized = "notAuthorized"

--- a/ios/BT/Storage/KeychainService.swift
+++ b/ios/BT/Storage/KeychainService.swift
@@ -13,20 +13,12 @@ final class DefaultKeychainService: NSObject, KeychainService {
 
   private lazy var keychain = Keychain(service: ReactNativeConfig.env(for: .postKeysUrl))
 
-  private var isDev: Bool {
-    ReactNativeConfig.env(for: .dev) != nil
-  }
-
   @objc func setRevisionToken(_ token: String) {
-    if isDev {
-      keychain[String.revisionTokenDev] = token
-    } else {
-      keychain[String.revisionToken] = token
-    }
+    keychain[String.revisionToken] = token
   }
 
   @objc var revisionToken: String {
-    return (isDev ? keychain[String.revisionTokenDev] : keychain[String.revisionToken]) ?? .default
+    return keychain[String.revisionToken] ?? .default
   }
 
 }


### PR DESCRIPTION
### This Commit
This commit removes unused code that made a distinction between environments when storing the revision token. Now that we store the revision token based on the key server url being used, that distinction is implicit.