### PR TITLE
Introduce StatusBar component

### DIFF
--- a/__mocks__/react-native-safe-area-context.js
+++ b/__mocks__/react-native-safe-area-context.js
@@ -1,0 +1,1 @@
+export const useSafeAreaInsets = jest.fn().mockReturnValue({insets: {bottom: 0}})

--- a/__mocks__/react-native-safe-area-context.js
+++ b/__mocks__/react-native-safe-area-context.js
@@ -1,1 +1,1 @@
-export const useSafeAreaInsets = jest.fn().mockReturnValue({insets: {bottom: 0}})
+export const useSafeAreaInsets = jest.fn().mockReturnValue({ insets: { bottom: 0 } })

--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -1,16 +1,12 @@
 import React from "react"
 import { render } from "@testing-library/react-native"
 import { useNavigation } from "@react-navigation/native"
-import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 import { ExposureDatum } from "../../exposure"
 import { DateTimeUtils } from "../../utils"
 import { factories } from "../../factories"
 
 import History from "."
-
-jest.mock("react-native-safe-area-context")
-;(useSafeAreaInsets as jest.Mock).mockReturnValue({ insets: { bottom: 0 } })
 
 jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })

--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -1,12 +1,16 @@
 import React from "react"
 import { render } from "@testing-library/react-native"
 import { useNavigation } from "@react-navigation/native"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 import { ExposureDatum } from "../../exposure"
 import { DateTimeUtils } from "../../utils"
 import { factories } from "../../factories"
 
 import History from "."
