### PR TITLE
Fix status bar rendering issues

### DIFF
--- a/__mocks__/react-native-safe-area-context.js
+++ b/__mocks__/react-native-safe-area-context.js
@@ -1,1 +1,3 @@
-export const useSafeAreaInsets = jest.fn().mockReturnValue({ insets: { bottom: 0 } })
+export const useSafeAreaInsets = () => {
+  return { insets: {}  }
+}

--- a/src/Activation/AcceptEula.tsx
+++ b/src/Activation/AcceptEula.tsx
@@ -12,9 +12,8 @@ import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
 import { Icons } from "../assets"
-import { GradientBackground, StatusBar } from "../components"
-import { GlobalText, Button } from "../components"
-import { ActivationScreens } from "../navigation"
+import { GlobalText, Button, GradientBackground } from "../components"
+import { ActivationScreens, useStatusBarEffect } from "../navigation"
 
 import {
   Forms,
@@ -27,6 +26,7 @@ import {
 import { useConfigurationContext } from "../ConfigurationContext"
 
 const AcceptEula: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const configuration = useConfigurationContext()
   const [boxChecked, toggleCheckbox] = useState(false)
   const { t } = useTranslation()
@@ -54,7 +54,6 @@ const AcceptEula: FunctionComponent = () => {
 
   return (
     <>
-      <StatusBar backgroundColor={Colors.primaryLightBackground} />
       <GradientBackground gradient={Colors.gradientPrimary10}>
         <SafeAreaView style={style.container}>
           <GlobalText style={style.headerText}>

--- a/src/Activation/AcceptEula.tsx
+++ b/src/Activation/AcceptEula.tsx
@@ -12,7 +12,7 @@ import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
 import { Icons } from "../assets"
-import { GradientBackground } from "../components"
+import { GradientBackground, StatusBar } from "../components"
 import { GlobalText, Button } from "../components"
 import { ActivationScreens } from "../navigation"
 
@@ -24,11 +24,9 @@ import {
   Outlines,
   Typography,
 } from "../styles"
-import { useStatusBarEffect } from "../navigation"
 import { useConfigurationContext } from "../ConfigurationContext"
 
 const AcceptEula: FunctionComponent = () => {
-  useStatusBarEffect("dark-content")
   const configuration = useConfigurationContext()
   const [boxChecked, toggleCheckbox] = useState(false)
   const { t } = useTranslation()
@@ -55,43 +53,46 @@ const AcceptEula: FunctionComponent = () => {
     : t("label.unchecked_checkbox")
 
   return (
-    <GradientBackground gradient={Colors.gradientPrimary10}>
-      <SafeAreaView style={style.container}>
-        <GlobalText style={style.headerText}>
-          {t("onboarding.terms_header_title")}
-        </GlobalText>
-        <EulaLink
-          docName={"onboarding.privacy_policy"}
-          onPress={linkToPrivacyPolicy}
-        />
-        <EulaLink docName={"onboarding.eula"} onPress={linkToEula} />
-        <View style={style.footerContainer}>
-          <TouchableOpacity
-            style={style.checkboxContainer}
-            onPress={() => toggleCheckbox(!boxChecked)}
-            accessible
-            accessibilityRole="checkbox"
-            accessibilityLabel={checkboxLabel}
-            testID="accept-terms-of-use-checkbox"
-          >
-            <SvgXml
-              xml={checkboxIcon}
-              fill={Colors.primary100}
-              width={Iconography.small}
-              height={Iconography.small}
-            />
-            <GlobalText style={style.checkboxText}>
-              {t("onboarding.eula_agree_terms_of_use")}
-            </GlobalText>
-          </TouchableOpacity>
-          <Button
-            onPress={handleOnPressNext}
-            disabled={!boxChecked}
-            label={t("common.continue")}
+    <>
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <GradientBackground gradient={Colors.gradientPrimary10}>
+        <SafeAreaView style={style.container}>
+          <GlobalText style={style.headerText}>
+            {t("onboarding.terms_header_title")}
+          </GlobalText>
+          <EulaLink
+            docName={"onboarding.privacy_policy"}
+            onPress={linkToPrivacyPolicy}
           />
-        </View>
-      </SafeAreaView>
-    </GradientBackground>
+          <EulaLink docName={"onboarding.eula"} onPress={linkToEula} />
+          <View style={style.footerContainer}>
+            <TouchableOpacity
+              style={style.checkboxContainer}
+              onPress={() => toggleCheckbox(!boxChecked)}
+              accessible
+              accessibilityRole="checkbox"
+              accessibilityLabel={checkboxLabel}
+              testID="accept-terms-of-use-checkbox"
+            >
+              <SvgXml
+                xml={checkboxIcon}
+                fill={Colors.primary100}
+                width={Iconography.small}
+                height={Iconography.small}
+              />
+              <GlobalText style={style.checkboxText}>
+                {t("onboarding.eula_agree_terms_of_use")}
+              </GlobalText>
+            </TouchableOpacity>
+            <Button
+              onPress={handleOnPressNext}
+              disabled={!boxChecked}
+              label={t("common.continue")}
+            />
+          </View>
+        </SafeAreaView>
+      </GradientBackground>
+    </>
   )
 }
 

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -13,12 +13,12 @@ import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 
-import { GlobalText, Button } from "../../components"
+import { GlobalText, Button, StatusBar } from "../../components"
 import { useAffectedUserContext } from "../AffectedUserContext"
 import * as API from "../verificationAPI"
 import { calculateHmac } from "../hmac"
 import { useExposureContext } from "../../ExposureContext"
-import { Screens } from "../../navigation"
+import { Screens, useStatusBarEffect } from "../../navigation"
 
 import { Icons } from "../../assets"
 import {
@@ -35,6 +35,7 @@ import Logger from "../../logger"
 const defaultErrorMessage = ""
 
 const CodeInputForm: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const { t } = useTranslation()
   const navigation = useNavigation()
   const strategy = useExposureContext()
@@ -156,83 +157,86 @@ const CodeInputForm: FunctionComponent = () => {
   const codeInputStyle = { ...style.codeInput, ...codeInputFocusedStyle }
 
   return (
-    <ScrollView
-      contentContainerStyle={style.contentContainer}
-      testID={"affected-user-code-input-form"}
-    >
-      <View style={style.backButtonContainer}>
-        <TouchableOpacity
-          onPress={handleOnPressBack}
-          accessible
-          accessibilityLabel={t("export.code_input_button_back")}
-        >
-          <View style={style.backButtonInnerContainer}>
-            <SvgXml
-              xml={Icons.ArrowLeft}
-              fill={Colors.black}
-              width={Iconography.xSmall}
-              height={Iconography.xSmall}
-            />
-          </View>
-        </TouchableOpacity>
-      </View>
+    <>
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <ScrollView
+        contentContainerStyle={style.contentContainer}
+        testID={"affected-user-code-input-form"}
+      >
+        <View style={style.backButtonContainer}>
+          <TouchableOpacity
+            onPress={handleOnPressBack}
+            accessible
+            accessibilityLabel={t("export.code_input_button_back")}
+          >
+            <View style={style.backButtonInnerContainer}>
+              <SvgXml
+                xml={Icons.ArrowLeft}
+                fill={Colors.black}
+                width={Iconography.xSmall}
+                height={Iconography.xSmall}
+              />
+            </View>
+          </TouchableOpacity>
+        </View>
 
-      <View style={style.cancelButtonContainer}>
-        <TouchableOpacity
-          onPress={handleOnPressCancel}
-          accessible
-          accessibilityLabel={t("export.code_input_button_cancel")}
-        >
-          <View style={style.cancelButtonInnerContainer}>
-            <SvgXml
-              xml={Icons.X}
-              fill={Colors.black}
-              width={Iconography.xSmall}
-              height={Iconography.xSmall}
-            />
-          </View>
-        </TouchableOpacity>
-      </View>
+        <View style={style.cancelButtonContainer}>
+          <TouchableOpacity
+            onPress={handleOnPressCancel}
+            accessible
+            accessibilityLabel={t("export.code_input_button_cancel")}
+          >
+            <View style={style.cancelButtonInnerContainer}>
+              <SvgXml
+                xml={Icons.X}
+                fill={Colors.black}
+                width={Iconography.xSmall}
+                height={Iconography.xSmall}
+              />
+            </View>
+          </TouchableOpacity>
+        </View>
 
-      <View style={style.headerContainer}>
-        <GlobalText style={style.header}>
-          {t("export.code_input_title_bluetooth")}
-        </GlobalText>
+        <View style={style.headerContainer}>
+          <GlobalText style={style.header}>
+            {t("export.code_input_title_bluetooth")}
+          </GlobalText>
 
-        <GlobalText style={style.subheader}>
-          {t("export.code_input_body_bluetooth")}
-        </GlobalText>
-      </View>
+          <GlobalText style={style.subheader}>
+            {t("export.code_input_body_bluetooth")}
+          </GlobalText>
+        </View>
 
-      <View>
-        <TextInput
-          testID="code-input"
-          value={code}
-          placeholder="00000000"
-          placeholderTextColor={Colors.placeholderText}
-          maxLength={codeLength}
-          style={codeInputStyle}
-          keyboardType="number-pad"
-          returnKeyType="done"
-          onChangeText={handleOnChangeText}
-          onFocus={handleOnToggleFocus}
-          onBlur={handleOnToggleFocus}
-          onSubmitEditing={Keyboard.dismiss}
-          blurOnSubmit={false}
+        <View>
+          <TextInput
+            testID="code-input"
+            value={code}
+            placeholder="00000000"
+            placeholderTextColor={Colors.placeholderText}
+            maxLength={codeLength}
+            style={codeInputStyle}
+            keyboardType="number-pad"
+            returnKeyType="done"
+            onChangeText={handleOnChangeText}
+            onFocus={handleOnToggleFocus}
+            onBlur={handleOnToggleFocus}
+            onSubmitEditing={Keyboard.dismiss}
+            blurOnSubmit={false}
+          />
+        </View>
+
+        <GlobalText style={style.errorSubtitle}>{errorMessage}</GlobalText>
+        {isLoading ? <LoadingIndicator /> : null}
+
+        <Button
+          onPress={handleOnPressSubmit}
+          label={t("common.next")}
+          disabled={isDisabled}
+          customButtonStyle={style.button}
+          hasRightArrow
         />
-      </View>
-
-      <GlobalText style={style.errorSubtitle}>{errorMessage}</GlobalText>
-      {isLoading ? <LoadingIndicator /> : null}
-
-      <Button
-        onPress={handleOnPressSubmit}
-        label={t("common.next")}
-        disabled={isDisabled}
-        customButtonStyle={style.button}
-        hasRightArrow
-      />
-    </ScrollView>
+      </ScrollView>
+    </>
   )
 }
 

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
@@ -10,12 +10,13 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
-import { GlobalText, Button } from "../../components"
-import { Screens } from "../../navigation"
+import { GlobalText, Button, StatusBar } from "../../components"
+import { Screens, useStatusBarEffect } from "../../navigation"
 import { Iconography, Colors, Typography, Spacing, Layout } from "../../styles"
 import { Icons } from "../../assets"
 
 const EnableExposureNotifications: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const { t } = useTranslation()
   const navigation = useNavigation()
 
@@ -28,42 +29,45 @@ const EnableExposureNotifications: FunctionComponent = () => {
   }
 
   return (
-    <ScrollView
-      style={style.container}
-      contentContainerStyle={style.contentContainer}
-      testID={"affected-user-enable-exposure-notifications-screen"}
-    >
-      <View style={style.cancelButtonContainer}>
-        <TouchableOpacity
-          onPress={handleOnPressCancel}
-          accessible
-          accessibilityLabel={t("export.code_input_button_cancel")}
-        >
-          <View style={style.cancelButtonInnerContainer}>
-            <SvgXml
-              xml={Icons.X}
-              fill={Colors.black}
-              width={Iconography.xSmall}
-              height={Iconography.xSmall}
-            />
-          </View>
-        </TouchableOpacity>
-      </View>
-      <View style={style.headerContainer}>
-        <GlobalText style={style.header}>
-          {t("export.enable_exposure_notifications_title")}
-        </GlobalText>
-        <GlobalText style={style.subheader}>
-          {t("export.enable_exposure_notifications_body")}
-        </GlobalText>
-      </View>
-      <View style={style.buttonContainer}>
-        <Button
-          onPress={handleOnPressOpenSettings}
-          label={t("common.settings")}
-        />
-      </View>
-    </ScrollView>
+    <>
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+        testID={"affected-user-enable-exposure-notifications-screen"}
+      >
+        <View style={style.cancelButtonContainer}>
+          <TouchableOpacity
+            onPress={handleOnPressCancel}
+            accessible
+            accessibilityLabel={t("export.code_input_button_cancel")}
+          >
+            <View style={style.cancelButtonInnerContainer}>
+              <SvgXml
+                xml={Icons.X}
+                fill={Colors.black}
+                width={Iconography.xSmall}
+                height={Iconography.xSmall}
+              />
+            </View>
+          </TouchableOpacity>
+        </View>
+        <View style={style.headerContainer}>
+          <GlobalText style={style.header}>
+            {t("export.enable_exposure_notifications_title")}
+          </GlobalText>
+          <GlobalText style={style.subheader}>
+            {t("export.enable_exposure_notifications_body")}
+          </GlobalText>
+        </View>
+        <View style={style.buttonContainer}>
+          <Button
+            onPress={handleOnPressOpenSettings}
+            label={t("common.settings")}
+          />
+        </View>
+      </ScrollView>
+    </>
   )
 }
 

--- a/src/AffectedUserFlow/Complete.tsx
+++ b/src/AffectedUserFlow/Complete.tsx
@@ -3,15 +3,14 @@ import { ScrollView, Image, StyleSheet } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
-import { useStatusBarEffect } from "../navigation"
-import { GlobalText, Button } from "../components"
-import { Screens } from "../navigation"
+import { StatusBar, GlobalText, Button } from "../components"
+import { Screens, useStatusBarEffect } from "../navigation"
 
 import { Images } from "../assets"
-import { Layout, Spacing, Typography } from "../styles"
+import { Colors, Layout, Spacing, Typography } from "../styles"
 
-export const ExportComplete: FunctionComponent = () => {
-  useStatusBarEffect("dark-content")
+export const AffectedUserComplete: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const { t } = useTranslation()
   const navigation = useNavigation()
 
@@ -20,23 +19,29 @@ export const ExportComplete: FunctionComponent = () => {
   }
 
   return (
-    <ScrollView
-      style={style.container}
-      contentContainerStyle={style.contentContainer}
-    >
-      <Image source={Images.CheckInCircle} style={style.image} />
-      <GlobalText style={style.header}>{t("export.complete_title")}</GlobalText>
-      <GlobalText style={style.contentText}>
-        {t("export.complete_body_bluetooth")}
-      </GlobalText>
-      <Button onPress={handleOnPressDone} label={t("common.done")} />
-    </ScrollView>
+    <>
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+      >
+        <Image source={Images.CheckInCircle} style={style.image} />
+        <GlobalText style={style.header}>
+          {t("export.complete_title")}
+        </GlobalText>
+        <GlobalText style={style.contentText}>
+          {t("export.complete_body_bluetooth")}
+        </GlobalText>
+        <Button onPress={handleOnPressDone} label={t("common.done")} />
+      </ScrollView>
+    </>
   )
 }
 
 const style = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: Colors.primaryLightBackground,
   },
   contentContainer: {
     justifyContent: "center",
@@ -63,4 +68,4 @@ const style = StyleSheet.create({
   },
 })
 
-export default ExportComplete
+export default AffectedUserComplete

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -14,7 +14,11 @@ import Logger from "../../logger"
 jest.mock("@react-navigation/native")
 jest.mock("../../logger.ts")
 
-describe("PublishConsentScreen", () => {
+describe("PublishConsentForm", () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
   it("navigates to the home screen when user cancels", () => {
     const navigateSpy = jest.fn()
     ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
@@ -162,7 +166,6 @@ describe("PublishConsentScreen", () => {
           [{ onPress: expect.any(Function) }],
         )
       })
-      jest.resetAllMocks()
     })
   })
 
@@ -205,7 +208,6 @@ describe("PublishConsentScreen", () => {
             `IncompleteKeySumbission.Unknown.${errorMessage}`,
           )
         })
-        jest.resetAllMocks()
       })
     })
 
