### PR TITLE
Add helper for displaying configurable copy per HA

### DIFF
--- a/bin/download_copy.sh
+++ b/bin/download_copy.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+#
+# Download the copy json for a specific HA and places it on the configuration
+# folder
+#
+# Usage
+#
+#   bin/download_copy.sh <health-authority-label> <github-token>
+#
+# Example
+#
+#   bin/download_assets.sh guam <token>
+#
+# Requirements
+#
+# 1. Remote access to the environment repo
+# 2. A github personal access token saved in `.env`:
+#    https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
+
+require "open3"
+require "dotenv"
+require_relative "./download_copy_methods"
+Dotenv.load
+
+HA_LABEL = ARGV[0]
+ACCESS_TOKEN = ARGV[1] || ENV.fetch("ACCESS_TOKEN")
+validate_token!(ACCESS_TOKEN)
+validate_ha_label!(HA_LABEL, "download_copy")
+
+puts "...fetching copy for #{HA_LABEL}"
+
+download_copy_file(HA_LABEL, ACCESS_TOKEN)

--- a/bin/download_copy_methods.rb
+++ b/bin/download_copy_methods.rb
@@ -1,0 +1,15 @@
+# Utility to fetch the copy json from the configuration repo.
+require_relative "./helpers"
+
+COPY_FILE_NAME = "copy.json"
+COPY_FILE_PATH = "src/configuration"
+
+def download_copy_file(ha_label, access_token)
+  copy_file_url = "https://#{access_token}@raw.githubusercontent.com/Path-Check/pathcheck-mobile-resources/#{mobile_resources_commit}/copy/#{HA_LABEL}/#{COPY_FILE_NAME}"
+
+  file_destination = "#{COPY_FILE_PATH}/#{COPY_FILE_NAME}"
+
+  return true if download_file(file_destination, copy_file_url)
+
+  puts "Failed to download copy file for #{ha_label}"
+end

--- a/bin/helpers.rb
+++ b/bin/helpers.rb
@@ -1,5 +1,19 @@
+def url_exists?(remote_url)
+  output, _error, status = Open3.capture3(
+    "curl", "-I", remote_url
+  )
+  url_exists = output.split("\n")[0].match("404").to_a.empty?
+
+  return true if status.success? && url_exists
+
+  puts "#{remote_url} could not be found"
+  false
+end
+
 def download_file(file_name, remote_url)
