### PR TITLE
Update response handling for keys posting

### DIFF
--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -9,6 +9,7 @@ import { Screens } from "../../navigation"
 import { ExposureContext } from "../../ExposureContext"
 import { factories } from "../../factories"
 import * as ExposureAPI from "../exposureNotificationAPI"
+import Logger from "../../logger"
 
 jest.mock("@react-navigation/native")
 jest.mock("../../logger.ts")
@@ -90,8 +91,7 @@ describe("PublishConsentScreen", () => {
       const storeRevisionTokenSpy = jest.fn()
       const newRevisionToken = "newRevisionToken"
       const successfulPostResponse = {
-        kind: "success" as const,
-        body: { revisionToken: newRevisionToken },
+        revisionToken: newRevisionToken,
       }
       const postDiagnosisKeysSpy = jest.spyOn(ExposureAPI, "postDiagnosisKeys")
       postDiagnosisKeysSpy.mockResolvedValue(successfulPostResponse)
@@ -125,20 +125,59 @@ describe("PublishConsentScreen", () => {
     })
   })
 
+  describe("on a no-op key submission", () => {
+    it("displays a message explaining the cause to the user", async () => {
+      const navigateSpy = jest.fn()
+      ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+      const newKeysInserted = 1
+      const noOpPostResponse = {
+        reason: ExposureAPI.PostKeysNoOpReason.NoTokenForExistingKeys,
+        newKeysInserted,
+        message: "no_token_for_existing_keys",
+      }
+      const postDiagnosisKeysSpy = jest.spyOn(ExposureAPI, "postDiagnosisKeys")
+      postDiagnosisKeysSpy.mockResolvedValueOnce(noOpPostResponse)
+      const alertSpy = jest.spyOn(Alert, "alert")
+
+      const { getByLabelText } = render(
+        <PublishConsentForm
+          hmacKey="hmacKey"
+          certificate="certificate"
+          exposureKeys={[]}
+          storeRevisionToken={jest.fn()}
+          revisionToken=""
+          appPackageName=""
+          regionCodes={[""]}
+        />,
+      )
+
+      fireEvent.press(getByLabelText("I Understand and Consent"))
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Attempt to submit existing keys",
+          `Existing data was sent to the server. This usually means that this process was attempted previously from this device, but on a different application. You can communicate this to the authority that provided the verification code that was used. There were ${newKeysInserted} new keys added.`,
+          [{ onPress: expect.any(Function) }],
+        )
+      })
+      jest.resetAllMocks()
+    })
+  })
+
   describe("on a failed key submission", () => {
-    describe("when there is a server error", () => {
-      it("displays an alert with the error message from the server", async () => {
+    describe("when the error is unknown", () => {
+      it("displays an alert with the error message", async () => {
         const errorMessage = "error"
         const postDiagnosisKeysSpy = jest.spyOn(
           ExposureAPI,
           "postDiagnosisKeys",
         )
         postDiagnosisKeysSpy.mockResolvedValueOnce({
-          kind: "failure" as const,
-          error: "Unknown",
+          nature: ExposureAPI.PostKeysError.Unknown,
           message: errorMessage,
         })
         const alertSpy = jest.spyOn(Alert, "alert")
+        const loggerSpy = jest.spyOn(Logger, "error")
 
         const { getByLabelText } = render(
           <PublishConsentForm
@@ -156,22 +195,31 @@ describe("PublishConsentScreen", () => {
 
         await waitFor(() => {
           expect(alertSpy).toHaveBeenCalledWith(
-            "Something went wrong",
-            errorMessage,
+            "Failed to submit the exposure data",
+            `The operation could not be completed. ${errorMessage}`,
+          )
+          expect(loggerSpy).toHaveBeenCalledWith(
+            `IncompleteKeySumbission.Unknown.${errorMessage}`,
           )
         })
+        jest.resetAllMocks()
       })
     })
 
-    describe("when there is an unhandled exception", () => {
-      it("displays an alert with a generic message", async () => {
+    describe("when the request processing fails", () => {
+      it("displays an alert with the error message", async () => {
         const errorMessage = "error"
         const postDiagnosisKeysSpy = jest.spyOn(
           ExposureAPI,
           "postDiagnosisKeys",
         )
-        postDiagnosisKeysSpy.mockRejectedValueOnce(new Error(errorMessage))
+        postDiagnosisKeysSpy.mockResolvedValueOnce({
+          nature: ExposureAPI.PostKeysError.RequestFailed,
+          message: errorMessage,
+        })
+
         const alertSpy = jest.spyOn(Alert, "alert")
+        const loggerSpy = jest.spyOn(Logger, "error")
 
         const { getByLabelText } = render(
           <PublishConsentForm
@@ -190,9 +238,13 @@ describe("PublishConsentScreen", () => {
         await waitFor(() => {
           expect(alertSpy).toHaveBeenCalledWith(
             "Something went wrong",
-            errorMessage,
+            `The operation could not be completed. ${errorMessage}`,
+          )
+          expect(loggerSpy).toHaveBeenCalledWith(
+            `IncompleteKeySumbission.RequestFailed.${errorMessage}`,
           )
         })
+        jest.resetAllMocks()
       })
     })
   })

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -91,6 +91,7 @@ describe("PublishConsentScreen", () => {
       const storeRevisionTokenSpy = jest.fn()
       const newRevisionToken = "newRevisionToken"
       const successfulPostResponse = {
+        kind: "success" as const,
         revisionToken: newRevisionToken,
       }
       const postDiagnosisKeysSpy = jest.spyOn(ExposureAPI, "postDiagnosisKeys")
@@ -131,6 +132,7 @@ describe("PublishConsentScreen", () => {
       ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
       const newKeysInserted = 1
       const noOpPostResponse = {
+        kind: "no-op" as const,
         reason: ExposureAPI.PostKeysNoOpReason.NoTokenForExistingKeys,
         newKeysInserted,
         message: "no_token_for_existing_keys",
@@ -173,6 +175,7 @@ describe("PublishConsentScreen", () => {
           "postDiagnosisKeys",
         )
         postDiagnosisKeysSpy.mockResolvedValueOnce({
+          kind: "failure",
           nature: ExposureAPI.PostKeysError.Unknown,
           message: errorMessage,
         })
@@ -214,6 +217,7 @@ describe("PublishConsentScreen", () => {
           "postDiagnosisKeys",
         )
         postDiagnosisKeysSpy.mockResolvedValueOnce({
+          kind: "failure",
           nature: ExposureAPI.PostKeysError.RequestFailed,
           message: errorMessage,
         })

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -33,7 +33,6 @@ import {
   postDiagnosisKeys,
   PostKeysError,
   PostKeysNoOp,
-  PostKeysSuccess,
   PostKeysFailure,
 } from "../exposureNotificationAPI"
 
@@ -121,13 +120,13 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
       revisionToken,
     )
     setIsLoading(false)
-    if ((response as PostKeysSuccess).revisionToken) {
-      storeRevisionToken((response as PostKeysSuccess).revisionToken)
+    if (response.kind === "success") {
+      storeRevisionToken(response.revisionToken)
       navigation.navigate(AffectedUserFlowScreens.AffectedUserComplete)
-    } else if ((response as PostKeysNoOp).reason) {
-      handleNoOpResponse(response as PostKeysNoOp)
+    } else if (response.kind === "no-op") {
+      handleNoOpResponse(response)
     } else {
-      handleFailureResponse(response as PostKeysFailure)
+      handleFailureResponse(response)
     }
   }
   useStatusBarEffect("dark-content")

--- a/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
@@ -48,13 +48,11 @@ describe("postDiagnosisKeys", () => {
 
   describe("on a successful request", () => {
     it("returns a success response with the revisionToken", async () => {
-      const jsonResponse = {
-        revisionToken: "revisionToken",
-      }
+      const revisionToken = "revisionToken"
 
       ;(fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
-        json: jest.fn().mockResolvedValueOnce(jsonResponse),
+        json: jest.fn().mockResolvedValueOnce({ revisionToken }),
       })
 
       const result = await postDiagnosisKeys(
@@ -66,7 +64,10 @@ describe("postDiagnosisKeys", () => {
         "revisionToken",
       )
 
-      expect(result).toEqual(jsonResponse)
+      expect(result).toEqual({
+        kind: "success",
+        revisionToken,
+      })
     })
   })
 
@@ -94,6 +95,7 @@ describe("postDiagnosisKeys", () => {
       )
 
       expect(result).toEqual({
+        kind: "no-op",
         reason: PostKeysNoOpReason.NoTokenForExistingKeys,
         newKeysInserted,
         message,
@@ -119,6 +121,7 @@ describe("postDiagnosisKeys", () => {
         )
 
         expect(result).toEqual({
+          kind: "failure",
           nature: PostKeysError.RequestFailed,
           message: errorMessage,
         })
@@ -143,6 +146,7 @@ describe("postDiagnosisKeys", () => {
         )
 
         expect(result).toEqual({
+          kind: "failure",
           nature: PostKeysError.Unknown,
           message: error,
         })

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -26,11 +26,13 @@ export enum PostKeysError {
 }
 
 export type PostKeysFailure = {
+  kind: "failure"
   nature: PostKeysError
   message: string
 }
 
 export type PostKeysSuccess = {
+  kind: "success"
   revisionToken: Token
 }
 
@@ -39,6 +41,7 @@ export enum PostKeysNoOpReason {
 }
 
 export type PostKeysNoOp = {
+  kind: "no-op"
   reason: PostKeysNoOpReason
   newKeysInserted: number
   message: string
@@ -77,22 +80,31 @@ export const postDiagnosisKeys = async (
 
     const json: PostKeysResponseBody = await response.json()
     if (response.ok) {
-      return { revisionToken: json.revisionToken }
+      return { kind: "success", revisionToken: json.revisionToken }
     } else {
       switch (json.error) {
         case EXISTING_KEYS_SENT_RESPONSE: {
           return {
+            kind: "no-op",
             reason: PostKeysNoOpReason.NoTokenForExistingKeys,
             newKeysInserted: json.insertedExposures || 0,
             message: json.error,
           }
         }
         default: {
-          return { nature: PostKeysError.Unknown, message: json.error }
+          return {
+            kind: "failure",
+            nature: PostKeysError.Unknown,
+            message: json.error,
+          }
         }
       }
     }
   } catch (e) {
-    return { nature: PostKeysError.RequestFailed, message: e.message }
+    return {
+      kind: "failure",
+      nature: PostKeysError.RequestFailed,
+      message: e.message,
+    }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -91,7 +91,17 @@
       "verification_code_used": "Verification code has already been used"
     },
     "publish_consent_title_bluetooth": "Notify others in your community",
-    "start_header_bluetooth": "Help contain the spread of the virus and protect others in your community"
+    "start_header_bluetooth": "Help contain the spread of the virus and protect others in your community",
+    "publish_keys": {
+      "no_op": {
+        "title": "Attempt to submit existing keys",
+        "no_token_for_existing_keys": "Existing data was sent to the server. This usually means that this process was attempted previously from this device, but on a different application. You can communicate this to the authority that provided the verification code that was used. There were {{newKeysInserted}} new keys added."
+      },
+      "errors": {
+        "unknown": "Failed to submit the exposure data",
+        "description": "The operation could not be completed. {{message}}"
+      }
+    }
   },
   "exposure_history": {
     "exposure_detail": {


### PR DESCRIPTION
Why:
----
When the server returns a response stating that the keys sent were already inserted but no revision token was sent, we are displaying a scary and hard to understand error. This operation should not be treated as an error since the keys were added and therefore the exposed devices were notified and it should happen only if a positive was reported with a different jurisdiction. There is a disproportion of occurrences of it given the nature of how we test.

This Commit:
----
- Modify request management to handle no-op responses
- Add some copy to the error for the no-op response to the users