@@ -247,7 +249,6 @@ describe("PublishConsentScreen", () => {
             `IncompleteKeySumbission.Timeout.${errorMessage}`,
           )
         })
-        jest.resetAllMocks()
       })
     })
 
@@ -290,7 +291,6 @@ describe("PublishConsentScreen", () => {
             `IncompleteKeySumbission.RequestFailed.${errorMessage}`,
           )
         })
-        jest.resetAllMocks()
       })
     })
   })

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, useState } from "react"
 import {
   ScrollView,
-  SafeAreaView,
   Alert,
   TouchableOpacity,
   StyleSheet,
@@ -15,9 +14,9 @@ import { ExposureKey } from "../../exposureKey"
 import { GlobalText, Button } from "../../components"
 
 import {
+  useStatusBarEffect,
   AffectedUserFlowScreens,
   Screens,
-  useStatusBarEffect,
 } from "../../navigation"
 import { Icons } from "../../assets"
 import {
@@ -55,6 +54,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
   appPackageName,
   regionCodes,
 }) => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const navigation = useNavigation()
   const { t } = useTranslation()
   const [isLoading, setIsLoading] = useState(false)
@@ -132,7 +132,6 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
       handleFailureResponse(response)
     }
   }
-  useStatusBarEffect("dark-content")
 
   const handleOnPressBack = () => {
     navigation.goBack()
@@ -147,103 +146,91 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
   }
 
   return (
-    <>
-      <SafeAreaView style={style.topSafeArea} />
-      <SafeAreaView style={style.bottomSafeArea}>
-        <View style={style.outerContainer}>
-          <View style={style.navButtonContainer}>
-            <TouchableOpacity
-              onPress={handleOnPressBack}
-              accessible
-              accessibilityLabel={t("export.code_input_button_back")}
-            >
-              <View style={style.backButtonInnerContainer}>
-                <SvgXml
-                  xml={Icons.ArrowLeft}
-                  fill={Colors.black}
-                  width={Iconography.xSmall}
-                  height={Iconography.xSmall}
-                />
-              </View>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              onPress={handleOnPressCancel}
-              accessible
-              accessibilityLabel={t("export.code_input_button_cancel")}
-            >
-              <View style={style.cancelButtonInnerContainer}>
-                <SvgXml
-                  xml={Icons.X}
-                  fill={Colors.black}
-                  width={Iconography.xSmall}
-                  height={Iconography.xSmall}
-                />
-              </View>
-            </TouchableOpacity>
-          </View>
-
-          <ScrollView
-            contentContainerStyle={style.contentContainer}
-            testID="publish-consent-form"
-            alwaysBounceVertical={false}
-          >
-            <View style={style.content}>
-              <GlobalText style={style.header}>
-                {t("export.publish_consent_title_bluetooth")}
-              </GlobalText>
-              <GlobalText style={style.bodyText}>
-                {t("export.consent_body_0")}
-              </GlobalText>
-              <GlobalText style={style.subheaderText}>
-                {t("export.consent_subheader_1")}
-              </GlobalText>
-              <GlobalText style={style.bodyText}>
-                {t("export.consent_body_1")}
-              </GlobalText>
-              <GlobalText style={style.subheaderText}>
-                {t("export.consent_subheader_2")}
-              </GlobalText>
-              <GlobalText style={style.bodyText}>
-                {t("export.consent_body_2")}
-              </GlobalText>
-            </View>
-
-            <Button
-              loading={isLoading}
-              label={t("export.consent_button_title")}
-              onPress={handleOnPressConfirm}
-              customButtonStyle={style.button}
-            />
-          </ScrollView>
-          <TouchableOpacity
-            style={style.bottomButtonContainer}
-            onPress={handleOnPressProtectPrivacy}
-          >
-            <GlobalText style={style.bottomButtonText}>
-              {t("onboarding.protect_privacy_button")}
-            </GlobalText>
+    <View style={style.outerContainer}>
+      <View style={style.navButtonContainer}>
+        <TouchableOpacity
+          onPress={handleOnPressBack}
+          accessible
+          accessibilityLabel={t("export.code_input_button_back")}
+        >
+          <View style={style.backButtonInnerContainer}>
             <SvgXml
-              xml={Icons.ChevronUp}
-              fill={Colors.primary150}
-              width={Iconography.xxSmall}
-              height={Iconography.xxSmall}
+              xml={Icons.ArrowLeft}
+              fill={Colors.black}
+              width={Iconography.xSmall}
+              height={Iconography.xSmall}
             />
-          </TouchableOpacity>
+          </View>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={handleOnPressCancel}
+          accessible
+          accessibilityLabel={t("export.code_input_button_cancel")}
+        >
+          <View style={style.cancelButtonInnerContainer}>
+            <SvgXml
+              xml={Icons.X}
+              fill={Colors.black}
+              width={Iconography.xSmall}
+              height={Iconography.xSmall}
+            />
+          </View>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView
+        contentContainerStyle={style.contentContainer}
+        testID="publish-consent-form"
+        alwaysBounceVertical={false}
+      >
+        <View style={style.content}>
+          <GlobalText style={style.header}>
+            {t("export.publish_consent_title_bluetooth")}
+          </GlobalText>
+          <GlobalText style={style.bodyText}>
+            {t("export.consent_body_0")}
+          </GlobalText>
+          <GlobalText style={style.subheaderText}>
+            {t("export.consent_subheader_1")}
+          </GlobalText>
+          <GlobalText style={style.bodyText}>
+            {t("export.consent_body_1")}
+          </GlobalText>
+          <GlobalText style={style.subheaderText}>
+            {t("export.consent_subheader_2")}
+          </GlobalText>
+          <GlobalText style={style.bodyText}>
+            {t("export.consent_body_2")}
+          </GlobalText>
         </View>
-      </SafeAreaView>
-    </>
+
+        <Button
+          loading={isLoading}
+          label={t("export.consent_button_title")}
+          onPress={handleOnPressConfirm}
+          customButtonStyle={style.button}
+        />
+      </ScrollView>
+      <TouchableOpacity
+        style={style.bottomButtonContainer}
+        onPress={handleOnPressProtectPrivacy}
+      >
+        <GlobalText style={style.bottomButtonText}>
+          {t("onboarding.protect_privacy_button")}
+        </GlobalText>
+        <SvgXml
+          xml={Icons.ChevronUp}
+          fill={Colors.primary150}
+          width={Iconography.xxSmall}
+          height={Iconography.xxSmall}
+        />
+      </TouchableOpacity>
+    </View>
   )
 }
 
 const style = StyleSheet.create({
-  topSafeArea: {
-    backgroundColor: Colors.primaryLightBackground,
-  },
-  bottomSafeArea: {
-    flex: 1,
-    backgroundColor: Colors.secondary10,
-  },
   outerContainer: {
     flex: 1,
     backgroundColor: Colors.primaryLightBackground,

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
@@ -3,7 +3,7 @@ import { View, Text, Button } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 
 import { StatusBar } from "../../components"
-import { Screens } from "../../navigation"
+import { Screens, useStatusBarEffect } from "../../navigation"
 import { useAffectedUserContext } from "../AffectedUserContext"
 import PublishConsentForm from "./PublishConsentForm"
 import { useExposureContext } from "../../ExposureContext"
@@ -12,6 +12,7 @@ import { useConfigurationContext } from "../../ConfigurationContext"
 import { Colors } from "../../styles"
 
 const PublishConsentScreen: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const [revisionToken, setRevisionToken] = useState("")
   const { storeRevisionToken, getRevisionToken } = useExposureContext()
   const navigation = useNavigation()

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
@@ -2,14 +2,16 @@ import React, { FunctionComponent, useState, useEffect } from "react"
 import { View, Text, Button } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 
-import { useStatusBarEffect, Screens } from "../../navigation"
+import { StatusBar } from "../../components"
+import { Screens } from "../../navigation"
 import { useAffectedUserContext } from "../AffectedUserContext"
 import PublishConsentForm from "./PublishConsentForm"
 import { useExposureContext } from "../../ExposureContext"
 import { useConfigurationContext } from "../../ConfigurationContext"
 
+import { Colors } from "../../styles"
+
 const PublishConsentScreen: FunctionComponent = () => {
-  useStatusBarEffect("light-content")
   const [revisionToken, setRevisionToken] = useState("")
   const { storeRevisionToken, getRevisionToken } = useExposureContext()
   const navigation = useNavigation()
@@ -36,15 +38,18 @@ const PublishConsentScreen: FunctionComponent = () => {
     )
   } else {
     return (
-      <View>
-        <Text>Invalid State</Text>
-        <Button
-          onPress={() => {
-            navigation.navigate(Screens.Home)
-          }}
-          title={"Go Back"}
-        />
-      </View>
+      <>
+        <StatusBar backgroundColor={Colors.primaryLightBackground} />
+        <View>
+          <Text>Invalid State</Text>
+          <Button
+            onPress={() => {
+              navigation.navigate(Screens.Home)
+            }}
+            title={"Go Back"}
+          />
+        </View>
+      </>
     )
   }
 }

--- a/src/AffectedUserFlow/Start.tsx
+++ b/src/AffectedUserFlow/Start.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react"
 import {
-  TouchableOpacity,
   StyleSheet,
+  TouchableOpacity,
   View,
   Image,
   ScrollView,
@@ -10,18 +10,16 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
-import { GlobalText, Button } from "../components"
-import { useStatusBarEffect } from "../navigation"
-import { Screens } from "../navigation"
+import { StatusBar, GlobalText, Button } from "../components"
+import { Screens, useStatusBarEffect } from "../navigation"
 
-import { Spacing, Colors, Iconography, Typography, Layout } from "../styles"
+import { Layout, Spacing, Colors, Iconography, Typography } from "../styles"
 import { Images, Icons } from "../assets"
 
 export const ExportIntro: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const { t } = useTranslation()
   const navigation = useNavigation()
-
-  useStatusBarEffect("dark-content")
 
   const handleOnPressNext = () => {
     navigation.navigate(Screens.AffectedUserCodeInput)
@@ -32,44 +30,47 @@ export const ExportIntro: FunctionComponent = () => {
   }
 
   return (
-    <ScrollView
-      style={style.container}
-      contentContainerStyle={style.contentContainer}
-      alwaysBounceVertical={false}
-    >
-      <View style={style.cancelButtonContainer}>
-        <TouchableOpacity
-          onPress={handleOnPressCancel}
+    <>
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
+      >
+        <View style={style.cancelButtonContainer}>
+          <TouchableOpacity
+            onPress={handleOnPressCancel}
+            accessible
+            accessibilityLabel={t("export.code_input_button_cancel")}
+          >
+            <View style={style.cancelButtonInnerContainer}>
+              <SvgXml
+                xml={Icons.X}
+                fill={Colors.black}
+                width={Iconography.xSmall}
+                height={Iconography.xSmall}
+              />
+            </View>
+          </TouchableOpacity>
+        </View>
+        <Image
+          source={Images.PersonAndHealthExpert}
+          style={style.image}
           accessible
-          accessibilityLabel={t("export.code_input_button_cancel")}
-        >
-          <View style={style.cancelButtonInnerContainer}>
-            <SvgXml
-              xml={Icons.X}
-              fill={Colors.black}
-              width={Iconography.xSmall}
-              height={Iconography.xSmall}
-            />
-          </View>
-        </TouchableOpacity>
-      </View>
-      <Image
-        source={Images.PersonAndHealthExpert}
-        style={style.image}
-        accessible
-        accessibilityLabel={t("exoprt.start_image_label")}
-      />
-      <GlobalText style={style.header}>
-        {t("export.start_header_bluetooth")}
-      </GlobalText>
-      <View style={style.buttonContainer}>
-        <Button
-          label={t("common.start")}
-          onPress={handleOnPressNext}
-          hasRightArrow
+          accessibilityLabel={t("exoprt.start_image_label")}
         />
-      </View>
-    </ScrollView>
+        <GlobalText style={style.header}>
+          {t("export.start_header_bluetooth")}
+        </GlobalText>
+        <View style={style.buttonContainer}>
+          <Button
+            label={t("common.start")}
+            onPress={handleOnPressNext}
+            hasRightArrow
+          />
+        </View>
+      </ScrollView>
+    </>
   )
 }
 

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -19,7 +19,7 @@ const ExposureDetail: FunctionComponent = () => {
   const route = useRoute<
     RouteProp<ExposureHistoryStackParamList, "ExposureDetail">
   >()
-  useStatusBarEffect("light-content")
+  useStatusBarEffect("light-content", Colors.headerBackground)
   const { t } = useTranslation()
   const {
     healthAuthorityName,

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -13,6 +13,7 @@ import isEqual from "lodash.isequal"
 
 import { ExposureDatum } from "../../exposure"
 import { StatusBar, GlobalText } from "../../components"
+import { useStatusBarEffect } from "../../navigation/index"
 
 import DateInfoHeader from "./DateInfoHeader"
 import ExposureList from "./ExposureList"
@@ -33,6 +34,7 @@ const History: FunctionComponent<HistoryProps> = ({
   lastDetectionDate,
   exposures,
 }) => {
+  useStatusBarEffect("dark-content", Colors.secondary10)
   const { t } = useTranslation()
   const navigation = useNavigation()
   const [refreshing, setRefreshing] = useState(false)
@@ -59,7 +61,7 @@ const History: FunctionComponent<HistoryProps> = ({
 
   return (
     <>
-      <StatusBar />
+      <StatusBar backgroundColor={Colors.secondary10} />
       <ScrollView
         contentContainerStyle={style.contentContainer}
         style={style.container}
@@ -106,7 +108,8 @@ const style = StyleSheet.create({
     paddingBottom: Spacing.xxHuge,
   },
   container: {
-    padding: Spacing.medium,
+    paddingHorizontal: Spacing.medium,
+    paddingBottom: Spacing.medium,
     backgroundColor: Colors.secondary10,
   },
   headerRow: {

--- a/src/ExposureHistory/MoreInfo.tsx
+++ b/src/ExposureHistory/MoreInfo.tsx
@@ -1,15 +1,15 @@
 import React, { FunctionComponent } from "react"
 import { View, ScrollView, StyleSheet } from "react-native"
 import { useTranslation } from "react-i18next"
+import { useStatusBarEffect } from "../navigation/index"
 
 import { GlobalText } from "../components"
-import { useStatusBarEffect } from "../navigation"
 
 import { Spacing, Typography, Colors } from "../styles"
 
 const MoreInfo: FunctionComponent = () => {
+  useStatusBarEffect("light-content", Colors.headerBackground)
   const { t } = useTranslation()
-  useStatusBarEffect("light-content")
 
   return (
     <>

--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -1,7 +1,6 @@
-import React from "react"
+import React, { FunctionComponent } from "react"
 
 import { useExposureContext } from "../ExposureContext"
-import { useStatusBarEffect } from "../navigation"
 import History from "./History"
 
 import { ExposureInfo, ExposureDatum } from "../exposure"
@@ -10,10 +9,8 @@ const toExposureList = (exposureInfo: ExposureInfo): ExposureDatum[] => {
   return exposureInfo
 }
 
-const ExposureHistoryScreen = (): JSX.Element => {
+const ExposureHistoryScreen: FunctionComponent = () => {
   const { lastExposureDetectionDate, exposureInfo } = useExposureContext()
-
-  useStatusBarEffect("dark-content")
 
   const exposures = toExposureList(exposureInfo)
 

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -25,7 +25,7 @@ import { Icons } from "../assets"
 import { Spacing, Colors, Typography, Outlines, Iconography } from "../styles"
 
 const Home: FunctionComponent = () => {
-  useStatusBarEffect("light-content")
+  useStatusBarEffect("light-content", Colors.gradientPrimary100Lighter)
   const {
     t,
     i18n: { language: localeCode },

--- a/src/More/ENDebugMenu.tsx
+++ b/src/More/ENDebugMenu.tsx
@@ -14,6 +14,7 @@ import { GlobalText } from "../components"
 import { useOnboardingContext } from "../OnboardingContext"
 import { NativeModule } from "../gaen"
 import { NavigationProp, Screens } from "../navigation"
+import { useStatusBarEffect } from "../navigation/index"
 
 import { Colors, Spacing, Typography, Outlines } from "../styles"
 
@@ -22,6 +23,7 @@ type ENDebugMenuProps = {
 }
 
 const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
+  useStatusBarEffect("light-content", Colors.headerBackground)
   const [loading, setLoading] = useState(false)
   const { resetOnboarding } = useOnboardingContext()
 

--- a/src/More/LanguageSelection.tsx
+++ b/src/More/LanguageSelection.tsx
@@ -58,35 +58,33 @@ const LanguageSelection: FunctionComponent = () => {
   }
 
   return (
-    <>
-      <View style={style.container}>
-        <View style={style.headerContainer}>
-          <GlobalText style={style.headerText}>
-            {t("onboarding.select_language")}
-          </GlobalText>
-          <TouchableOpacity
-            style={style.closeIconContainer}
-            onPress={navigation.goBack}
-          >
-            <SvgXml
-              xml={Icons.XInCircle}
-              fill={Colors.neutral30}
-              width={Iconography.small}
-              height={Iconography.small}
-            />
-          </TouchableOpacity>
-        </View>
-        <FlatList
-          keyExtractor={(_, i) => `${i}`}
-          data={localeList}
-          renderItem={renderItem}
-          ItemSeparatorComponent={itemSeparatorComponent}
-          ListFooterComponent={itemSeparatorComponent}
-          alwaysBounceVertical={false}
-          style={style.languageButtonsContainer}
-        />
+    <View style={style.container}>
+      <View style={style.headerContainer}>
+        <GlobalText style={style.headerText}>
+          {t("onboarding.select_language")}
+        </GlobalText>
+        <TouchableOpacity
+          style={style.closeIconContainer}
+          onPress={navigation.goBack}
+        >
+          <SvgXml
+            xml={Icons.XInCircle}
+            fill={Colors.neutral30}
+            width={Iconography.small}
+            height={Iconography.small}
+          />
+        </TouchableOpacity>
       </View>
-    </>
+      <FlatList
+        keyExtractor={(_, i) => `${i}`}
+        data={localeList}
+        renderItem={renderItem}
+        ItemSeparatorComponent={itemSeparatorComponent}
+        ListFooterComponent={itemSeparatorComponent}
+        alwaysBounceVertical={false}
+        style={style.languageButtonsContainer}
+      />
+    </View>
   )
 }
 

--- a/src/More/LanguageSelection.tsx
+++ b/src/More/LanguageSelection.tsx
@@ -2,12 +2,12 @@ import React, { FunctionComponent } from "react"
 import { FlatList, View, StyleSheet, TouchableOpacity } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
-import { useStatusBarEffect } from "../navigation"
 import { SvgXml } from "react-native-svg"
 
 import { getLocaleList, setUserLocaleOverride } from "../locales/languages"
 import { GlobalText } from "../components"
 import { Icons } from "../assets"
+import { useStatusBarEffect } from "../navigation"
 
 import {
   Outlines,
@@ -19,13 +19,13 @@ import {
 } from "../styles"
 
 const LanguageSelection: FunctionComponent = () => {
+  useStatusBarEffect("light-content", Colors.headerBackground)
   const {
     i18n: { language },
     t,
   } = useTranslation()
   const navigation = useNavigation()
   const localeList = getLocaleList()
-  useStatusBarEffect("light-content")
 
   type ListItem = {
     label: string
@@ -58,33 +58,35 @@ const LanguageSelection: FunctionComponent = () => {
   }
 
   return (
-    <View style={style.container}>
-      <View style={style.headerContainer}>
-        <GlobalText style={style.headerText}>
-          {t("onboarding.select_language")}
-        </GlobalText>
-        <TouchableOpacity
-          style={style.closeIconContainer}
-          onPress={navigation.goBack}
-        >
-          <SvgXml
-            xml={Icons.XInCircle}
-            fill={Colors.neutral30}
-            width={Iconography.small}
-            height={Iconography.small}
-          />
-        </TouchableOpacity>
+    <>
+      <View style={style.container}>
+        <View style={style.headerContainer}>
+          <GlobalText style={style.headerText}>
+            {t("onboarding.select_language")}
+          </GlobalText>
+          <TouchableOpacity
+            style={style.closeIconContainer}
+            onPress={navigation.goBack}
+          >
+            <SvgXml
+              xml={Icons.XInCircle}
+              fill={Colors.neutral30}
+              width={Iconography.small}
+              height={Iconography.small}
+            />
+          </TouchableOpacity>
+        </View>
+        <FlatList
+          keyExtractor={(_, i) => `${i}`}
+          data={localeList}
+          renderItem={renderItem}
+          ItemSeparatorComponent={itemSeparatorComponent}
+          ListFooterComponent={itemSeparatorComponent}
+          alwaysBounceVertical={false}
+          style={style.languageButtonsContainer}
+        />
       </View>
-      <FlatList
-        keyExtractor={(_, i) => `${i}`}
-        data={localeList}
-        renderItem={renderItem}
-        ItemSeparatorComponent={itemSeparatorComponent}
-        ListFooterComponent={itemSeparatorComponent}
-        alwaysBounceVertical={false}
-        style={style.languageButtonsContainer}
-      />
-    </View>
+    </>
   )
 }
 

--- a/src/More/Menu.tsx
+++ b/src/More/Menu.tsx
@@ -28,51 +28,49 @@ const MenuScreen: FunctionComponent = () => {
   }
 
   return (
-    <>
-      <ScrollView style={style.container}>
-        <View style={[style.section, style.firstSection]}>
-          <TouchableOpacity
-            onPress={handleOnPressSelectLanguage}
-            accessible
-            accessibilityLabel={t("more.select_language")}
-          >
-            <View style={[style.listItem, style.languageButtonContainer]}>
-              <SvgXml
-                xml={Icons.LanguagesIcon}
-                width={Iconography.small}
-                height={Iconography.small}
-                style={style.icon}
-                accessible
-                accessibilityLabel={t("label.language_icon")}
-              />
-              <GlobalText style={style.languageButtonText}>
-                {languageName}
-              </GlobalText>
-            </View>
-          </TouchableOpacity>
-        </View>
+    <ScrollView style={style.container}>
+      <View style={[style.section, style.firstSection]}>
+        <TouchableOpacity
+          onPress={handleOnPressSelectLanguage}
+          accessible
+          accessibilityLabel={t("more.select_language")}
+        >
+          <View style={[style.listItem, style.languageButtonContainer]}>
+            <SvgXml
+              xml={Icons.LanguagesIcon}
+              width={Iconography.small}
+              height={Iconography.small}
+              style={style.icon}
+              accessible
+              accessibilityLabel={t("label.language_icon")}
+            />
+            <GlobalText style={style.languageButtonText}>
+              {languageName}
+            </GlobalText>
+          </View>
+        </TouchableOpacity>
+      </View>
+      <View style={style.section}>
+        <SettingsListItem
+          label={t("screen_titles.about")}
+          onPress={() => navigation.navigate(MoreStackScreens.About)}
+        />
+        <SettingsListItem
+          label={t("screen_titles.legal")}
+          onPress={() => navigation.navigate(MoreStackScreens.Legal)}
+          lastItem
+        />
+      </View>
+      {showDebugMenu ? (
         <View style={style.section}>
           <SettingsListItem
-            label={t("screen_titles.about")}
-            onPress={() => navigation.navigate(MoreStackScreens.About)}
-          />
-          <SettingsListItem
-            label={t("screen_titles.legal")}
-            onPress={() => navigation.navigate(MoreStackScreens.Legal)}
+            label="EN Debug Menu"
+            onPress={() => navigation.navigate(MoreStackScreens.ENDebugMenu)}
             lastItem
           />
         </View>
-        {showDebugMenu ? (
-          <View style={style.section}>
-            <SettingsListItem
-              label="EN Debug Menu"
-              onPress={() => navigation.navigate(MoreStackScreens.ENDebugMenu)}
-              lastItem
-            />
-          </View>
-        ) : null}
-      </ScrollView>
-    </>
+      ) : null}
+    </ScrollView>
   )
 }
 

--- a/src/More/Menu.tsx
+++ b/src/More/Menu.tsx
@@ -7,19 +7,20 @@ import env from "react-native-config"
 
 import { getLocalNames } from "../locales/languages"
 import { GlobalText } from "../components"
-import { Screens, MoreStackScreens, useStatusBarEffect } from "../navigation"
+import { Screens, MoreStackScreens } from "../navigation"
+import { useStatusBarEffect } from "../navigation/index"
 
 import { Icons } from "../assets"
 import { Iconography, Colors, Spacing, Typography, Outlines } from "../styles"
 
 const MenuScreen: FunctionComponent = () => {
+  useStatusBarEffect("light-content", Colors.headerBackground)
   const navigation = useNavigation()
   const {
     t,
     i18n: { language: localeCode },
   } = useTranslation()
   const languageName = getLocalNames()[localeCode]
-  useStatusBarEffect("light-content")
   const showDebugMenu = env.STAGING === "true" || __DEV__
 
   const handleOnPressSelectLanguage = () => {
@@ -27,49 +28,51 @@ const MenuScreen: FunctionComponent = () => {
   }
 
   return (
-    <ScrollView style={style.container}>
-      <View style={[style.section, style.firstSection]}>
-        <TouchableOpacity
-          onPress={handleOnPressSelectLanguage}
-          accessible
-          accessibilityLabel={t("more.select_language")}
-        >
-          <View style={[style.listItem, style.languageButtonContainer]}>
-            <SvgXml
-              xml={Icons.LanguagesIcon}
-              width={Iconography.small}
-              height={Iconography.small}
-              style={style.icon}
-              accessible
-              accessibilityLabel={t("label.language_icon")}
-            />
-            <GlobalText style={style.languageButtonText}>
-              {languageName}
-            </GlobalText>
-          </View>
-        </TouchableOpacity>
-      </View>
-      <View style={style.section}>
-        <SettingsListItem
-          label={t("screen_titles.about")}
-          onPress={() => navigation.navigate(MoreStackScreens.About)}
-        />
-        <SettingsListItem
-          label={t("screen_titles.legal")}
-          onPress={() => navigation.navigate(MoreStackScreens.Legal)}
-          lastItem
-        />
-      </View>
-      {showDebugMenu ? (
+    <>
+      <ScrollView style={style.container}>
+        <View style={[style.section, style.firstSection]}>
+          <TouchableOpacity
+            onPress={handleOnPressSelectLanguage}
+            accessible
+            accessibilityLabel={t("more.select_language")}
+          >
+            <View style={[style.listItem, style.languageButtonContainer]}>
+              <SvgXml
+                xml={Icons.LanguagesIcon}
+                width={Iconography.small}
+                height={Iconography.small}
+                style={style.icon}
+                accessible
+                accessibilityLabel={t("label.language_icon")}
+              />
+              <GlobalText style={style.languageButtonText}>
+                {languageName}
+              </GlobalText>
+            </View>
+          </TouchableOpacity>
+        </View>
         <View style={style.section}>
           <SettingsListItem
-            label="EN Debug Menu"
-            onPress={() => navigation.navigate(MoreStackScreens.ENDebugMenu)}
+            label={t("screen_titles.about")}
+            onPress={() => navigation.navigate(MoreStackScreens.About)}
+          />
+          <SettingsListItem
+            label={t("screen_titles.legal")}
+            onPress={() => navigation.navigate(MoreStackScreens.Legal)}
             lastItem
           />
         </View>
-      ) : null}
-    </ScrollView>
+        {showDebugMenu ? (
+          <View style={style.section}>
+            <SettingsListItem
+              label="EN Debug Menu"
+              onPress={() => navigation.navigate(MoreStackScreens.ENDebugMenu)}
+              lastItem
+            />
+          </View>
+        ) : null}
+      </ScrollView>
+    </>
   )
 }
 

--- a/src/Onboarding/OnboardingScreen.tsx
+++ b/src/Onboarding/OnboardingScreen.tsx
@@ -8,14 +8,14 @@ import {
   ImageSourcePropType,
   ViewStyle,
   TouchableOpacity,
-  SafeAreaView,
 } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 import LinearGradient from "react-native-linear-gradient"
+import { SafeAreaView } from "react-navigation"
 
-import { GlobalText, Button } from "../components"
+import { StatusBar, GlobalText, Button } from "../components"
 import {
   Screens,
   OnboardingScreens,
@@ -56,13 +56,13 @@ const OnboardingScreen: FunctionComponent<OnboardingScreenProps> = ({
   onboardingScreenContent,
   onboardingScreenActions,
 }: OnboardingScreenProps) => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const navigation = useNavigation()
   const {
     t,
     i18n: { language: localeCode },
   } = useTranslation()
   const languageName = getLocalNames()[localeCode]
-  useStatusBarEffect("dark-content")
 
   const handleOnPressSelectLanguage = () => {
     navigation.navigate(Screens.LanguageSelection)
@@ -74,8 +74,11 @@ const OnboardingScreen: FunctionComponent<OnboardingScreenProps> = ({
 
   return (
     <>
-      <SafeAreaView style={style.topSafeArea} />
-      <SafeAreaView style={style.bottomSafeArea}>
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <SafeAreaView
+        style={{ flex: 1 }}
+        forceInset={{ top: "never", bottom: "always" }}
+      >
         <View style={style.header}>
           <TouchableOpacity onPress={handleOnPressSelectLanguage}>
             <LinearGradient
@@ -178,26 +181,17 @@ const PositionDots: FunctionComponent<PositionDotsProps> = ({
   )
 }
 
-const iosHeaderHeight = 65
-const androidHeaderHeight = 90
+const iosPaddingTop = 65
+const androidPaddingTop = 90
 const headerHeight = Platform.select({
-  ios: iosHeaderHeight,
-  android: androidHeaderHeight,
-  default: iosHeaderHeight,
+  ios: iosPaddingTop,
+  android: androidPaddingTop,
+  default: iosPaddingTop,
 })
 
 const style = StyleSheet.create({
-  topSafeArea: {
-    backgroundColor: Colors.primaryLightBackground,
-  },
-  bottomSafeArea: {
-    flex: 1,
-    backgroundColor: Colors.secondary10,
-  },
   header: {
     position: "absolute",
-    top: 0,
-    height: headerHeight,
     width: "100%",
     zIndex: Layout.zLevel1,
     flexDirection: "row",

--- a/src/Onboarding/ProtectPrivacy.tsx
+++ b/src/Onboarding/ProtectPrivacy.tsx
@@ -13,7 +13,6 @@ import { SvgXml } from "react-native-svg"
 
 import { GlobalText } from "../components"
 import { useApplicationName } from "../hooks/useApplicationInfo"
-import { useStatusBarEffect } from "../navigation"
 
 import { Layout, Typography, Spacing, Colors, Iconography } from "../styles"
 import { Icons, Images } from "../assets"
@@ -28,7 +27,6 @@ const ProtectPrivacy: FunctionComponent<ProtectPrivacyProps> = ({
   const navigation = useNavigation()
   const { t } = useTranslation()
   const { applicationName } = useApplicationName()
-  useStatusBarEffect("dark-content")
 
   const headerContainerConditionalStyle = modalStyle && {
     ...style.headerContainerModal,

--- a/src/Onboarding/Welcome.tsx
+++ b/src/Onboarding/Welcome.tsx
@@ -4,7 +4,12 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import LinearGradient from "react-native-linear-gradient"
 
-import { GlobalText, Button, GradientBackground } from "../components"
+import {
+  StatusBar,
+  GlobalText,
+  Button,
+  GradientBackground,
+} from "../components"
 import { getLocalNames } from "../locales/languages"
 import { useApplicationName } from "../hooks/useApplicationInfo"
 import { Screens, OnboardingScreens, useStatusBarEffect } from "../navigation"
@@ -13,6 +18,7 @@ import { Images } from "../assets"
 import { Spacing, Colors, Typography, Outlines } from "../styles"
 
 const Welcome: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const navigation = useNavigation()
   const {
     t,
@@ -20,57 +26,62 @@ const Welcome: FunctionComponent = () => {
   } = useTranslation()
   const languageName = getLocalNames()[localeCode]
   const { applicationName } = useApplicationName()
-  useStatusBarEffect("dark-content")
 
   const handleOnPressSelectLanguage = () => {
     navigation.navigate(Screens.LanguageSelection)
   }
 
   return (
-    <GradientBackground gradient={Colors.gradientPrimary10} angleCenterY={0.25}>
-      <View style={style.container}>
-        <TouchableOpacity
-          onPress={handleOnPressSelectLanguage}
-          style={style.languageButtonContainer}
-        >
-          <LinearGradient
-            colors={Colors.gradientPrimary10}
-            useAngle
-            angle={0}
-            angleCenter={{ x: 0.5, y: 0.5 }}
+    <>
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <GradientBackground
+        gradient={Colors.gradientPrimary10}
+        angleCenterY={0.25}
+      >
+        <View style={style.container}>
+          <TouchableOpacity
+            onPress={handleOnPressSelectLanguage}
             style={style.languageButtonContainer}
           >
-            <GlobalText style={style.languageButtonText}>
-              {languageName}
+            <LinearGradient
+              colors={Colors.gradientPrimary10}
+              useAngle
+              angle={0}
+              angleCenter={{ x: 0.5, y: 0.5 }}
+              style={style.languageButtonContainer}
+            >
+              <GlobalText style={style.languageButtonText}>
+                {languageName}
+              </GlobalText>
+            </LinearGradient>
+          </TouchableOpacity>
+          <View>
+            <Image
+              source={Images.PeopleOnNetworkNodes}
+              style={style.image}
+              accessible
+              accessibilityLabel={t("onboarding.welcome_image_label")}
+            />
+            <GlobalText style={style.mainText}>
+              {t("label.launch_screen1_header")}
             </GlobalText>
-          </LinearGradient>
-        </TouchableOpacity>
-        <View>
-          <Image
-            source={Images.PeopleOnNetworkNodes}
-            style={style.image}
-            accessible
-            accessibilityLabel={t("onboarding.welcome_image_label")}
+            <GlobalText style={style.mainText}>{applicationName}</GlobalText>
+          </View>
+          <Button
+            label={t("label.launch_get_started")}
+            onPress={() => navigation.navigate(OnboardingScreens.Introduction)}
+            hasRightArrow
           />
-          <GlobalText style={style.mainText}>
-            {t("label.launch_screen1_header")}
-          </GlobalText>
-          <GlobalText style={style.mainText}>{applicationName}</GlobalText>
         </View>
-        <Button
-          label={t("label.launch_get_started")}
-          onPress={() => navigation.navigate(OnboardingScreens.Introduction)}
-          hasRightArrow
-        />
-      </View>
-    </GradientBackground>
+      </GradientBackground>
+    </>
   )
 }
 
 const style = StyleSheet.create({
   container: {
     flex: 1,
-    paddingVertical: Spacing.xxHuge,
+    paddingBottom: Spacing.xxHuge,
     paddingHorizontal: Spacing.large,
     alignItems: "center",
     justifyContent: "space-between",

--- a/src/ReportIssue/ReportIssueForm.tsx
+++ b/src/ReportIssue/ReportIssueForm.tsx
@@ -18,7 +18,6 @@ import { useVersionInfo } from "../hooks/useApplicationInfo"
 import { GlobalText, Button } from "../components"
 import { reportAnIssue, ReportIssueError } from "../More/zendeskAPI"
 import { Icons } from "../assets"
-import { useStatusBarEffect } from "../navigation"
 
 import { Spacing, Layout, Forms, Colors, Outlines, Typography } from "../styles"
 
@@ -27,7 +26,6 @@ const defaultErrorMessage = ""
 const ReportIssueForm: FunctionComponent = () => {
   const { t } = useTranslation()
   const { versionInfo } = useVersionInfo()
-  useStatusBarEffect("light-content")
 
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")

--- a/src/ReportIssue/ReportIssueForm.tsx
+++ b/src/ReportIssue/ReportIssueForm.tsx
@@ -18,12 +18,14 @@ import { useVersionInfo } from "../hooks/useApplicationInfo"
 import { GlobalText, Button } from "../components"
 import { reportAnIssue, ReportIssueError } from "../More/zendeskAPI"
 import { Icons } from "../assets"
+import { useStatusBarEffect } from "../navigation"
 
 import { Spacing, Layout, Forms, Colors, Outlines, Typography } from "../styles"
 
 const defaultErrorMessage = ""
 
 const ReportIssueForm: FunctionComponent = () => {
+  useStatusBarEffect("light-content", Colors.headerBackground)
   const { t } = useTranslation()
   const { versionInfo } = useVersionInfo()
 

--- a/src/SelfAssessment/index.js
+++ b/src/SelfAssessment/index.js
@@ -29,7 +29,6 @@ import { Emergency } from "./endScreens/Emergency"
 import { Isolate } from "./endScreens/Isolate"
 import { Share } from "./endScreens/Share"
 
-import { useStatusBarEffect } from "../navigation"
 import { Icons } from "../assets"
 import { Colors, Spacing } from "../styles"
 
@@ -68,8 +67,6 @@ import { Colors, Spacing } from "../styles"
 const Stack = createStackNavigator()
 
 const Assessment = ({ navigation }) => {
-  useStatusBarEffect("dark-content")
-
   /** @type {React.MutableRefObject<SurveyAnswers>} */
   const answers = useRef({})
   const survey = survey_en

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -12,7 +12,7 @@ const StatusBar: FunctionComponent<StatusBarProps> = ({ backgroundColor }) => {
 
   return (
     <View style={style.statusBarContainer}>
-      <RNStatusBar backgroundColor={backgroundColor} />
+      <RNStatusBar />
     </View>
   )
 }

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -2,21 +2,17 @@ import React, { FunctionComponent } from "react"
 import { View, StatusBar as RNStatusBar, StyleSheet } from "react-native"
 import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 
-import { Colors } from "../styles"
-
 interface StatusBarProps {
-  backgroundColor?: string
+  backgroundColor: string
 }
 
-const StatusBar: FunctionComponent<StatusBarProps> = ({
-  backgroundColor = Colors.primaryLightBackground,
-}) => {
+const StatusBar: FunctionComponent<StatusBarProps> = ({ backgroundColor }) => {
   const insets = useSafeAreaInsets()
   const style = createStyle({ insets, backgroundColor })
 
   return (
     <View style={style.statusBarContainer}>
-      <RNStatusBar />
+      <RNStatusBar backgroundColor={backgroundColor} />
     </View>
   )
 }

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react"
-import { StatusBar } from "react-native"
+import { Platform, StatusBar, StatusBarStyle } from "react-native"
 import {
   NavigationParams,
   NavigationScreenProp,
@@ -187,12 +187,16 @@ export const Stacks: { [key in Stack]: Stack } = {
   ReportIssue: "ReportIssue",
 }
 
-export type StatusBarStyle = "dark-content" | "light-content"
-
-export const useStatusBarEffect = (statusBarStyle: StatusBarStyle): void => {
+export const useStatusBarEffect = (
+  statusBarStyle: StatusBarStyle,
+  backgroundColor: string,
+): void => {
   useFocusEffect(
     useCallback(() => {
       StatusBar.setBarStyle(statusBarStyle)
-    }, [statusBarStyle]),
+      if (Platform.OS === "android") {
+        StatusBar.setBackgroundColor(backgroundColor)
+      }
+    }, [statusBarStyle, backgroundColor]),
   )
 }


### PR DESCRIPTION
Why: in order for the status bar to render correctly on all platforms, we need
to make use of both the `StatusBar` component from React Native as well
as a custom `useStatusBarEffect` hook.

This commit:
- Updates the `StatusBar` component
- Updates `useStatusBarEffect` to take a background color to render the
status bar correctly on Android
- Uses `StatusBar` in all the appropriate places
- Uses `useStatusBarEffect` in all the appropriate places

Notes:
- `useStatusBarEffect` is used to set the `barStyle` on both platforms
- `useStatusBarEffect` is used to set the status bar background color on
Android
- `StatusBar` is used to set the status bar background color on iOS
- `StatusBar` should not be used if a header exists on the screen via
React Navigation
- `StatusBar` should be used on any screen that does not have a header
because text _could_ overlap the status bar if the text size is made large
via accessibility settings

![status](https://user-images.githubusercontent.com/39350030/92031680-fe60e000-ed36-11ea-9f8a-5558b879444d.gif)