### PR TITLE
Show all debug options on staging builds

### DIFF
--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -133,41 +133,39 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
               onPress={handleOnPressRestartOnboarding}
             />
           </View>
-          {__DEV__ ? (
-            <View style={style.section}>
-              <DebugMenuListItem
-                label="Show Exposures"
-                onPress={() => {
-                  navigation.navigate(Screens.ExposureListDebugScreen)
-                }}
-              />
-              <DebugMenuListItem
-                label="Toggle Exposure Notifications"
-                onPress={handleOnPressSimulationButton(
-                  NativeModule.toggleExposureNotifications,
-                )}
-              />
-              <DebugMenuListItem
-                label="Detect Exposures Now"
-                onPress={handleOnPressSimulationButton(
-                  NativeModule.detectExposuresNow,
-                )}
-              />
-              <DebugMenuListItem
-                label="Reset Exposures"
-                itemStyle={style.lastListItem}
-                onPress={handleOnPressSimulationButton(
-                  NativeModule.resetExposures,
-                )}
-              />
-              <DebugMenuListItem
-                label="Simulate Exposure Detection Error"
-                onPress={handleOnPressSimulationButton(
-                  NativeModule.simulateExposureDetectionError,
-                )}
-              />
-            </View>
-          ) : null}
+          <View style={style.section}>
+            <DebugMenuListItem
+              label="Show Exposures"
+              onPress={() => {
+                navigation.navigate(Screens.ExposureListDebugScreen)
+              }}
+            />
+            <DebugMenuListItem
+              label="Toggle Exposure Notifications"
+              onPress={handleOnPressSimulationButton(
+                NativeModule.toggleExposureNotifications,
+              )}
+            />
+            <DebugMenuListItem
+              label="Detect Exposures Now"
+              onPress={handleOnPressSimulationButton(
+                NativeModule.detectExposuresNow,
+              )}
+            />
+            <DebugMenuListItem
+              label="Reset Exposures"
+              itemStyle={style.lastListItem}
+              onPress={handleOnPressSimulationButton(
+                NativeModule.resetExposures,
+              )}
+            />
+            <DebugMenuListItem
+              label="Simulate Exposure Detection Error"
+              onPress={handleOnPressSimulationButton(
+                NativeModule.simulateExposureDetectionError,
+              )}
+            />
+          </View>
         </ScrollView>
       )}
     </>

--- a/src/More/Menu.tsx
+++ b/src/More/Menu.tsx
@@ -20,7 +20,7 @@ const MenuScreen: FunctionComponent = () => {
   } = useTranslation()
   const languageName = getLocalNames()[localeCode]
   useStatusBarEffect("light-content")
-  const showDebugMenu = env.DEV === "true"
+  const showDebugMenu = env.STAGING === "true" || __DEV__
 
   const handleOnPressSelectLanguage = () => {
     navigation.navigate(Screens.LanguageSelection)


### PR DESCRIPTION
Why:
Currently we are only showing a portion of debug options on staging
builds and we would like to show them all.

This commit:
Removes the `__DEV__` check in the debug menu and updates the conditional
for showing the link to the debug menu to allow it for either staging or
`__DEV__` environments.


### 

<img width="559" alt="Screen Shot 2020-08-28 at 8 44 15 AM" src="https://user-images.githubusercontent.com/16049495/91588773-8a28d580-e90d-11ea-88a1-2cad2cdf1d6e.png">