+
+jest.mock("react-native-safe-area-context")
+;(useSafeAreaInsets as jest.Mock).mockReturnValue({ insets: { bottom: 0 } })
 
 jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useState, useEffect, useRef } from "react"
 import {
-  SafeAreaView,
   StyleSheet,
   TouchableOpacity,
   View,
@@ -13,7 +12,7 @@ import { useNavigation } from "@react-navigation/native"
 import isEqual from "lodash.isequal"
 
 import { ExposureDatum } from "../../exposure"
-import { GlobalText } from "../../components"
+import { StatusBar, GlobalText } from "../../components"
 
 import DateInfoHeader from "./DateInfoHeader"
 import ExposureList from "./ExposureList"
@@ -62,57 +61,46 @@ const History: FunctionComponent<HistoryProps> = ({
 
   return (
     <>
-      <SafeAreaView style={style.safeAreaTop} />
-      <SafeAreaView style={style.safeAreaBottom}>
-        <ScrollView
-          contentContainerStyle={style.contentContainer}
-          style={style.container}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={handleOnRefresh}
-            />
-          }
-        >
-          <View>
-            <View style={style.headerRow}>
-              <GlobalText style={style.headerText}>{titleText}</GlobalText>
-              <TouchableOpacity
-                onPress={handleOnPressMoreInfo}
-                style={style.moreInfoButton}
-              >
-                <SvgXml
-                  xml={Icons.QuestionMark}
-                  accessible
-                  accessibilityLabel={t("label.question_icon")}
-                  style={style.moreInfoButtonIcon}
-                />
-              </TouchableOpacity>
-            </View>
-            <View style={style.subheaderRow}>
-              <DateInfoHeader lastDetectionDate={lastDetectionDate} />
-            </View>
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <ScrollView
+        contentContainerStyle={style.contentContainer}
+        style={style.container}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleOnRefresh} />
+        }
+      >
+        <View>
+          <View style={style.headerRow}>
+            <GlobalText style={style.headerText}>{titleText}</GlobalText>
+            <TouchableOpacity
+              onPress={handleOnPressMoreInfo}
+              style={style.moreInfoButton}
+            >
+              <SvgXml
+                xml={Icons.QuestionMark}
+                accessible
+                accessibilityLabel={t("label.question_icon")}
+                style={style.moreInfoButtonIcon}
+              />
+            </TouchableOpacity>
           </View>
-          <View style={style.listContainer}>
-            {showExposureHistory ? (
-              <ExposureList exposures={exposures} />
-            ) : (
-              <NoExposures />
-            )}
+          <View style={style.subheaderRow}>
+            <DateInfoHeader lastDetectionDate={lastDetectionDate} />
           </View>
-        </ScrollView>
-      </SafeAreaView>
+        </View>
+        <View style={style.listContainer}>
+          {showExposureHistory ? (
+            <ExposureList exposures={exposures} />
+          ) : (
+            <NoExposures />
+          )}
+        </View>
+      </ScrollView>
     </>
   )
 }
 
 const style = StyleSheet.create({
-  safeAreaTop: {
-    backgroundColor: Colors.secondary10,
-  },
-  safeAreaBottom: {
-    flex: 1,
-  },
   contentContainer: {
     paddingTop: Spacing.xSmall,
     paddingBottom: Spacing.xxHuge,

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -57,11 +57,9 @@ const History: FunctionComponent<HistoryProps> = ({
 
   const showExposureHistory = exposures.length > 0
 
-  const titleText = t("screen_titles.exposure_history")
-
   return (
     <>
-      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <StatusBar />
       <ScrollView
         contentContainerStyle={style.contentContainer}
         style={style.container}
@@ -71,7 +69,9 @@ const History: FunctionComponent<HistoryProps> = ({
       >
         <View>
           <View style={style.headerRow}>
-            <GlobalText style={style.headerText}>{titleText}</GlobalText>
+            <GlobalText style={style.headerText}>
+              {t("screen_titles.exposure_history")}
+            </GlobalText>
             <TouchableOpacity
               onPress={handleOnPressMoreInfo}
               style={style.moreInfoButton}

--- a/src/Home/index.spec.tsx
+++ b/src/Home/index.spec.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { Alert, Share } from "react-native"
 import { render, fireEvent, within } from "@testing-library/react-native"
 import { useNavigation } from "@react-navigation/native"
-import { useSafeAreaInsets } from "react-native-safe-area-context"
 import "@testing-library/jest-native/extend-expect"
 
 import Home from "."
@@ -13,9 +12,6 @@ import { useBluetoothStatus } from "../useBluetoothStatus"
 import { useHasLocationRequirements } from "./useHasLocationRequirements"
 import { factories } from "../factories"
 import { ConfigurationContext } from "../ConfigurationContext"
-
-jest.mock("react-native-safe-area-context")
-;(useSafeAreaInsets as jest.Mock).mockReturnValue({ insets: { bottom: 0 } })
 
 jest.mock("@react-navigation/native")
 

--- a/src/Home/index.spec.tsx
+++ b/src/Home/index.spec.tsx
@@ -14,10 +14,10 @@ import { useHasLocationRequirements } from "./useHasLocationRequirements"
 import { factories } from "../factories"
 import { ConfigurationContext } from "../ConfigurationContext"
 
-jest.mock("@react-navigation/native")
-
 jest.mock("react-native-safe-area-context")
 ;(useSafeAreaInsets as jest.Mock).mockReturnValue({ insets: { bottom: 0 } })
+
+jest.mock("@react-navigation/native")
 
 jest.mock("../utils/index")
 const mockedApplicationName = "applicationName"

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -1,20 +1,18 @@
 import React, { FunctionComponent } from "react"
-import {
-  ScrollView,
-  TouchableOpacity,
-  StyleSheet,
-  StatusBar,
-  View,
-} from "react-native"
+import { ScrollView, TouchableOpacity, StyleSheet, View } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
-import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 
 import { usePermissionsContext, ENStatus } from "../PermissionsContext"
 import { Screens, useStatusBarEffect, Stacks } from "../navigation"
 import { useApplicationName } from "../hooks/useApplicationInfo"
-import { GlobalText, Button, GradientBackground } from "../components"
+import {
+  StatusBar,
+  GlobalText,
+  Button,
+  GradientBackground,
+} from "../components"
 import { getLocalNames } from "../locales/languages"
 import { useBluetoothStatus } from "../useBluetoothStatus"
 import { useHasLocationRequirements } from "./useHasLocationRequirements"
@@ -36,9 +34,6 @@ const Home: FunctionComponent = () => {
 
   const languageName = getLocalNames()[localeCode]
   const { applicationName } = useApplicationName()
-
-  const insets = useSafeAreaInsets()
-  const style = createStyle(insets)
 
   const isBluetoothOn = useBluetoothStatus()
   const {
@@ -79,9 +74,7 @@ const Home: FunctionComponent = () => {
 
   return (
     <>
-      <View style={style.statusBarContainer}>
-        <StatusBar />
-      </View>
+      <StatusBar backgroundColor={Colors.gradientPrimary100Lighter} />
       <ScrollView
         style={style.container}
         contentContainerStyle={style.contentContainer}
@@ -137,82 +130,75 @@ const Home: FunctionComponent = () => {
   )
 }
 
-const createStyle = (insets: EdgeInsets) => {
-  /* es-lint-disable-no-unused-styles */
-  return StyleSheet.create({
-    statusBarContainer: {
-      height: insets.top,
-      backgroundColor: Colors.gradientPrimary100Lighter,
-    },
-    topScrollViewBackground: {
-      position: "absolute",
-      top: "-100%",
-      left: 0,
-      right: 0,
-      backgroundColor: Colors.gradientPrimary100Lighter,
-      height: "100%",
-    },
-    container: {
-      backgroundColor: Colors.primaryLightBackground,
-    },
-    contentContainer: {
-      paddingBottom: Spacing.large,
-      backgroundColor: Colors.primaryLightBackground,
-    },
-    topContainer: {
-      width: "100%",
-      alignItems: "center",
-      paddingTop: Spacing.xxSmall,
-      paddingBottom: Spacing.xLarge,
-    },
-    languageButtonContainer: {
-      alignSelf: "center",
-      paddingVertical: Spacing.xxSmall,
-      paddingHorizontal: Spacing.large,
-      backgroundColor: Colors.transparentNeutral30,
-      borderRadius: Outlines.borderRadiusMax,
-      marginBottom: Spacing.large,
-    },
-    languageButtonText: {
-      ...Typography.body3,
-      letterSpacing: Typography.xLargeLetterSpacing,
-      color: Colors.primary150,
-      textAlign: "center",
-      textTransform: "uppercase",
-    },
-    topIcon: {
-      backgroundColor: Colors.white,
-      borderRadius: Outlines.borderRadiusMax,
-      padding: 10,
-      marginBottom: Spacing.large,
-    },
-    headerText: {
-      ...Typography.header1,
-      ...Typography.mediumBold,
-      color: Colors.white,
-      textAlign: "center",
-      marginBottom: Spacing.xxSmall,
-    },
-    subheaderText: {
-      ...Typography.body1,
-      fontSize: Typography.large,
-      paddingHorizontal: Spacing.medium,
-      color: Colors.white,
-      textAlign: "center",
-      marginBottom: Spacing.xxSmall,
-    },
-    bottomContainer: {
-      backgroundColor: Colors.primaryLightBackground,
-    },
-    buttonContainer: {
-      paddingTop: Spacing.medium,
-      paddingHorizontal: Spacing.small,
-    },
-    button: {
-      alignSelf: "center",
-      width: "100%",
-    },
-  })
-}
+const style = StyleSheet.create({
+  topScrollViewBackground: {
+    position: "absolute",
+    top: "-100%",
+    left: 0,
+    right: 0,
+    backgroundColor: Colors.gradientPrimary100Lighter,
+    height: "100%",
+  },
+  container: {
+    backgroundColor: Colors.primaryLightBackground,
+  },
+  contentContainer: {
+    paddingBottom: Spacing.large,
+    backgroundColor: Colors.primaryLightBackground,
+  },
+  topContainer: {
+    width: "100%",
+    alignItems: "center",
+    paddingTop: Spacing.xxSmall,
+    paddingBottom: Spacing.xLarge,
+  },
+  languageButtonContainer: {
+    alignSelf: "center",
+    paddingVertical: Spacing.xxSmall,
+    paddingHorizontal: Spacing.large,
+    backgroundColor: Colors.transparentNeutral30,
+    borderRadius: Outlines.borderRadiusMax,
+    marginBottom: Spacing.large,
+  },
+  languageButtonText: {
+    ...Typography.body3,
+    letterSpacing: Typography.xLargeLetterSpacing,
+    color: Colors.primary150,
+    textAlign: "center",
+    textTransform: "uppercase",
+  },
+  topIcon: {
+    backgroundColor: Colors.white,
+    borderRadius: Outlines.borderRadiusMax,
+    padding: 10,
+    marginBottom: Spacing.large,
+  },
+  headerText: {
+    ...Typography.header1,
+    ...Typography.mediumBold,
+    color: Colors.white,
+    textAlign: "center",
+    marginBottom: Spacing.xxSmall,
+  },
+  subheaderText: {
+    ...Typography.body1,
+    fontSize: Typography.large,
+    paddingHorizontal: Spacing.medium,
+    color: Colors.white,
+    textAlign: "center",
+    marginBottom: Spacing.xxSmall,
+  },
+  bottomContainer: {
+    backgroundColor: Colors.primaryLightBackground,
+  },
+  buttonContainer: {
+    paddingTop: Spacing.medium,
+    paddingHorizontal: Spacing.small,
+  },
+  button: {
+    alignSelf: "center",
+    width: "100%",
+  },
+})
 
 export default Home

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,0 +1,35 @@
+import React, { FunctionComponent } from "react"
+import { View, StatusBar as RNStatusBar, StyleSheet } from "react-native"
+import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
+
+interface StatusBarProps {
+  backgroundColor: string
+}
+
+const StatusBar: FunctionComponent<StatusBarProps> = ({ backgroundColor }) => {
+  const insets = useSafeAreaInsets()
+  const style = createStyle({ insets, backgroundColor })
+
+  return (
+    <View style={style.statusBarContainer}>
+      <RNStatusBar />
+    </View>
+  )
+}
+
+type StyleProps = {
+  insets: EdgeInsets
+  backgroundColor: string
+}
+
+const createStyle = ({ insets, backgroundColor }: StyleProps) => {
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    statusBarContainer: {
+      height: insets.top,
+      backgroundColor: backgroundColor,
+    },
+  })
+}
+
+export default StatusBar

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -2,11 +2,15 @@ import React, { FunctionComponent } from "react"
 import { View, StatusBar as RNStatusBar, StyleSheet } from "react-native"
 import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 
+import { Colors } from "../styles"
+
 interface StatusBarProps {
-  backgroundColor: string
+  backgroundColor?: string
 }
 
-const StatusBar: FunctionComponent<StatusBarProps> = ({ backgroundColor }) => {
+const StatusBar: FunctionComponent<StatusBarProps> = ({
+  backgroundColor = Colors.primaryLightBackground,
+}) => {
   const insets = useSafeAreaInsets()
   const style = createStyle({ insets, backgroundColor })
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 import GradientBackground from "./GradientBackground"
 import Button from "./Button"
 import GlobalText from "./GlobalText"
+import StatusBar from "./StatusBar"
 
-export { GradientBackground, GlobalText, Button }
+export { GradientBackground, GlobalText, Button, StatusBar }

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react"
-import { Platform, StatusBar } from "react-native"
+import { StatusBar } from "react-native"
 import {
   NavigationParams,
   NavigationScreenProp,

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -193,10 +193,6 @@ export const useStatusBarEffect = (statusBarStyle: StatusBarStyle): void => {
   useFocusEffect(
     useCallback(() => {
       StatusBar.setBarStyle(statusBarStyle)
-      if (Platform.OS === "android") {
-        StatusBar.setBackgroundColor("transparent")
-        StatusBar.setTranslucent(true)
-      }
     }, [statusBarStyle]),
   )
 }


### PR DESCRIPTION
Why: prior to this commit, there were places within the app where screen
content would overlap with status bar content.

Using `SafeAreaView` does not result in the correct UI or functionality because
it results in challenging and non-intuitive cross-platform behavior.

The cross-platform behavior is more intuitive and predictable using a
plain `View`, which wraps the `StatusBar` component from React Native.
This `View`'s height is set using `insets.top` (provided by the `useSafeAreaInsets`
hook from `react-native-safe-area-context`). The background color on this `View`
effectively becomes the status bar's background color.

Notes:
- This should be used on all screens without a header bar because all screens will
be scrollable to support large accessibility text sizes. Most screens will use this
with the `primaryLightBackground` color. 
- A future commit may remove `useStatusBarEffect` and wrap all the status bar
styling in the new `StatusBar` component

This commit:
- Introduces a `StatusBar` component
- Uses `StatusBar` on `Home/index` and `ExposureHistory/History/index`
- Removes translucent status bars on android

**Before**
![before](https://user-images.githubusercontent.com/39350030/91899435-284cd080-ec6b-11ea-8383-fef88c759004.gif)

**After**
![statusbar](https://user-images.githubusercontent.com/39350030/91899517-3f8bbe00-ec6b-11ea-9380-13948eb30fc9.gif)