### PR TITLE
Fix for Exposure History Screen State Bug

### DIFF
--- a/src/factories/exposureContext.tsx
+++ b/src/factories/exposureContext.tsx
@@ -7,7 +7,7 @@ export default Factory.define<ExposureState>(() => ({
   userHasNewExposure: true,
   observeExposures: (): void => {},
   resetExposures: (): void => {},
-  getCurrentExposures: (): void => {},
+  getCurrentExposures: () => Promise.resolve([]),
   getExposureKeys: () => Promise.resolve([]),
   lastExposureDetectionDate: null,
   storeRevisionToken: (_revisionToken: string) => Promise.resolve(),

--- a/src/factories/gaenStrategy.tsx
+++ b/src/factories/gaenStrategy.tsx
@@ -7,7 +7,7 @@ export default Factory.define<GaenStrategy>(() => ({
     exposureInfoSubscription: () => {
       return { remove: () => {} }
     },
-    getCurrentExposures: () => {},
+    getCurrentExposures: () => new Promise(() => []),
     getLastDetectionDate: () => {
       return new Promise(() => null)
     },

--- a/src/gaen/index.ts
+++ b/src/gaen/index.ts
@@ -16,7 +16,7 @@ type ExposureInfoSubscription = (
 
 export interface ExposureEventsStrategy {
   exposureInfoSubscription: ExposureInfoSubscription
-  getCurrentExposures: (cb: (exposureInfo: ExposureInfo) => void) => void
+  getCurrentExposures: () => Promise<ExposureInfo>
   getLastDetectionDate: () => Promise<Posix | null>
   getExposureKeys: () => Promise<ExposureKey[]>
   getRevisionToken: () => Promise<string>


### PR DESCRIPTION
### Why
Exposures stored in the native database were not visible in the UI after force quitting and re-opening the app

### This Commit
This commit accommodates the function signature `getCurrentExposures = async (): Promise<ExposureInfo>` in `nativeModule.ts` (had previously used a callback some weeks ago, the JS-layer functions calling the method were still using the callback although it had been changed) and also fetches exposures from the database on AppState change.