-  _output, _error, status = Open3.capture3(
+  return false unless url_exists?(remote_url)
+
+  _output, error, status = Open3.capture3(
     "curl", remote_url, "-L", "-o", file_name
   )
   return true if status.success?

--- a/bin/set_ha.sh
+++ b/bin/set_ha.sh
@@ -18,6 +18,8 @@
 
 require 'open3'
 require 'dotenv'
+require_relative "./download_copy_methods"
+
 Dotenv.load
 
 HA_LABEL = ARGV[0]
@@ -29,4 +31,6 @@ else
    raise "Empty github access token"
 end
 
-fetching_env_succeeded && system("./bin/configure_builds.sh") && system("./bin/download_assets.sh #{HA_LABEL} #{ACCESS_TOKEN}")
+result = fetching_env_succeeded && system("./bin/configure_builds.sh") && system("./bin/download_assets.sh #{HA_LABEL} #{ACCESS_TOKEN}") && download_copy_file(HA_LABEL, ACCESS_TOKEN)
+
+result ? exit 0 : exit 1

--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -90,7 +90,7 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
     return () => {
       AppState.removeEventListener("change", handleAppStateChange)
     }
-  }, [getCurrentExposures])
+  }, [])
 
   useEffect(() => {
     const subscription = exposureInfoSubscription(

--- a/src/More/About.tsx
+++ b/src/More/About.tsx
@@ -3,28 +3,32 @@ import { useTranslation } from "react-i18next"
 import { Platform, ScrollView, StyleSheet, View } from "react-native"
 
 import { GlobalText } from "../components"
-
 import { Colors, Spacing, Typography } from "../styles"
 import { useApplicationInfo } from "../hooks/useApplicationInfo"
 import { useConfigurationContext } from "../ConfigurationContext"
+import useAuthorityCopy from "../configuration/useAuthorityCopy"
 
 export const AboutScreen: FunctionComponent = () => {
-  const { t } = useTranslation()
+  const {
+    t,
+    i18n: { language: localeCode },
+  } = useTranslation()
   const osInfo = `${Platform.OS} v${Platform.Version}`
   const { applicationName, versionInfo } = useApplicationInfo()
   const { healthAuthorityName } = useConfigurationContext()
 
+  const aboutContent = useAuthorityCopy(
+    "about",
+    localeCode,
+    t("about.description", { applicationName, healthAuthorityName }),
+  )
+
   return (
-    <ScrollView
-      contentContainerStyle={style.contentContainer}
-      alwaysBounceVertical={false}
-    >
+    <ScrollView style={style.container} alwaysBounceVertical={false}>
       <View>
         <GlobalText style={style.headerContent}>{applicationName}</GlobalText>
       </View>
-      <GlobalText style={style.aboutContent}>
-        {t("about.description", { applicationName, healthAuthorityName })}
-      </GlobalText>
+      <GlobalText style={style.aboutContent}>{aboutContent}</GlobalText>
       <View style={style.infoRowContainer}>
         <View style={style.infoRow}>
           <GlobalText style={style.aboutSectionParaLabel}>
@@ -48,7 +52,7 @@ export const AboutScreen: FunctionComponent = () => {
 }
 
 const style = StyleSheet.create({
-  contentContainer: {
+  container: {
     flex: 1,
     backgroundColor: Colors.primaryLightBackground,
     paddingTop: Spacing.large,
@@ -74,6 +78,7 @@ const style = StyleSheet.create({
   },
   infoRowContainer: {
     marginTop: Spacing.medium,
+    marginBottom: Spacing.medium,
   },
   infoRow: {
     flexDirection: "row",

--- a/src/More/Legal.tsx
+++ b/src/More/Legal.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react"
-import { Linking, StyleSheet, TouchableOpacity, View } from "react-native"
+import { Linking, ScrollView, StyleSheet, TouchableOpacity } from "react-native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 
@@ -8,9 +8,13 @@ import { GlobalText } from "../components"
 import { Colors, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
 import { useConfigurationContext } from "../ConfigurationContext"
+import useAuthorityCopy from "../configuration/useAuthorityCopy"
 
 const Legal: FunctionComponent = () => {
-  const { t } = useTranslation()
+  const {
+    t,
+    i18n: { language: localeCode },
+  } = useTranslation()
   const { applicationName } = useApplicationName()
   const {
     healthAuthorityName,
@@ -21,12 +25,17 @@ const Legal: FunctionComponent = () => {
     Linking.openURL(healthAuthorityPrivacyPolicyUrl)
   }
 
+  const legalContent = useAuthorityCopy(
+    "legal",
+    localeCode,
+    healthAuthorityName,
+  )
+
   return (
-    <View style={style.container}>
+    <ScrollView style={style.container} alwaysBounceVertical={false}>
       <GlobalText style={style.headerContent} testID={"licenses-legal-header"}>
         {applicationName}
       </GlobalText>
-      <GlobalText style={style.contentText}>{healthAuthorityName}</GlobalText>
       <TouchableOpacity
         onPress={handleOnPressLink}
         accessibilityLabel={t("label.privacy_policy")}
@@ -36,7 +45,8 @@ const Legal: FunctionComponent = () => {
         </GlobalText>
         <SvgXml xml={Icons.ChevronRight} fill={Colors.white} />
       </TouchableOpacity>
-    </View>
+      <GlobalText style={style.contentText}>{legalContent}</GlobalText>
+    </ScrollView>
   )
 }
 

--- a/src/Onboarding/Welcome.tsx
+++ b/src/Onboarding/Welcome.tsx
@@ -13,6 +13,7 @@ import {
 import { getLocalNames } from "../locales/languages"
 import { useApplicationName } from "../hooks/useApplicationInfo"
 import { Screens, OnboardingScreens, useStatusBarEffect } from "../navigation"
+import useAuthorityCopy from "../configuration/useAuthorityCopy"
 
 import { Images } from "../assets"
 import { Spacing, Colors, Typography, Outlines } from "../styles"
@@ -26,6 +27,12 @@ const Welcome: FunctionComponent = () => {
   } = useTranslation()
   const languageName = getLocalNames()[localeCode]
   const { applicationName } = useApplicationName()
+
+  const welcomeMessage = useAuthorityCopy(
+    "welcome_message",
+    localeCode,
+    t("label.launch_screen1_header"),
+  )
 
   const handleOnPressSelectLanguage = () => {
     navigation.navigate(Screens.LanguageSelection)
@@ -62,9 +69,7 @@ const Welcome: FunctionComponent = () => {
               accessible
               accessibilityLabel={t("onboarding.welcome_image_label")}
             />
-            <GlobalText style={style.mainText}>
-              {t("label.launch_screen1_header")}
-            </GlobalText>
+            <GlobalText style={style.mainText}>{welcomeMessage}</GlobalText>
             <GlobalText style={style.mainText}>{applicationName}</GlobalText>
           </View>
           <Button

--- a/src/configuration/copy.json
+++ b/src/configuration/copy.json
@@ -1,0 +1,11 @@
+{
+  "welcome_message": {
+    "en": ""
+  },
+  "about": {
+    "en": ""
+  },
+  "legal": {
+    "en": ""
+  }
+}

--- a/src/configuration/useAuthorityCopy.ts
+++ b/src/configuration/useAuthorityCopy.ts
@@ -1,0 +1,22 @@
+import copy from "./copy.json"
+
+type CopyKey = "welcome_message" | "about" | "legal"
+type CopyValues = Record<string, string>
+type AuthorityCopyContent = Record<CopyKey, CopyValues>
+
+const useAuthorityCopy = (
+  key: CopyKey,
+  localeCode: string,
+  defaultValue: string,
+): string => {
+  try {
+    const authorityCopyOverrides = copy as AuthorityCopyContent
+    const overrideCopy = authorityCopyOverrides[key][localeCode]
+
+    return overrideCopy.length > 0 ? overrideCopy : defaultValue
+  } catch {
+    return defaultValue
+  }
+}
+
+export default useAuthorityCopy

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -85,8 +85,8 @@
     "enable_exposure_notifications_body": "You must enable exposure notifcations to report a positive test result.",
     "enable_exposure_notifications_title": "Enable exposure notifications to continue",
     "error": {
-      "invalid_format": "Invalid format",
       "invalid_code": "Try a different code",
+      "invalid_format": "Invalid format",
       "unknown_code_verification_error": "Try a different code",
       "verification_code_used": "Verification code has already been used"
     },


### PR DESCRIPTION
Why:
----
There are three configurable options on the application that each authority will set up independently, those user-facing text bodies need to be localized and should follow the same language preference that the application is using. They need to live on the resources repo since they are private to each HA.

This Commit:
----
- Add the download copy script
- Add the helper to consume a key, and fetch it from the copy json
- Add default values to useAuthorityCopy
- Display content from authority copy on legal and about if present
- Change surrounding scrollview for legal and about screens
- Update download file script
- Include download_copy_methods on the set_ha script

Reviewers:
----
This approach assumes that the content of the copy file will be verified prior usage. Also assumes that the supported locales are in sync with the ones that are present on the specific authority configuration.
The approach follows constraints expressed on the trello card. 

The new version respects the current behavior and should not change anything except for the content of the screen after the app is built per authority.

There's an accompanying PR here https://github.com/Path-Check/pathcheck-mobile-resources/pull/30

Co-authored-by: Thomas Paresi<thomas.paresi@thoughtbot.com>