### PR TITLE
(Android) Fetch configuration from server

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
@@ -158,7 +158,11 @@ public class ExposureNotificationClientWrapper {
 
       List<DailySummary> filteredSummaries = new ArrayList<>();
       for (DailySummary summary : summaries) {
-        if (summary.getSummaryData().getWeightedDurationSum() >= config.getTriggerThresholdWeightedDuration()) {
+        long exposureDurationMinutes = Duration
+            .ofSeconds((int) summary.getSummaryData().getWeightedDurationSum())
+            .toMinutes();
+
+        if (exposureDurationMinutes >= config.getTriggerThresholdWeightedDuration()) {
           filteredSummaries.add(summary);
         }
       }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
@@ -112,13 +112,13 @@ public class ExposureNotificationClientWrapper {
           // Ignore the error, use the default config
           return null;
         }, AppExecutors.getLightweightExecutor())
-        .transformAsync((aVoid) -> setDiagnosisKeysDataMapping(), AppExecutors.getBackgroundExecutor())
+        .transformAsync((done) -> setDiagnosisKeysDataMapping(), AppExecutors.getBackgroundExecutor())
         .catching(Exception.class, exception -> {
           Log.d(TAG, "setDiagnosisKeysDataMapping failed: " + exception);
           // Ignore the error, this method throws an error if it's called multiple times
           return null;
         }, AppExecutors.getLightweightExecutor())
-        .transformAsync((aVoid) -> provideDiagnosisKeysFuture(files), AppExecutors.getBackgroundExecutor());
+        .transformAsync((done) -> provideDiagnosisKeysFuture(files), AppExecutors.getBackgroundExecutor());
   }
 
   private ListenableFuture<Void> provideDiagnosisKeysFuture(List<File> files) {

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java
@@ -11,25 +11,39 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.nearby.Nearby;
+import com.google.android.gms.nearby.exposurenotification.DailySummary;
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient;
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationStatusCodes;
-import com.google.android.gms.nearby.exposurenotification.ExposureWindow;
 import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey;
 import com.google.android.gms.tasks.Task;
+import com.google.common.util.concurrent.FluentFuture;
+import com.google.common.util.concurrent.ListenableFuture;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.pathcheck.covidsafepaths.exposurenotifications.common.AppExecutors;
+import org.pathcheck.covidsafepaths.exposurenotifications.common.TaskToFutureAdapter;
+import org.pathcheck.covidsafepaths.exposurenotifications.nearby.ExposureConfigurations;
 import org.pathcheck.covidsafepaths.exposurenotifications.nearby.ProvideDiagnosisKeysWorker;
 import org.pathcheck.covidsafepaths.exposurenotifications.utils.RequestCodes;
 import org.pathcheck.covidsafepaths.exposurenotifications.utils.Util;
+import org.threeten.bp.Duration;
 
 /**
  * Wrapper around {@link com.google.android.gms.nearby.Nearby} APIs.
  */
 public class ExposureNotificationClientWrapper {
 
+  private static final Duration GET_DAILY_SUMMARIES_TIMEOUT = Duration.ofSeconds(120);
+  private static final Duration SET_DIAGNOSIS_KEY_DATA_MAPPING_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration PROVIDE_KEYS_TIMEOUT = Duration.ofMinutes(30);
+  private static final String TAG = "ENClientWrapper";
+
   private static ExposureNotificationClientWrapper INSTANCE;
 
   private final ExposureNotificationClient exposureNotificationClient;
+  private final ExposureConfigurations config;
 
   public static ExposureNotificationClientWrapper get(Context context) {
     if (INSTANCE == null) {
@@ -40,6 +54,7 @@ public class ExposureNotificationClientWrapper {
 
   ExposureNotificationClientWrapper(Context context) {
     exposureNotificationClient = Nearby.getExposureNotificationClient(context);
+    config = new ExposureConfigurations(context);
   }
 
   public Task<Void> start(ReactContext context) {
@@ -89,13 +104,64 @@ public class ExposureNotificationClientWrapper {
     return exposureNotificationClient.getTemporaryExposureKeyHistory();
   }
 
-  public Task<Void> provideDiagnosisKeys(List<File> files) {
-    // Calls to this method are limited to six per day, we are only calling it once a day.
-    return exposureNotificationClient.provideDiagnosisKeys(files);
+  public ListenableFuture<Void> provideDiagnosisKeys(List<File> files) {
+    // Update the configuration each time we download keys
+    return FluentFuture.from(config.refresh())
+        .catching(Exception.class, exception -> {
+          Log.d(TAG, "Config refresh failed: " + exception);
+          // Ignore the error, use the default config
+          return null;
+        }, AppExecutors.getLightweightExecutor())
+        .transformAsync((aVoid) -> setDiagnosisKeysDataMapping(), AppExecutors.getBackgroundExecutor())
+        .catching(Exception.class, exception -> {
+          Log.d(TAG, "setDiagnosisKeysDataMapping failed: " + exception);
+          // Ignore the error, this method throws an error if it's called multiple times
+          return null;
+        }, AppExecutors.getLightweightExecutor())
+        .transformAsync((aVoid) -> provideDiagnosisKeysFuture(files), AppExecutors.getBackgroundExecutor());
   }
 
-  public Task<List<ExposureWindow>> getExposureWindows() {
-    return exposureNotificationClient.getExposureWindows();
+  private ListenableFuture<Void> provideDiagnosisKeysFuture(List<File> files) {
+    // Calls to this method are limited to six per day, we are only calling it once a day.
+    Log.d(TAG, "provideDiagnosisKeys called with " + files.size() + " files");
+    return TaskToFutureAdapter.getFutureWithTimeout(
+        exposureNotificationClient.provideDiagnosisKeys(files),
+        PROVIDE_KEYS_TIMEOUT.toMillis(),
+        TimeUnit.MILLISECONDS,
+        AppExecutors.getScheduledExecutor());
+  }
+
+  private ListenableFuture<Void> setDiagnosisKeysDataMapping() {
+    Log.d(TAG, "setDiagnosisKeysDataMapping called with config " + config.getDiagnosisKeysDataMapping());
+    return TaskToFutureAdapter.getFutureWithTimeout(
+        exposureNotificationClient.setDiagnosisKeysDataMapping(config.getDiagnosisKeysDataMapping()),
+        SET_DIAGNOSIS_KEY_DATA_MAPPING_TIMEOUT.toMillis(),
+        TimeUnit.MILLISECONDS,
+        AppExecutors.getScheduledExecutor());
+  }
+
+  public ListenableFuture<List<DailySummary>> getDailySummaries() {
+    return FluentFuture.from(
+        TaskToFutureAdapter.getFutureWithTimeout(
+            exposureNotificationClient.getDailySummaries(config.getDailySummariesConfig()),
+            GET_DAILY_SUMMARIES_TIMEOUT.toMillis(),
+            TimeUnit.MILLISECONDS,
+            AppExecutors.getScheduledExecutor())
+    ).transform(summaries -> {
+      if (summaries == null) {
+        return null;
+      }
+
+      List<DailySummary> filteredSummaries = new ArrayList<>();
+      for (DailySummary summary : summaries) {
+        if (summary.getSummaryData().getWeightedDurationSum() >= config.getTriggerThresholdWeightedDuration()) {
+          filteredSummaries.add(summary);
+        }
+      }
+
+      Log.d(TAG, "Returning " + filteredSummaries.size() + " summaries out of " + summaries.size());
+      return filteredSummaries;
+    }, AppExecutors.getLightweightExecutor());
   }
 
   public boolean deviceSupportsLocationlessScanning() {

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/dto/RNExposureInformation.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/dto/RNExposureInformation.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 @SuppressWarnings({"FieldCanBeLocal", "unused"})
 public class RNExposureInformation {
   private String id;
-  private long date;
+  private long date; // Milliseconds
   private double duration; // Minutes
 
   public RNExposureInformation(long date, double duration) {

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/dto/RNExposureInformation.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/dto/RNExposureInformation.java
@@ -6,9 +6,9 @@ import java.util.UUID;
 public class RNExposureInformation {
   private String id;
   private long date;
-  private long duration; // Minutes
+  private double duration; // Minutes
 
-  public RNExposureInformation(long date, long duration) {
+  public RNExposureInformation(long date, double duration) {
     this.id = UUID.randomUUID().toString();
     this.date = date;
     this.duration = duration;

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/DiagnosisKeyFileSubmitter.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/DiagnosisKeyFileSubmitter.java
@@ -26,11 +26,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.pathcheck.covidsafepaths.BuildConfig;
 import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
 import org.pathcheck.covidsafepaths.exposurenotifications.common.AppExecutors;
-import org.pathcheck.covidsafepaths.exposurenotifications.common.TaskToFutureAdapter;
 import org.pathcheck.covidsafepaths.exposurenotifications.network.KeyFileBatch;
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.RealmSecureStorageBte;
 import org.threeten.bp.Duration;
@@ -94,12 +92,7 @@ public class DiagnosisKeyFileSubmitter {
       logBatch(b);
     }
 
-    return FluentFuture.from(
-        TaskToFutureAdapter.getFutureWithTimeout(
-            client.provideDiagnosisKeys(files),
-            PROVIDE_KEYS_TIMEOUT.toMillis(),
-            TimeUnit.MILLISECONDS,
-            AppExecutors.getScheduledExecutor()))
+    return FluentFuture.from(client.provideDiagnosisKeys(files))
         .transform(done -> {
           // Keep track of the latest file we processed
           if (!batches.isEmpty()) {

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ExposureConfigurations.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ExposureConfigurations.kt
@@ -1,0 +1,147 @@
+package org.pathcheck.covidsafepaths.exposurenotifications.nearby
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.concurrent.futures.CallbackToFutureAdapter
+import com.android.volley.Response
+import com.android.volley.toolbox.JsonObjectRequest
+import com.google.android.gms.nearby.exposurenotification.DailySummariesConfig
+import com.google.android.gms.nearby.exposurenotification.DiagnosisKeysDataMapping
+import com.google.android.gms.nearby.exposurenotification.Infectiousness.HIGH
+import com.google.android.gms.nearby.exposurenotification.Infectiousness.STANDARD
+import com.google.android.gms.nearby.exposurenotification.ReportType.CONFIRMED_CLINICAL_DIAGNOSIS
+import com.google.android.gms.nearby.exposurenotification.ReportType.CONFIRMED_TEST
+import com.google.android.gms.nearby.exposurenotification.ReportType.RECURSIVE
+import com.google.android.gms.nearby.exposurenotification.ReportType.SELF_REPORT
+import com.google.common.util.concurrent.ListenableFuture
+import org.json.JSONException
+import org.json.JSONObject
+import org.pathcheck.covidsafepaths.BuildConfig
+import org.pathcheck.covidsafepaths.exposurenotifications.network.RequestQueueSingleton
+import org.pathcheck.covidsafepaths.exposurenotifications.storage.ExposureNotificationSharedPreferences
+
+/**
+ * A simple class to own setting configuration for this app's use of the EN API, with attenuation
+ * settings, etc.
+ */
+class ExposureConfigurations(context: Context) {
+    companion object {
+        private const val TAG = "ExposureConfigurations"
+        private const val configurationV6Path = "v1.6.config.json"
+        private val configurationUri = Uri.parse(BuildConfig.EXPOSURE_CONFIGURATION_BASE_URL)
+            .buildUpon()
+            .appendEncodedPath(configurationV6Path)
+
+        private const val DEFAULT_TRIGGER_THRESHOLD_WEIGHTED_DURATION = 15
+        private val DEFAULT_ATTENUATION_DURATION_THRESHOLDS = listOf(40, 53, 60)
+        private val DEFAULT_ATTENUATION_BUCKET_WEIGHTS = listOf(1.0, 1.0, 0.5, 0.0)
+        private val DEFAULT_REPORT_TYPE_WEIGHTS = listOf(1.0, 0.0, 0.0, 0.0)
+        private val DEFAULT_INFECTIOUSNESS_WEIGHT = listOf(1.0, 1.0)
+        private const val DEFAULT_INFECTIOUSNESS_WHEN_DAY_SINCE_ONSET_MISSING = 1
+        private val DEFAULT_DAYS_SINCE_ONSET_TO_INFECTIOUSNESS = mapOf(
+            -2 to 1, -1 to 1, 0 to 1, 1 to 1, 2 to 1, 3 to 1, 4 to 1, 5 to 1, 6 to 1,
+            7 to 1, 8 to 1, 9 to 1, 10 to 1, 11 to 1, 12 to 1, 13 to 1, 14 to 1
+        )
+        private const val DEFAULT_REPORT_TYPE_WHEN_MISSING = 1;
+    }
+
+    private val prefs = ExposureNotificationSharedPreferences(context)
+
+    fun refresh(): ListenableFuture<Unit> {
+        return CallbackToFutureAdapter.getFuture { completer: CallbackToFutureAdapter.Completer<Unit> ->
+            val responseListener = Response.Listener<JSONObject> { json ->
+                try {
+                    Log.d(TAG, "Parsing configuration response")
+                    val dailySummariesObject = json.getJSONObject("DailySummariesConfig")
+
+                    val attenuationDurationThresholds = dailySummariesObject.getJSONArray("attenuationDurationThresholds")
+                    val attenuationDurationThresholdsList = mutableListOf<Int>()
+                    for (i in 0 until attenuationDurationThresholds.length()) {
+                        attenuationDurationThresholdsList.add(attenuationDurationThresholds.getInt(i))
+                    }
+                    prefs.setAttenuationDurationThresholds(attenuationDurationThresholdsList)
+
+                    val attenuationBucketWeights = dailySummariesObject.getJSONArray("attenuationBucketWeights")
+                    val attenuationBucketWeightsList = mutableListOf<Double>()
+                    for (i in 0 until attenuationBucketWeights.length()) {
+                        attenuationBucketWeightsList.add(attenuationBucketWeights.getDouble(i))
+                    }
+                    prefs.setAttenuationBucketWeights(attenuationBucketWeightsList)
+
+                    val reportTypeWeights = dailySummariesObject.getJSONArray("reportTypeWeights")
+                    val reportTypeWeightsList = mutableListOf<Double>()
+                    for (i in 0 until reportTypeWeights.length()) {
+                        reportTypeWeightsList.add(reportTypeWeights.getDouble(i))
+                    }
+                    prefs.setReportTypeWeights(reportTypeWeightsList)
+
+                    val infectiousnessWeights = dailySummariesObject.getJSONArray("infectiousnessWeights")
+                    val infectiousnessWeightsList = mutableListOf<Double>()
+                    for (i in 0 until infectiousnessWeights.length()) {
+                        infectiousnessWeightsList.add(infectiousnessWeights.getDouble(i))
+                    }
+                    prefs.setInfectiousnessWeights(infectiousnessWeightsList)
+
+                    val daysSinceOnsetToInfectiousness = dailySummariesObject.getJSONArray("daysSinceOnsetToInfectiousness")
+                    val daysSinceOnsetToInfectiousnessMap = hashMapOf<Int, Int>()
+                    for (i in 0 until daysSinceOnsetToInfectiousness.length()) {
+                        val mapEntry = daysSinceOnsetToInfectiousness.getJSONArray(i)
+                        daysSinceOnsetToInfectiousnessMap[mapEntry.getInt(0)] = mapEntry.getInt(1)
+                    }
+                    prefs.setDaysSinceOnsetToInfectiousness(daysSinceOnsetToInfectiousnessMap)
+
+                    prefs.setInfectiousnessWhenDaysSinceOnsetMissing(dailySummariesObject.getInt("infectiousnessWhenDaysSinceOnsetMissing"))
+                    prefs.setReportTypeWhenMissing(dailySummariesObject.getInt("reportTypeWhenMissing"))
+
+                    prefs.setTriggerThresholdWeightedDuration(json.getInt("triggerThresholdWeightedDuration"))
+
+                    Log.d(TAG, "Configuration refresh succeeded")
+                    completer.set(null)
+                } catch (exception: JSONException) {
+                    Log.e(TAG, "Failed to parse configuration: $exception")
+                    completer.setCancelled()
+                }
+            }
+            val errorListener = Response.ErrorListener { exception ->
+                Log.e(TAG, "Failed to fetch configuration: $exception")
+                completer.setCancelled()
+            }
+
+            Log.d(TAG, "Fetching configuration file from $configurationUri")
+            val request = JsonObjectRequest(configurationUri.toString(), null, responseListener, errorListener)
+            request.setShouldCache(false)
+            RequestQueueSingleton.get().add(request)
+            request
+        }
+    }
+
+    fun getDailySummariesConfig(): DailySummariesConfig {
+        val reportTypeWeights = prefs.getReportTypeWeights(DEFAULT_REPORT_TYPE_WEIGHTS)
+        val infectiousnessWeights = prefs.getInfectiousnessWeights(DEFAULT_INFECTIOUSNESS_WEIGHT)
+
+        return DailySummariesConfig.DailySummariesConfigBuilder()
+            .setAttenuationBuckets(
+                prefs.getAttenuationDurationThresholds(DEFAULT_ATTENUATION_DURATION_THRESHOLDS),
+                prefs.getAttenuationBucketWeights(DEFAULT_ATTENUATION_BUCKET_WEIGHTS)
+            )
+            .setReportTypeWeight(CONFIRMED_TEST, reportTypeWeights[0])
+            .setReportTypeWeight(CONFIRMED_CLINICAL_DIAGNOSIS, reportTypeWeights[1])
+            .setReportTypeWeight(SELF_REPORT, reportTypeWeights[2])
+            .setReportTypeWeight(RECURSIVE, reportTypeWeights[3])
+            .setInfectiousnessWeight(STANDARD, infectiousnessWeights[0])
+            .setInfectiousnessWeight(HIGH, infectiousnessWeights[1])
+            .build()
+    }
+
+    fun getDiagnosisKeysDataMapping(): DiagnosisKeysDataMapping {
+        return DiagnosisKeysDataMapping.DiagnosisKeysDataMappingBuilder()
+            .setInfectiousnessWhenDaysSinceOnsetMissing(prefs.getInfectiousnessWhenDaysSinceOnsetMissing(DEFAULT_INFECTIOUSNESS_WHEN_DAY_SINCE_ONSET_MISSING))
+            .setDaysSinceOnsetToInfectiousness(prefs.getDaysSinceOnsetToInfectiousness(DEFAULT_DAYS_SINCE_ONSET_TO_INFECTIOUSNESS))
+            .setReportTypeWhenMissing(prefs.getReportTypeWhenMissing(DEFAULT_REPORT_TYPE_WHEN_MISSING))
+            .build()
+    }
+
+    fun getTriggerThresholdWeightedDuration(): Int =
+        prefs.getTriggerThresholdWeightedDuration(DEFAULT_TRIGGER_THRESHOLD_WEIGHTED_DURATION)
+}

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ExposureConfigurations.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ExposureConfigurations.kt
@@ -43,7 +43,7 @@ class ExposureConfigurations(context: Context) {
             -2 to 1, -1 to 1, 0 to 1, 1 to 1, 2 to 1, 3 to 1, 4 to 1, 5 to 1, 6 to 1,
             7 to 1, 8 to 1, 9 to 1, 10 to 1, 11 to 1, 12 to 1, 13 to 1, 14 to 1
         )
-        private const val DEFAULT_REPORT_TYPE_WHEN_MISSING = 1;
+        private const val DEFAULT_REPORT_TYPE_WHEN_MISSING = 1
     }
 
     private val prefs = ExposureNotificationSharedPreferences(context)
@@ -55,7 +55,8 @@ class ExposureConfigurations(context: Context) {
                     Log.d(TAG, "Parsing configuration response")
                     val dailySummariesObject = json.getJSONObject("DailySummariesConfig")
 
-                    val attenuationDurationThresholds = dailySummariesObject.getJSONArray("attenuationDurationThresholds")
+                    val attenuationDurationThresholds =
+                        dailySummariesObject.getJSONArray("attenuationDurationThresholds")
                     val attenuationDurationThresholdsList = mutableListOf<Int>()
                     for (i in 0 until attenuationDurationThresholds.length()) {
                         attenuationDurationThresholdsList.add(attenuationDurationThresholds.getInt(i))
@@ -83,7 +84,8 @@ class ExposureConfigurations(context: Context) {
                     }
                     prefs.setInfectiousnessWeights(infectiousnessWeightsList)
 
-                    val daysSinceOnsetToInfectiousness = dailySummariesObject.getJSONArray("daysSinceOnsetToInfectiousness")
+                    val daysSinceOnsetToInfectiousness =
+                        dailySummariesObject.getJSONArray("daysSinceOnsetToInfectiousness")
                     val daysSinceOnsetToInfectiousnessMap = hashMapOf<Int, Int>()
                     for (i in 0 until daysSinceOnsetToInfectiousness.length()) {
                         val mapEntry = daysSinceOnsetToInfectiousness.getJSONArray(i)
@@ -91,7 +93,9 @@ class ExposureConfigurations(context: Context) {
                     }
                     prefs.setDaysSinceOnsetToInfectiousness(daysSinceOnsetToInfectiousnessMap)
 
-                    prefs.setInfectiousnessWhenDaysSinceOnsetMissing(dailySummariesObject.getInt("infectiousnessWhenDaysSinceOnsetMissing"))
+                    prefs.setInfectiousnessWhenDaysSinceOnsetMissing(
+                        dailySummariesObject.getInt("infectiousnessWhenDaysSinceOnsetMissing")
+                    )
                     prefs.setReportTypeWhenMissing(dailySummariesObject.getInt("reportTypeWhenMissing"))
 
                     prefs.setTriggerThresholdWeightedDuration(json.getInt("triggerThresholdWeightedDuration"))
@@ -136,9 +140,15 @@ class ExposureConfigurations(context: Context) {
 
     fun getDiagnosisKeysDataMapping(): DiagnosisKeysDataMapping {
         return DiagnosisKeysDataMapping.DiagnosisKeysDataMappingBuilder()
-            .setInfectiousnessWhenDaysSinceOnsetMissing(prefs.getInfectiousnessWhenDaysSinceOnsetMissing(DEFAULT_INFECTIOUSNESS_WHEN_DAY_SINCE_ONSET_MISSING))
-            .setDaysSinceOnsetToInfectiousness(prefs.getDaysSinceOnsetToInfectiousness(DEFAULT_DAYS_SINCE_ONSET_TO_INFECTIOUSNESS))
-            .setReportTypeWhenMissing(prefs.getReportTypeWhenMissing(DEFAULT_REPORT_TYPE_WHEN_MISSING))
+            .setInfectiousnessWhenDaysSinceOnsetMissing(
+                prefs.getInfectiousnessWhenDaysSinceOnsetMissing(DEFAULT_INFECTIOUSNESS_WHEN_DAY_SINCE_ONSET_MISSING)
+            )
+            .setDaysSinceOnsetToInfectiousness(
+                prefs.getDaysSinceOnsetToInfectiousness(DEFAULT_DAYS_SINCE_ONSET_TO_INFECTIOUSNESS)
+            )
+            .setReportTypeWhenMissing(
+                prefs.getReportTypeWhenMissing(DEFAULT_REPORT_TYPE_WHEN_MISSING)
+            )
             .build()
     }
 

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ExposureNotificationBroadcastReceiver.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ExposureNotificationBroadcastReceiver.java
@@ -3,6 +3,7 @@ package org.pathcheck.covidsafepaths.exposurenotifications.nearby;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient;
 import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
 
@@ -14,10 +15,12 @@ import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationCl
  * @see <a href="Documentation">https://developers.google.com/android/exposure-notifications/exposure-notifications-api#broadcast-receivers</a>
  */
 public class ExposureNotificationBroadcastReceiver extends BroadcastReceiver {
+  private static final String TAG = "ENBroadcastReceiver";
 
   @Override
   public void onReceive(Context context, Intent intent) {
     String action = intent.getAction();
+    Log.d(TAG, "Broadcast receiver invoked with action: " + action);
     if (ExposureNotificationClient.ACTION_EXPOSURE_STATE_UPDATED.equals(action)
         || ExposureNotificationClient.ACTION_EXPOSURE_NOT_FOUND.equals(action)) {
       StateUpdatedWorker.runOnce(context);

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/StateUpdatedWorker.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/StateUpdatedWorker.java
@@ -63,7 +63,9 @@ public class StateUpdatedWorker extends ListenableWorker {
           }
           return Result.success();
         }, AppExecutors.getLightweightExecutor())
-        .catching(Exception.class, x -> {
+        .catching(
+            Exception.class,
+            x -> {
               Log.e(TAG, "Failure to update app state (tokens, etc) from exposure summary.", x);
               return Result.failure();
             },

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/Uris.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/Uris.java
@@ -120,8 +120,7 @@ public class Uris {
 
           Uri indexUri = baseDownloadUri.buildUpon().appendEncodedPath(INDEX_FILE_PATH).build();
           Log.d(TAG, "Getting index file from " + indexUri);
-          StringRequest request =
-              new StringRequest(indexUri.toString(), responseListener, errorListener);
+          StringRequest request = new StringRequest(indexUri.toString(), responseListener, errorListener);
           request.setShouldCache(false);
           RequestQueueSingleton.get().add(request);
           return request;

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DeviceInfoModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DeviceInfoModule.java
@@ -17,7 +17,7 @@ import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationCl
 @ReactModule(name = DeviceInfoModule.MODULE_NAME)
 public class DeviceInfoModule extends ReactContextBaseJavaModule {
   public static final String MODULE_NAME = "DeviceInfoModule";
-  public static final String TAG = "DeviceInfoModule";
+  private static final String TAG = "DeviceInfoModule";
 
   public DeviceInfoModule(@NonNull ReactApplicationContext reactContext) {
     super(reactContext);

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
@@ -56,7 +56,7 @@ public class ExposureHistoryModule extends ReactContextBaseJavaModule {
         for (DailySummary dailySummary : result) {
           RNExposureInformation exposure = new RNExposureInformation(
               Duration.ofDays(dailySummary.getDaysSinceEpoch()).toMillis(),
-              dailySummary.getSummaryData().getWeightedDurationSum()
+              Duration.ofSeconds((int) dailySummary.getSummaryData().getWeightedDurationSum()).toMinutes()
           );
 
           exposures.add(exposure);

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
@@ -6,20 +6,25 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.module.annotations.ReactModule;
-import com.google.android.gms.nearby.exposurenotification.ExposureWindow;
-import com.google.android.gms.nearby.exposurenotification.ScanInstance;
+import com.google.android.gms.nearby.exposurenotification.DailySummary;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
 import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.List;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.jetbrains.annotations.NotNull;
 import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
+import org.pathcheck.covidsafepaths.exposurenotifications.common.AppExecutors;
 import org.pathcheck.covidsafepaths.exposurenotifications.dto.RNExposureInformation;
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.ExposureNotificationSharedPreferences;
+import org.threeten.bp.Duration;
 
 @SuppressWarnings("unused")
 @ReactModule(name = ExposureHistoryModule.MODULE_NAME)
 public class ExposureHistoryModule extends ReactContextBaseJavaModule {
   public static final String MODULE_NAME = "ExposureHistoryModule";
-  public static final String TAG = "ExposureHistoryModule";
+  private static final String TAG = "ExposureHistoryModule";
 
   private ExposureNotificationSharedPreferences prefs;
 
@@ -38,25 +43,40 @@ public class ExposureHistoryModule extends ReactContextBaseJavaModule {
   public void getCurrentExposures(final Promise promise) {
     ExposureNotificationClientWrapper exposureNotificationsClient =
         ExposureNotificationClientWrapper.get(getReactApplicationContext());
-    exposureNotificationsClient.getExposureWindows()
-        .addOnSuccessListener(exposureWindows -> {
-          List<RNExposureInformation> exposures = new ArrayList<>();
-          for (ExposureWindow window : exposureWindows) {
-            long durationMinutes = 0;
-            for (ScanInstance scan : window.getScanInstances()) {
-              // We don't need a float type here, getSecondsSinceLastScan() is coarsened to 60-second increments
-              durationMinutes += scan.getSecondsSinceLastScan() / 60;
-            }
-            RNExposureInformation exposure = new RNExposureInformation(
-                window.getDateMillisSinceEpoch(),
-                durationMinutes
-            );
-            exposures.add(exposure);
-          }
 
-          String json = new Gson().toJson(exposures);
-          promise.resolve(json);
-        });
+    FutureCallback<List<DailySummary>> callback = new FutureCallback<List<DailySummary>>() {
+      @Override
+      public void onSuccess(@NullableDecl List<DailySummary> result) {
+        if (result == null) {
+          promise.resolve(null);
+          return;
+        }
+
+        List<RNExposureInformation> exposures = new ArrayList<>();
+        for (DailySummary dailySummary : result) {
+          RNExposureInformation exposure = new RNExposureInformation(
+              Duration.ofDays(dailySummary.getDaysSinceEpoch()).toMillis(),
+              dailySummary.getSummaryData().getWeightedDurationSum()
+          );
+
+          exposures.add(exposure);
+        }
+
+        String json = new Gson().toJson(exposures);
+        promise.resolve(json);
+      }
+
+      @Override
+      public void onFailure(@NotNull Throwable t) {
+        promise.reject(t);
+      }
+    };
+
+    Futures.addCallback(
+        exposureNotificationsClient.getDailySummaries(),
+        callback,
+        AppExecutors.getLightweightExecutor()
+    );
   }
 
   @ReactMethod

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureNotificationsModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureNotificationsModule.java
@@ -24,7 +24,7 @@ import org.pathcheck.covidsafepaths.exposurenotifications.utils.Util;
 @ReactModule(name = MODULE_NAME)
 public class ExposureNotificationsModule extends ReactContextBaseJavaModule {
   public static final String MODULE_NAME = "ENPermissionsModule";
-  public static final String TAG = "ENModule";
+  private static final String TAG = "ENModule";
 
   private final ExposureNotificationClient exposureNotificationClient;
 

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/ExposureNotificationSharedPreferences.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/ExposureNotificationSharedPreferences.java
@@ -96,8 +96,7 @@ public class ExposureNotificationSharedPreferences {
     String json = sharedPreferences.getString(ATTENUATION_DURATION_THRESHOLDS, null);
     return json == null
         ? defaultValue
-        : new Gson().fromJson(json, new TypeToken<List<Integer>>() {
-    }.getType());
+        : new Gson().fromJson(json, new TypeToken<List<Integer>>() {}.getType());
   }
 
   public void setAttenuationBucketWeights(List<Double> weights) {
@@ -108,8 +107,7 @@ public class ExposureNotificationSharedPreferences {
     String json = sharedPreferences.getString(ATTENUATION_BUCKET_WEIGHTS, null);
     return json == null
         ? defaultValue
-        : new Gson().fromJson(json, new TypeToken<List<Double>>() {
-    }.getType());
+        : new Gson().fromJson(json, new TypeToken<List<Double>>() {}.getType());
   }
 
   public void setReportTypeWeights(List<Double> weights) {
@@ -120,8 +118,7 @@ public class ExposureNotificationSharedPreferences {
     String json = sharedPreferences.getString(REPORT_TYPE_WEIGHTS, null);
     return json == null
         ? defaultValue
-        : new Gson().fromJson(json, new TypeToken<List<Double>>() {
-    }.getType());
+        : new Gson().fromJson(json, new TypeToken<List<Double>>() {}.getType());
   }
 
   public void setInfectiousnessWeights(List<Double> weights) {
@@ -132,8 +129,7 @@ public class ExposureNotificationSharedPreferences {
     String json = sharedPreferences.getString(INFECTIOUSNESS_WEIGHTS, null);
     return json == null
         ? defaultValue
-        : new Gson().fromJson(json, new TypeToken<List<Double>>() {
-    }.getType());
+        : new Gson().fromJson(json, new TypeToken<List<Double>>() {}.getType());
   }
 
   public void setInfectiousnessWhenDaysSinceOnsetMissing(Integer infectiousness) {
@@ -152,8 +148,7 @@ public class ExposureNotificationSharedPreferences {
     String json = sharedPreferences.getString(DAYS_SINCE_ONSET_TO_INFECTIOUSNESS, null);
     return json == null
         ? defaultValue
-        : new Gson().fromJson(json, new TypeToken<Map<Integer, Integer>>() {
-    }.getType());
+        : new Gson().fromJson(json, new TypeToken<Map<Integer, Integer>>() {}.getType());
   }
 
   public void setReportTypeWhenMissing(Integer reportType) {

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/ExposureNotificationSharedPreferences.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/ExposureNotificationSharedPreferences.java
@@ -19,6 +19,10 @@ package org.pathcheck.covidsafepaths.exposurenotifications.storage;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Key value storage for ExposureNotification.
@@ -35,6 +39,30 @@ public class ExposureNotificationSharedPreferences {
   private static final String LAST_DETECTION_PROCESS_DATE =
       "ExposureNotificationSharedPreferences.LAST_DETECTION_PROCESS_DATE";
 
+  private static final String TRIGGER_THRESHOLD_WEIGHTED_DURATION =
+      "ExposureNotificationSharedPreferences.TRIGGER_THRESHOLD_WEIGHTED_DURATION";
+
+  private static final String ATTENUATION_DURATION_THRESHOLDS =
+      "ExposureNotificationSharedPreferences.ATTENUATION_DURATION_THRESHOLDS";
+
+  private static final String ATTENUATION_BUCKET_WEIGHTS =
+      "ExposureNotificationSharedPreferences.ATTENUATION_BUCKET_WEIGHTS";
+
+  private static final String REPORT_TYPE_WEIGHTS =
+      "ExposureNotificationSharedPreferences.REPORT_TYPE_WEIGHTS";
+
+  private static final String INFECTIOUSNESS_WEIGHTS =
+      "ExposureNotificationSharedPreferences.INFECTIOUSNESS_WEIGHTS";
+
+  private static final String INFECTIOUSNESS_WHEN_DAY_SINCE_ONSET_MISSING =
+      "ExposureNotificationSharedPreferences.INFECTIOUSNESS_WHEN_DAY_SINCE_ONSET_MISSING";
+
+  private static final String DAYS_SINCE_ONSET_TO_INFECTIOUSNESS =
+      "ExposureNotificationSharedPreferences.DAYS_SINCE_ONSET_TO_INFECTIOUSNESS";
+
+  private static final String REPORT_TYPE_WHEN_MISSING =
+      "ExposureNotificationSharedPreferences.REPORT_TYPE_WHEN_MISSING";
+
   private final SharedPreferences sharedPreferences;
 
   public ExposureNotificationSharedPreferences(Context context) {
@@ -43,12 +71,96 @@ public class ExposureNotificationSharedPreferences {
     sharedPreferences = context.getSharedPreferences(SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
   }
 
+  public void setLastDetectionProcessDate(Long date) {
+    sharedPreferences.edit().putLong(LAST_DETECTION_PROCESS_DATE, date).commit();
+  }
+
   public Long getLastDetectionProcessDate() {
     long date = sharedPreferences.getLong(LAST_DETECTION_PROCESS_DATE, -1);
     return date != -1 ? date : null;
   }
 
-  public void setLastDetectionProcessDate(Long date) {
-    sharedPreferences.edit().putLong(LAST_DETECTION_PROCESS_DATE, date).commit();
+  public void setTriggerThresholdWeightedDuration(Integer duration) {
+    sharedPreferences.edit().putInt(TRIGGER_THRESHOLD_WEIGHTED_DURATION, duration).commit();
+  }
+
+  public Integer getTriggerThresholdWeightedDuration(Integer defaultValue) {
+    return sharedPreferences.getInt(TRIGGER_THRESHOLD_WEIGHTED_DURATION, defaultValue);
+  }
+
+  public void setAttenuationDurationThresholds(List<Integer> thresholds) {
+    sharedPreferences.edit().putString(ATTENUATION_DURATION_THRESHOLDS, new Gson().toJson(thresholds)).commit();
+  }
+
+  public List<Integer> getAttenuationDurationThresholds(List<Integer> defaultValue) {
+    String json = sharedPreferences.getString(ATTENUATION_DURATION_THRESHOLDS, null);
+    return json == null
+        ? defaultValue
+        : new Gson().fromJson(json, new TypeToken<List<Integer>>() {
+    }.getType());
+  }
+
+  public void setAttenuationBucketWeights(List<Double> weights) {
+    sharedPreferences.edit().putString(ATTENUATION_BUCKET_WEIGHTS, new Gson().toJson(weights)).commit();
+  }
+
+  public List<Double> getAttenuationBucketWeights(List<Double> defaultValue) {
+    String json = sharedPreferences.getString(ATTENUATION_BUCKET_WEIGHTS, null);
+    return json == null
+        ? defaultValue
+        : new Gson().fromJson(json, new TypeToken<List<Double>>() {
+    }.getType());
+  }
+
+  public void setReportTypeWeights(List<Double> weights) {
+    sharedPreferences.edit().putString(REPORT_TYPE_WEIGHTS, new Gson().toJson(weights)).commit();
+  }
+
+  public List<Double> getReportTypeWeights(List<Double> defaultValue) {
+    String json = sharedPreferences.getString(REPORT_TYPE_WEIGHTS, null);
+    return json == null
+        ? defaultValue
+        : new Gson().fromJson(json, new TypeToken<List<Double>>() {
+    }.getType());
+  }
+
+  public void setInfectiousnessWeights(List<Double> weights) {
+    sharedPreferences.edit().putString(INFECTIOUSNESS_WEIGHTS, new Gson().toJson(weights)).commit();
+  }
+
+  public List<Double> getInfectiousnessWeights(List<Double> defaultValue) {
+    String json = sharedPreferences.getString(INFECTIOUSNESS_WEIGHTS, null);
+    return json == null
+        ? defaultValue
+        : new Gson().fromJson(json, new TypeToken<List<Double>>() {
+    }.getType());
+  }
+
+  public void setInfectiousnessWhenDaysSinceOnsetMissing(Integer infectiousness) {
+    sharedPreferences.edit().putInt(INFECTIOUSNESS_WHEN_DAY_SINCE_ONSET_MISSING, infectiousness).commit();
+  }
+
+  public Integer getInfectiousnessWhenDaysSinceOnsetMissing(Integer defaultValue) {
+    return sharedPreferences.getInt(INFECTIOUSNESS_WHEN_DAY_SINCE_ONSET_MISSING, defaultValue);
+  }
+
+  public void setDaysSinceOnsetToInfectiousness(Map<Integer, Integer> map) {
+    sharedPreferences.edit().putString(DAYS_SINCE_ONSET_TO_INFECTIOUSNESS, new Gson().toJson(map)).commit();
+  }
+
+  public Map<Integer, Integer> getDaysSinceOnsetToInfectiousness(Map<Integer, Integer> defaultValue) {
+    String json = sharedPreferences.getString(DAYS_SINCE_ONSET_TO_INFECTIOUSNESS, null);
+    return json == null
+        ? defaultValue
+        : new Gson().fromJson(json, new TypeToken<Map<Integer, Integer>>() {
+    }.getType());
+  }
+
+  public void setReportTypeWhenMissing(Integer reportType) {
+    sharedPreferences.edit().putInt(REPORT_TYPE_WHEN_MISSING, reportType).commit();
+  }
+
+  public Integer getReportTypeWhenMissing(Integer defaultValue) {
+    return sharedPreferences.getInt(REPORT_TYPE_WHEN_MISSING, defaultValue);
   }
 }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
@@ -100,7 +100,8 @@ object RealmSecureStorageBte {
         var somethingAdded = false
         getRealmInstance().use {
             it.executeTransaction { db ->
-                // Keep track of the exposures already handled and remove them when we find matching windows.
+                // Keep track of the exposures already handled to avoid showing the same notification multiple times.
+                // The list passes as a parameter should have only those summaries that exceeded the threshold.
                 val results: RealmResults<ExposureEntity> = db.where(ExposureEntity::class.java).findAll()
                 val exposureEntities: MutableList<ExposureEntity> = db.copyFromRealm(results)
                 for (dailySummary in dailySummaries) {
@@ -114,7 +115,7 @@ object RealmSecureStorageBte {
                         }
                     }
                     if (!found) {
-                        // No existing ExposureEntity with the given date, must add an entity for this window.
+                        // No existing ExposureEntity with the given date, must add an entity for this summary.
                         somethingAdded = true
                         db.insert(
                             ExposureEntity.create(dateMillisSinceEpoch, System.currentTimeMillis())

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
@@ -5,7 +5,6 @@ import androidx.annotation.VisibleForTesting
 import com.bottlerocketstudios.vault.SharedPreferenceVault
 import com.bottlerocketstudios.vault.SharedPreferenceVaultFactory
 import com.google.android.gms.nearby.exposurenotification.DailySummary
-import com.google.android.gms.nearby.exposurenotification.ExposureWindow
 import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.RealmResults
@@ -16,7 +15,6 @@ import org.pathcheck.covidsafepaths.exposurenotifications.storage.objects.KeyVal
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.objects.KeyValues.Companion.LAST_PROCESSED_FILE_NAME_KEY
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.objects.KeyValues.Companion.REVISION_TOKEN_KEY
 import org.threeten.bp.Duration
-import java.util.concurrent.TimeUnit
 
 /**
  * Modified from GPS target to support Exposure Notification on-device data


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
This PR implements scoring on the client side .
It does fetch the EN configuration from the server and passes it to GAEN API to do the scoring.

Configuration is re-fetched every time we pull keys to get the latest changes (if any). If an error happens during the process we will use the previous configuration or the default one (check `ExposureConfigurations` constants) if it's the first time.

`setDiagnosisKeysDataMapping`  can only be called once within 7 days and it will throw `FAILED_RATE_LIMITED` if called twice, so there are some values that can only be changed once a week.

`getExposureWindows` has been replaced by `getDailySummaries` to provide a configuration object. We will trigger a notification only when `summary.getSummaryData().getWeightedDurationSum() >= config.getTriggerThresholdWeightedDuration()`.

Additional documentation:
https://docs.google.com/document/d/1aMF7aHHNF3ftEEGAXDBKSCfWGcmy0PDJQ1JHq2TXgi0/edit#
https://developers.google.com/android/exposure-notifications/exposure-notifications-api

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://trello.com/c/knLJ8aHB/428-as-a-user-on-android-when-i-submit-keys-i-am-using-the-16-version-scoring-config

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
Check the logs to see if the config has been updated.