### PR TITLE
Retry post diagnosis request when necessary

### DIFF
--- a/bin/set_ha.sh
+++ b/bin/set_ha.sh
@@ -33,4 +33,8 @@ end
 
 result = fetching_env_succeeded && system("./bin/configure_builds.sh") && system("./bin/download_assets.sh #{HA_LABEL} #{ACCESS_TOKEN}") && download_copy_file(HA_LABEL, ACCESS_TOKEN)
 
-result ? exit 0 : exit 1
+if result
+  exit 0
+else
+  exit 1
+end

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -89,6 +89,9 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
       case PostKeysError.Timeout: {
         return t("export.publish_keys.errors.timeout")
       }
+      case PostKeysError.InternalServerError: {
+        return t("export.publish_keys.errors.internal_server_error")
+      }
       case PostKeysError.Unknown: {
         return t("export.publish_keys.errors.unknown")
       }

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -10,8 +10,6 @@ const defaultHeaders = {
   accept: "application/json",
 }
 
-const EXISTING_KEYS_SENT_RESPONSE = "no revision token, but sent existing keys"
-
 type Token = string
 
 interface PostKeysResponseBody {
@@ -23,6 +21,7 @@ interface PostKeysResponseBody {
 
 export enum PostKeysError {
   Unknown = "Unknown",
+  InternalServerError = "InternalServerError",
   RequestFailed = "RequestFailed",
   Timeout = "Timeout",
 }
@@ -54,7 +53,126 @@ type PostKeysResponse = PostKeysSuccess | PostKeysNoOp
 type RegionCode = string
 
 const DEFAULT_PADDING = ""
-const TIMEOUT = 5000
+
+type PostDiagnosisKeysRequestData = {
+  temporaryExposureKeys: ExposureKey[]
+  regions: RegionCode[]
+  verificationPayload: Token
+  hmackey: string
+  padding: string
+  appPackageName: string
+  revisionToken: string
+}
+
+class PostDiagnosisKeysRequest {
+  private requestData: PostDiagnosisKeysRequestData
+  private retriesMade = 1
+
+  private static MAX_RETRIES = 3
+  private static RETRY_STATUS_CODES = [429, 503]
+  private static INTERNAL_ERROR = "internal_error"
+  private static EXISTING_KEYS_SENT_RESPONSE =
+    "no revision token, but sent existing keys"
+  private static TIMEOUT = 5000
+  private static DEFAULT_RETRY_DELAY_MS = 1000
+
+  static perform = (data: PostDiagnosisKeysRequestData) => {
+    return new PostDiagnosisKeysRequest(data).postKeys()
+  }
+
+  private constructor(requestData: PostDiagnosisKeysRequestData) {
+    this.requestData = requestData
+  }
+
+  private postKeys = async () => {
+    try {
+      const response = (await fetchWithTimeout(
+        exposureUrl,
+        {
+          method: "POST",
+          headers: defaultHeaders,
+          body: JSON.stringify(this.requestData),
+        },
+        PostDiagnosisKeysRequest.TIMEOUT,
+      )) as Response
+
+      return await this.handlePostDiagnosisKeysResponse(response)
+    } catch (e) {
+      return {
+        kind: "failure" as const,
+        nature:
+          e.message === TIMEOUT_ERROR
+            ? PostKeysError.Timeout
+            : PostKeysError.RequestFailed,
+        message: e.message,
+      }
+    }
+  }
+
+  private handlePostDiagnosisKeysResponse = async (
+    response: Response,
+  ): Promise<PostKeysResponse | PostKeysFailure> => {
+    const responseJsonBody: PostKeysResponseBody = await response.json()
+
+    if (response.ok) {
+      return {
+        kind: "success" as const,
+        revisionToken: responseJsonBody.revisionToken,
+      }
+    } else if (
+      this.requestShouldBeRetried(response.status, responseJsonBody.error)
+    ) {
+      await this.delayRetry()
+      this.retriesMade += 1
+      return this.postKeys()
+    }
+    return this.handlePostDiagnosisKeysFailure(responseJsonBody)
+  }
+
+  private handlePostDiagnosisKeysFailure = ({
+    error,
+    insertedExposures,
+  }: PostKeysResponseBody): PostKeysNoOp | PostKeysFailure => {
+    switch (error) {
+      case PostDiagnosisKeysRequest.EXISTING_KEYS_SENT_RESPONSE: {
+        return {
+          kind: "no-op" as const,
+          reason: PostKeysNoOpReason.NoTokenForExistingKeys,
+          newKeysInserted: insertedExposures || 0,
+          message: error,
+        }
+      }
+      case PostDiagnosisKeysRequest.INTERNAL_ERROR: {
+        return {
+          kind: "failure" as const,
+          nature: PostKeysError.InternalServerError,
+          message: error,
+        }
+      }
+      default: {
+        return {
+          kind: "failure" as const,
+          nature: PostKeysError.Unknown,
+          message: error,
+        }
+      }
+    }
+  }
+
+  private requestShouldBeRetried = (statusCode: number, error: string) => {
+    return (
+      this.retriesMade < PostDiagnosisKeysRequest.MAX_RETRIES &&
+      (PostDiagnosisKeysRequest.RETRY_STATUS_CODES.includes(statusCode) ||
+        error === PostDiagnosisKeysRequest.INTERNAL_ERROR)
+    )
+  }
+
+  private delayRetry = async () => {
+    return new Promise((resolve) =>
+      setTimeout(resolve, PostDiagnosisKeysRequest.DEFAULT_RETRY_DELAY_MS),
+    )
+  }
+}
 
 export const postDiagnosisKeys = async (
   exposureKeys: ExposureKey[],
@@ -64,7 +182,7 @@ export const postDiagnosisKeys = async (
   appPackageName: string,
   revisionToken: string,
 ): Promise<PostKeysResponse | PostKeysFailure> => {
-  const data = {
+  return await PostDiagnosisKeysRequest.perform({
     temporaryExposureKeys: exposureKeys,
     regions: regionCodes,
     appPackageName,
@@ -72,50 +190,5 @@ export const postDiagnosisKeys = async (
     hmackey: hmacKey,
     padding: DEFAULT_PADDING,
     revisionToken,
-  }
-
-  try {
-    const response = (await fetchWithTimeout(
-      exposureUrl,
-      {
-        method: "POST",
-        headers: defaultHeaders,
-        body: JSON.stringify(data),
-      },
-      TIMEOUT,
-    )) as Response
-
-    const json: PostKeysResponseBody = await response.json()
-
-    if (response.ok) {
-      return { kind: "success", revisionToken: json.revisionToken }
-    } else {
-      switch (json.error) {
-        case EXISTING_KEYS_SENT_RESPONSE: {
-          return {
-            kind: "no-op",
-            reason: PostKeysNoOpReason.NoTokenForExistingKeys,
-            newKeysInserted: json.insertedExposures || 0,
-            message: json.error,
-          }
-        }
-        default: {
-          return {
-            kind: "failure",
-            nature: PostKeysError.Unknown,
-            message: json.error,
-          }
-        }
-      }
-    }
-  } catch (e) {
-    return {
-      kind: "failure",
-      nature:
-        e.message === TIMEOUT_ERROR
-          ? PostKeysError.Timeout
-          : PostKeysError.RequestFailed,
-      message: e.message,
-    }
-  }
+  })
 }

--- a/src/AffectedUserFlow/fetchWithTimeout.ts
+++ b/src/AffectedUserFlow/fetchWithTimeout.ts
@@ -7,7 +7,6 @@ const fetchWithTimeout = async (
   timeoutInMs = DEFAULT_TIMEOUT,
 ): Promise<Response | unknown> => {
   return new Promise((resolve, reject) => {
-    // Need to get a hold of the timeout function to avoid orphan promises
     const timeoutId = setTimeout(() => {
       reject(new Error(TIMEOUT_ERROR))
     }, timeoutInMs)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -100,7 +100,8 @@
       "errors": {
         "unknown": "Failed to submit the exposure data",
         "timeout": "The request took too long to complete",
-        "description": "The operation could not be completed. {{message}}"
+        "description": "The operation could not be completed. {{message}}",
+        "internal_server_error": "The server is experiencing problems, please try again later"
       }
     }
   },


### PR DESCRIPTION
Why:
----
Some responses from the post-diagnosis keys endpoint return with a retry HTTP status code. We should honor these and retry the request when necessary.

How:
----
A document was shared about which error values deemed a retry response. This was used to determine the responses, in the case of the post-diagnosis endpoint, only `internal_error` and the responses with redirect headers `429` and `503`

This Commit:
----
- Adds retry logic to postDiagnosisKeys request
- Add post keys error for an internal error message

Reviewers:
----
Not sure about the delay after getting the retry to be confirmed, there is an [header] in these requests according to the HTTP standard, could not see any of those on my testing perhaps is worth checking? 

[header]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After