### PR TITLE
Refactor GradientBackground usage

### DIFF
--- a/__mocks__/react-native-linear-gradient.js
+++ b/__mocks__/react-native-linear-gradient.js
@@ -1,0 +1,3 @@
+import {View} from "react-native"
+
+export default View

--- a/__mocks__/react-native-linear-gradient.js
+++ b/__mocks__/react-native-linear-gradient.js
@@ -1,3 +1,3 @@
-import {View} from "react-native"
+import { View } from "react-native"
 
 export default View

--- a/src/Onboarding/Welcome.tsx
+++ b/src/Onboarding/Welcome.tsx
@@ -12,7 +12,7 @@ import { useApplicationName } from "../More/useApplicationInfo"
 import { Screens, OnboardingScreens, useStatusBarEffect } from "../navigation"
 
 import { Images } from "../assets"
-import { Layout, Spacing, Colors, Typography, Outlines } from "../styles"
+import { Spacing, Colors, Typography, Outlines } from "../styles"
 
 const Welcome: FunctionComponent = () => {
   const navigation = useNavigation()
@@ -29,8 +29,7 @@ const Welcome: FunctionComponent = () => {
   }
 
   return (
-    <>
-      <GradientBackground />
+    <GradientBackground>
       <View style={style.container}>
         <TouchableOpacity
           onPress={handleOnPressSelectLanguage}
@@ -66,13 +65,12 @@ const Welcome: FunctionComponent = () => {
           hasRightArrow
         />
       </View>
-    </>
+    </GradientBackground>
   )
 }
 
 const style = StyleSheet.create({
   container: {
-    ...Layout.positionOverBackground,
     flex: 1,
     paddingVertical: Spacing.xxHuge,
     paddingHorizontal: Spacing.large,

--- a/src/components/GradientBackground.tsx
+++ b/src/components/GradientBackground.tsx
@@ -5,7 +5,7 @@ import LinearGradient from "react-native-linear-gradient"
 
 import { Colors } from "../styles"
 
-const GradientBackground: FunctionComponent = () => {
+const GradientBackground: FunctionComponent = ({ children }) => {
   return (
     <LinearGradient
       colors={Colors.gradientPrimary10}
@@ -13,7 +13,9 @@ const GradientBackground: FunctionComponent = () => {
       useAngle
       angle={0}
       angleCenter={{ x: 0.5, y: 0.25 }}
-    />
+    >
+      {children}
+    </LinearGradient>
   )
 }
 


### PR DESCRIPTION
Why: we previously weren't able to wrap large portions of View code in `LinearGradient` because it prevented our tests from working.

This commit:
- Mocks `LinearGradient` so it just acts as a `View` in tests
- Updates `GradientBackground` to take children
- Uses `GradientBackground` with children on `Welcome`