### PR TITLE
Pull exposure keys every 12 hours

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
@@ -90,6 +90,7 @@ public class ExposureNotificationClientWrapper {
   }
 
   public Task<Void> provideDiagnosisKeys(List<File> files) {
+    // Calls to this method are limited to six per day, we are only calling it once a day.
     return exposureNotificationClient.provideDiagnosisKeys(files);
   }
 

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ExposureNotificationBroadcastReceiver.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ExposureNotificationBroadcastReceiver.java
@@ -4,11 +4,14 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient;
+import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
 
 /**
  * Receiver registered for notifications of a potential exposure.
- * This receiver is called by the API after we pass them the keys: client.provideDiagnosisKeys()
- * Documentation: https://developers.google.com/android/exposure-notifications/exposure-notifications-api#broadcast-receivers
+ * This receiver is called by the API after we pass them the keys via
+ * {@link ExposureNotificationClientWrapper#provideDiagnosisKeys}
+ *
+ * @see <a href="Documentation">https://developers.google.com/android/exposure-notifications/exposure-notifications-api#broadcast-receivers</a>
  */
 public class ExposureNotificationBroadcastReceiver extends BroadcastReceiver {
 

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ProvideDiagnosisKeysWorker.java
@@ -43,6 +43,9 @@ import org.threeten.bp.Instant;
 
 /**
  * Performs work to provide diagnosis keys to the exposure notifications API.
+ *
+ * <p>This Worker will run every 12 hours.
+ * It won't do anything if the index files have already been processed.
  */
 public class ProvideDiagnosisKeysWorker extends ListenableWorker {
 

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ProvideDiagnosisKeysWorker.java
@@ -49,8 +49,8 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
   private static final String TAG = "ProvideDiagnosisKeysWkr";
 
   private static final Duration IS_ENABLED_TIMEOUT = Duration.ofSeconds(10);
-  public static final Duration JOB_INTERVAL = Duration.ofHours(24);
-  public static final Duration JOB_FLEX_INTERVAL = Duration.ofHours(6);
+  public static final Duration JOB_INTERVAL = Duration.ofHours(12);
+  public static final Duration JOB_FLEX_INTERVAL = Duration.ofHours(3);
   public static final String WORKER_NAME = "ProvideDiagnosisKeysWorker";
 
   private final DiagnosisKeys diagnosisKeys;


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
This PR lowers the pull interval to 12 hours to avoid having to wait too much time to get an exposure notification.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://trello.com/c/TE9xVKd1/451-pull-keys-2x-per-day

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
Check that the time shown in Exposure History screen is updated every 12 hours.