### PR TITLE
Fix homepage copy issue

### DIFF
--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -41,7 +41,10 @@ const Home: FunctionComponent = () => {
   const style = createStyle(insets)
 
   const isBluetoothOn = useBluetoothStatus()
-  const { isLocationOffAndNeeded } = useHasLocationRequirements()
+  const {
+    isLocationNeeded,
+    isLocationOffAndNeeded,
+  } = useHasLocationRequirements()
   const { exposureNotifications } = usePermissionsContext()
 
   const isProximityTracingOn =
@@ -62,9 +65,18 @@ const Home: FunctionComponent = () => {
   const headerText = appIsActive
     ? t("home.bluetooth.tracing_on_header")
     : t("home.bluetooth.tracing_off_header")
-  const subheaderText = appIsActive
-    ? t("home.bluetooth.all_services_on_subheader", { applicationName })
-    : t("home.bluetooth.tracing_off_subheader")
+  const subheaderText = () => {
+    switch (appIsActive) {
+      case true:
+        return t("home.bluetooth.all_services_on_subheader", {
+          applicationName,
+        })
+      case false:
+        return isLocationNeeded
+          ? t("home.bluetooth.tracing_off_subheader_location")
+          : t("home.bluetooth.tracing_off_subheader")
+    }
+  }
 
   return (
     <>
@@ -103,7 +115,7 @@ const Home: FunctionComponent = () => {
               {headerText}
             </GlobalText>
             <GlobalText style={style.subheaderText} testID={"home-subheader"}>
-              {subheaderText}
+              {subheaderText()}
             </GlobalText>
           </View>
         </GradientBackground>

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -66,15 +66,14 @@ const Home: FunctionComponent = () => {
     ? t("home.bluetooth.tracing_on_header")
     : t("home.bluetooth.tracing_off_header")
   const subheaderText = () => {
-    switch (appIsActive) {
-      case true:
-        return t("home.bluetooth.all_services_on_subheader", {
-          applicationName,
-        })
-      case false:
-        return isLocationNeeded
-          ? t("home.bluetooth.tracing_off_subheader_location")
-          : t("home.bluetooth.tracing_off_subheader")
+    if (appIsActive) {
+      return t("home.bluetooth.all_services_on_subheader", {
+        applicationName,
+      })
+    } else {
+      return isLocationNeeded
+        ? t("home.bluetooth.tracing_off_subheader_location")
+        : t("home.bluetooth.tracing_off_subheader")
     }
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -161,6 +161,7 @@
       "share_message": "Check out this app {{applicationName}}, which can help us contain COVID-19! {{appDownloadLink}}",
       "tracing_off_header": "Inactive",
       "tracing_off_subheader": "Enable Bluetooth and Proximity Tracing to get info about possible exposures",
+      "tracing_off_subheader_location": "Enable Bluetooth, Proximity Tracing, and Location to get info about possible exposures",
       "tracing_on_header": "Active",
       "unauthorized_error_message": "To activate Proximity Tracing, authorize COVID-19 Exposure Logging in the Settings app",
       "unauthorized_error_title": "Authorize in Settings"


### PR DESCRIPTION
Why: prior to this commit, we were not informing the relevant users that
they need Location enabled in the home page subheader copy.

<img width="427" alt="Screen Shot 2020-09-01 at 2 20 04 PM" src="https://user-images.githubusercontent.com/39350030/91891001-452ed700-ec5e-11ea-8564-6c1025777d63.png">