### PR TITLE
Wrap fetch call for publish keys on a timeout

### DIFF
--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -86,6 +86,9 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
 
   const errorMessageTitle = (errorNature: PostKeysError) => {
     switch (errorNature) {
+      case PostKeysError.Timeout: {
+        return t("export.publish_keys.errors.timeout")
+      }
       case PostKeysError.Unknown: {
         return t("export.publish_keys.errors.unknown")
       }

--- a/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
@@ -4,6 +4,9 @@ import {
   PostKeysError,
 } from "./exposureNotificationAPI"
 import { ExposureKey } from "../exposureKey"
+import { fetchWithTimeout, TIMEOUT_ERROR } from "./fetchWithTimeout"
+
+jest.mock("./fetchWithTimeout")
 
 describe("postDiagnosisKeys", () => {
   it("executes requests with default headers and serialized data", async () => {
@@ -14,9 +17,8 @@ describe("postDiagnosisKeys", () => {
     const appPackageName = "appPackageName"
     const revisionToken = "revisionToken"
 
-    const fetchSpy = jest.fn()
-    ;(fetch as jest.Mock) = fetchSpy
-    fetchSpy.mockRejectedValueOnce("error")
+    const fetchWithTimeoutSpy = fetchWithTimeout as jest.Mock
+    fetchWithTimeoutSpy.mockRejectedValueOnce("error")
 
     await postDiagnosisKeys(
       exposureKeys,
@@ -28,29 +30,33 @@ describe("postDiagnosisKeys", () => {
     )
 
     // The constants are taken from "__mocks__/react-native-config.js"
-    expect(fetchSpy).toHaveBeenCalledWith("POST_DIAGNOSIS_KEYS_URL", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        accept: "application/json",
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledWith(
+      "POST_DIAGNOSIS_KEYS_URL",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: JSON.stringify({
+          temporaryExposureKeys: exposureKeys,
+          regions: regionCodes,
+          appPackageName,
+          verificationPayload: certificate,
+          hmackey: hmacKey,
+          padding: "",
+          revisionToken,
+        }),
       },
-      body: JSON.stringify({
-        temporaryExposureKeys: exposureKeys,
-        regions: regionCodes,
-        appPackageName,
-        verificationPayload: certificate,
-        hmackey: hmacKey,
-        padding: "",
-        revisionToken,
-      }),
-    })
+      5000,
+    )
   })
 
   describe("on a successful request", () => {
     it("returns a success response with the revisionToken", async () => {
       const revisionToken = "revisionToken"
 
-      ;(fetch as jest.Mock).mockResolvedValueOnce({
+      ;(fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
         ok: true,
         json: jest.fn().mockResolvedValueOnce({ revisionToken }),
       })
@@ -80,7 +86,7 @@ describe("postDiagnosisKeys", () => {
         insertedExposures: newKeysInserted,
       }
 
-      ;(fetch as jest.Mock).mockResolvedValueOnce({
+      ;(fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
         ok: false,
         json: jest.fn().mockResolvedValueOnce(jsonResponse),
       })
@@ -107,9 +113,9 @@ describe("postDiagnosisKeys", () => {
     describe("when the error is a catched exception", () => {
       it("returns the error message if the request errors", async () => {
         const errorMessage = "errorMessage"
-        const fetchSpy = jest.fn()
-        ;(fetch as jest.Mock) = fetchSpy
-        fetchSpy.mockRejectedValueOnce(new Error(errorMessage))
+        ;(fetchWithTimeout as jest.Mock).mockRejectedValueOnce(
+          new Error(errorMessage),
+        )
 
         const result = await postDiagnosisKeys(
           [],
@@ -128,10 +134,33 @@ describe("postDiagnosisKeys", () => {
       })
     })
 
+    describe("when the error is a timeout", () => {
+      it("returns a timeout failure", async () => {
+        const timeoutError = new Error(TIMEOUT_ERROR)
+        ;(fetchWithTimeout as jest.Mock).mockRejectedValueOnce(timeoutError)
+
+        const result = await postDiagnosisKeys(
+          [],
+          [],
+          "certificate",
+          "hmacKey",
+          "appPackageName",
+          "revisionToken",
+        )
+
+        expect(result).toEqual({
+          kind: "failure",
+          nature: PostKeysError.Timeout,
+          message: TIMEOUT_ERROR,
+        })
+      })
+    })
+
     describe("when the error is a failed response from the server", () => {
       it("returns the error on the response ", async () => {
         const error = "error"
-        ;(fetch as jest.Mock).mockResolvedValueOnce({
+
+        ;(fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
           ok: false,
           json: jest.fn().mockResolvedValueOnce({ error }),
         })

--- a/src/AffectedUserFlow/fetchWithTimeout.spec.ts
+++ b/src/AffectedUserFlow/fetchWithTimeout.spec.ts
@@ -1,0 +1,30 @@
+import { fetchWithTimeout, TIMEOUT_ERROR } from "./fetchWithTimeout"
+
+describe("fetchWithTimeout", () => {
+  it("delegates attributes to fetch and bubbles up the result", async () => {
+    const url = "url"
+    const options = {}
+    const fetchResolvedValue = "result"
+    const fetchSpy = jest.fn()
+    ;(fetch as jest.Mock) = fetchSpy
+    fetchSpy.mockResolvedValueOnce(fetchResolvedValue)
+
+    const result = await fetchWithTimeout(url, options)
+
+    expect(fetchSpy).toHaveBeenCalledWith(url, options)
+    expect(result).toEqual(fetchResolvedValue)
+  })
+
+  it("returns a timeout error if the fetch call hangs", async () => {
+    const shortTimeout = 100
+    const fetchSpy = jest.fn()
+    ;(fetch as jest.Mock) = fetchSpy
+    fetchSpy.mockReturnValueOnce(
+      new Promise((resolve) => setTimeout(resolve, shortTimeout * 2)),
+    )
+
+    await expect(fetchWithTimeout("url", {}, shortTimeout)).rejects.toThrow(
+      TIMEOUT_ERROR,
+    )
+  })
+})

--- a/src/AffectedUserFlow/fetchWithTimeout.ts
+++ b/src/AffectedUserFlow/fetchWithTimeout.ts
@@ -1,0 +1,28 @@
+const TIMEOUT_ERROR = "timeout"
+const DEFAULT_TIMEOUT = 5000
+
+const fetchWithTimeout = async (
+  url: RequestInfo,
+  options: RequestInit,
+  timeoutInMs = DEFAULT_TIMEOUT,
+): Promise<Response | unknown> => {
+  return new Promise((resolve, reject) => {
+    // Need to get a hold of the timeout function to avoid orphan promises
+    const timeoutId = setTimeout(() => {
+      reject(new Error(TIMEOUT_ERROR))
+    }, timeoutInMs)
+
+    fetch(url, options)
+      .then((response) => {
+        resolve(response)
+      })
+      .catch((error) => {
+        reject(error)
+      })
+      .finally(() => {
+        clearTimeout(timeoutId)
+      })
+  })
+}
+
+export { fetchWithTimeout, TIMEOUT_ERROR }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -99,6 +99,7 @@
       },
       "errors": {
         "unknown": "Failed to submit the exposure data",
+        "timeout": "The request took too long to complete",
         "description": "The operation could not be completed. {{message}}"
       }
     }


### PR DESCRIPTION
Why:
----
The publish keys request sometimes can timeout, the request is hanging and it it failing to complete. We need a way to detect when the request took too long and show the failure to the user.

This Commit:
----
- Add the `fetchWithTimeout` utility
- Wrap the fetch on the `postDiagnosisKeys` with a timeout of 5 seconds
- Display proper timeout error message to users when the request times out

How to test:
----
Submit keys through the flow and it should work as usual, and if you can send a first-time request(takes at least a second) and disconnect your internet in the middle you should see a timeout error
