### PR TITLE
Add eula link on the activation screen

### DIFF
--- a/src/Activation/AcceptEula.spec.tsx
+++ b/src/Activation/AcceptEula.spec.tsx
@@ -4,6 +4,8 @@ import { useNavigation } from "@react-navigation/native"
 import { Linking } from "react-native"
 
 import AcceptEula from "./AcceptEula"
+import { ConfigurationContext } from "../ConfigurationContext"
+import { factories } from "../factories"
 
 jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
@@ -39,5 +41,36 @@ describe("EulaModal", () => {
     await waitFor(() => {
       expect(linkSpy).toHaveBeenCalled()
     })
+  })
+
+  it("opens the link to the eula if present", async () => {
+    const healthAuthorityEulaUrl = "healthAuthorityEulaUrl"
+    const linkSpy = jest.spyOn(Linking, "openURL")
+    const { getByText } = render(
+      <ConfigurationContext.Provider
+        value={factories.configurationContext.build({ healthAuthorityEulaUrl })}
+      >
+        <AcceptEula />
+      </ConfigurationContext.Provider>,
+    )
+
+    fireEvent.press(getByText(/End User Legal Agreement/))
+
+    await waitFor(() => {
+      expect(linkSpy).toHaveBeenCalledWith(healthAuthorityEulaUrl)
+    })
+  })
+
+  it("does not show the eula link if the url is null", () => {
+    const healthAuthorityEulaUrl = null
+    const { queryByText } = render(
+      <ConfigurationContext.Provider
+        value={factories.configurationContext.build({ healthAuthorityEulaUrl })}
+      >
+        <AcceptEula />
+      </ConfigurationContext.Provider>,
+    )
+
+    expect(queryByText(/End User Legal Agreement/)).toBeNull()
   })
 })

--- a/src/Activation/AcceptEula.tsx
+++ b/src/Activation/AcceptEula.tsx
@@ -36,14 +36,6 @@ const AcceptEula: FunctionComponent = () => {
     navigation.navigate(ActivationScreens.ActivateProximityTracing)
   }
 
-  const linkToPrivacyPolicy = async () => {
-    await Linking.openURL(configuration.healthAuthorityPrivacyPolicyUrl)
-  }
-
-  const linkToEula = async () => {
-    await Promise.resolve()
-  }
-
   const checkboxIcon = boxChecked
     ? Icons.CheckboxChecked
     : Icons.CheckboxUnchecked
@@ -59,11 +51,14 @@ const AcceptEula: FunctionComponent = () => {
           <GlobalText style={style.headerText}>
             {t("onboarding.terms_header_title")}
           </GlobalText>
-          <EulaLink
+          <DocumentLink
             docName={"onboarding.privacy_policy"}
-            onPress={linkToPrivacyPolicy}
+            url={configuration.healthAuthorityPrivacyPolicyUrl}
           />
-          <EulaLink docName={"onboarding.eula"} onPress={linkToEula} />
+          <DocumentLink
+            docName={"onboarding.eula"}
+            url={configuration.healthAuthorityEulaUrl}
+          />
           <View style={style.footerContainer}>
             <TouchableOpacity
               style={style.checkboxContainer}
@@ -95,14 +90,27 @@ const AcceptEula: FunctionComponent = () => {
   )
 }
 
-type EulaLinkProps = {
+type DocumentLinkProps = {
   docName: string
-  onPress: () => Promise<void>
+  url: string | null
 }
-const EulaLink: FunctionComponent<EulaLinkProps> = ({ docName, onPress }) => {
+
+const DocumentLink: FunctionComponent<DocumentLinkProps> = ({
+  docName,
+  url,
+}) => {
   const { t } = useTranslation()
+
+  if (url === null) {
+    return null
+  }
+
+  const openLink = async () => {
+    await Linking.openURL(url)
+  }
+
   return (
-    <TouchableOpacity style={style.eulaLinkContainer} onPress={onPress}>
+    <TouchableOpacity style={style.eulaLinkContainer} onPress={openLink}>
       <View style={style.eulaTextContainer}>
         <GlobalText style={style.eulaText}>
           {t("onboarding.please_read_the")}
@@ -118,6 +126,7 @@ const EulaLink: FunctionComponent<EulaLinkProps> = ({ docName, onPress }) => {
     </TouchableOpacity>
   )
 }
+
 const style = StyleSheet.create({
   container: {
     flex: 1,

--- a/src/Activation/AcceptTermsOfService.spec.tsx
+++ b/src/Activation/AcceptTermsOfService.spec.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, waitFor } from "@testing-library/react-native"
 import { useNavigation } from "@react-navigation/native"
 import { Linking } from "react-native"
 
-import AcceptEula from "./AcceptEula"
+import AcceptTermsOfService from "./AcceptTermsOfService"
 import { ConfigurationContext } from "../ConfigurationContext"
 import { factories } from "../factories"
 
@@ -15,7 +15,7 @@ describe("EulaModal", () => {
     const navigationSpy = jest.fn()
     ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigationSpy })
 
-    const { getByLabelText, getByTestId } = render(<AcceptEula />)
+    const { getByLabelText, getByTestId } = render(<AcceptTermsOfService />)
 
     const continueButton = getByLabelText("Continue")
     fireEvent.press(continueButton)
@@ -34,7 +34,7 @@ describe("EulaModal", () => {
 
   it("links out to the privacy policy", async () => {
     const linkSpy = jest.spyOn(Linking, "openURL")
-    const { getByText } = render(<AcceptEula />)
+    const { getByText } = render(<AcceptTermsOfService />)
 
     fireEvent.press(getByText(/Privacy Policy/))
 
@@ -50,7 +50,7 @@ describe("EulaModal", () => {
       <ConfigurationContext.Provider
         value={factories.configurationContext.build({ healthAuthorityEulaUrl })}
       >
-        <AcceptEula />
+        <AcceptTermsOfService />
       </ConfigurationContext.Provider>,
     )
 
@@ -67,7 +67,7 @@ describe("EulaModal", () => {
       <ConfigurationContext.Provider
         value={factories.configurationContext.build({ healthAuthorityEulaUrl })}
       >
-        <AcceptEula />
+        <AcceptTermsOfService />
       </ConfigurationContext.Provider>,
     )
 

--- a/src/Activation/AcceptTermsOfService.spec.tsx
+++ b/src/Activation/AcceptTermsOfService.spec.tsx
@@ -10,7 +10,7 @@ import { factories } from "../factories"
 jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 
-describe("EulaModal", () => {
+describe("AcceptTermsOfService", () => {
   it("won't continue until a user accepts the terms of use", async () => {
     const navigationSpy = jest.fn()
     ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigationSpy })

--- a/src/Activation/AcceptTermsOfService.tsx
+++ b/src/Activation/AcceptTermsOfService.tsx
@@ -25,7 +25,7 @@ import {
 } from "../styles"
 import { useConfigurationContext } from "../ConfigurationContext"
 
-const AcceptEula: FunctionComponent = () => {
+const AcceptTermsOfService: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const configuration = useConfigurationContext()
   const [boxChecked, toggleCheckbox] = useState(false)
@@ -184,4 +184,4 @@ const style = StyleSheet.create({
   },
 })
 
-export default AcceptEula
+export default AcceptTermsOfService

--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -8,6 +8,7 @@ export interface Configuration {
   displayReportAnIssue: boolean
   displaySelfAssessment: boolean
   healthAuthorityAdviceUrl: string
+  healthAuthorityEulaUrl: string | null
   healthAuthorityName: string
   healthAuthorityPrivacyPolicyUrl: string
   regionCodes: string[]
@@ -19,6 +20,7 @@ const initialState = {
   displayReportAnIssue: false,
   displaySelfAssessment: false,
   healthAuthorityAdviceUrl: "",
+  healthAuthorityEulaUrl: null,
   healthAuthorityName: "",
   healthAuthorityPrivacyPolicyUrl: "",
   regionCodes: [],
@@ -31,6 +33,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
     AUTHORITY_ADVICE_URL: healthAuthorityAdviceUrl,
     GAEN_AUTHORITY_NAME: healthAuthorityName,
     PRIVACY_POLICY_URL: healthAuthorityPrivacyPolicyUrl,
+    EULA_URL: eulaUrl,
   } = env
   const displaySelfAssessment = env.DISPLAY_SELF_ASSESSMENT === "true"
   const displayReportAnIssue = env.DISPLAY_REPORT_AN_ISSUE === "true"
@@ -49,6 +52,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         displayReportAnIssue,
         displaySelfAssessment,
         healthAuthorityAdviceUrl,
+        healthAuthorityEulaUrl: eulaUrl || null,
         healthAuthorityName,
         healthAuthorityPrivacyPolicyUrl,
         regionCodes,

--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -5,6 +5,7 @@ import env from "react-native-config"
 export interface Configuration {
   appDownloadLink: string
   appPackageName: string
+  displayAcceptTermsOfService: boolean
   displayReportAnIssue: boolean
   displaySelfAssessment: boolean
   healthAuthorityAdviceUrl: string
@@ -17,6 +18,7 @@ export interface Configuration {
 const initialState = {
   appDownloadLink: "",
   appPackageName: "",
+  displayAcceptTermsOfService: false,
   displayReportAnIssue: false,
   displaySelfAssessment: false,
   healthAuthorityAdviceUrl: "",
@@ -35,6 +37,8 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
     PRIVACY_POLICY_URL: healthAuthorityPrivacyPolicyUrl,
     EULA_URL: eulaUrl,
   } = env
+  const displayAcceptTermsOfService =
+    env.DISPLAY_ACCEPT_TERMS_OF_SERVICE === "true"
   const displaySelfAssessment = env.DISPLAY_SELF_ASSESSMENT === "true"
   const displayReportAnIssue = env.DISPLAY_REPORT_AN_ISSUE === "true"
   const appDownloadLink = env.SHARE_APP_LINK
@@ -49,6 +53,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
       value={{
         appDownloadLink,
         appPackageName,
+        displayAcceptTermsOfService,
         displayReportAnIssue,
         displaySelfAssessment,
         healthAuthorityAdviceUrl,

--- a/src/Onboarding/OnboardingScreen.tsx
+++ b/src/Onboarding/OnboardingScreen.tsx
@@ -20,7 +20,6 @@ import {
   Screens,
   OnboardingScreens,
   Stacks,
-  ActivationScreens,
   useStatusBarEffect,
 } from "../navigation"
 import { getLocalNames } from "../locales/languages"
@@ -94,11 +93,7 @@ const OnboardingScreen: FunctionComponent<OnboardingScreenProps> = ({
             </LinearGradient>
           </TouchableOpacity>
           <TouchableOpacity
-            onPress={() =>
-              navigation.navigate(Stacks.Activation, {
-                screen: ActivationScreens.AcceptEula,
-              })
-            }
+            onPress={() => navigation.navigate(Stacks.Activation)}
           >
             <GlobalText style={style.skipButtonText}>
               {t("common.skip")}

--- a/src/Onboarding/ValueProposition.tsx
+++ b/src/Onboarding/ValueProposition.tsx
@@ -22,7 +22,7 @@ const ValueProposition: FunctionComponent = () => {
   const onboardingScreenActions = {
     primaryButtonOnPress: () => {
       return navigation.navigate(Stacks.Activation, {
-        screen: ActivationScreens.ActivateProximityTracing,
+        screen: ActivationScreens.AcceptEula,
       })
     },
   }

--- a/src/Onboarding/ValueProposition.tsx
+++ b/src/Onboarding/ValueProposition.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from "@react-navigation/native"
 
 import OnboardingScreen from "./OnboardingScreen"
 
-import { Stacks, ActivationScreens } from "../navigation"
+import { Stacks } from "../navigation"
 import { Images } from "../assets"
 
 const ValueProposition: FunctionComponent = () => {
@@ -21,9 +21,7 @@ const ValueProposition: FunctionComponent = () => {
 
   const onboardingScreenActions = {
     primaryButtonOnPress: () => {
-      return navigation.navigate(Stacks.Activation, {
-        screen: ActivationScreens.AcceptEula,
-      })
+      return navigation.navigate(Stacks.Activation)
     },
   }
 

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -7,6 +7,7 @@ export default Factory.define<Configuration>(() => ({
   displayReportAnIssue: false,
   displaySelfAssessment: false,
   healthAuthorityAdviceUrl: "authorityAdviceUrl",
+  healthAuthorityEulaUrl: "healthAuthorityEulaUrl",
   healthAuthorityName: "authorityName",
   healthAuthorityPrivacyPolicyUrl: "authorityPrivacyPolicyUrl",
   regionCodes: ["REGION"],

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -4,6 +4,7 @@ import { Configuration } from "../ConfigurationContext"
 export default Factory.define<Configuration>(() => ({
   appDownloadLink: "appDownloadLink",
   appPackageName: "appPackageName",
+  displayAcceptTermsOfService: false,
   displayReportAnIssue: false,
   displaySelfAssessment: false,
   healthAuthorityAdviceUrl: "authorityAdviceUrl",

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -19,6 +19,8 @@ import ActivationSummary from "../Activation/ActivationSummary"
 
 import { Icons } from "../assets"
 import { Layout, Spacing, Colors, Typography } from "../styles"
+import AcceptTermsOfService from "../Activation/AcceptTermsOfService"
+import { useConfigurationContext } from "../ConfigurationContext"
 
 type ActivationStackParams = {
   [key in ActivationScreen]: undefined
@@ -30,10 +32,16 @@ const ActivationStack: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
   const { isLocationNeeded } = useSystemServicesContext()
+  const { displayAcceptTermsOfService } = useConfigurationContext()
 
   interface ActivationStep {
     screenName: ActivationScreen
     component: FunctionComponent
+  }
+
+  const acceptTermsOfServiceStep: ActivationStep = {
+    screenName: ActivationScreens.AcceptTermsOfService,
+    component: AcceptTermsOfService,
   }
 
   const activateProximityTracing: ActivationStep = {
@@ -51,14 +59,18 @@ const ActivationStack: FunctionComponent = () => {
     component: NotificationPermissions,
   }
 
+  const baseActivationSteps = displayAcceptTermsOfService
+    ? [acceptTermsOfServiceStep, activateProximityTracing]
+    : [activateProximityTracing]
+
   const activationStepsIOS: ActivationStep[] = [
-    activateProximityTracing,
+    ...baseActivationSteps,
     notificationPermissions,
   ]
 
   const activationStepsAndroid: ActivationStep[] = isLocationNeeded
-    ? [activateProximityTracing, activateLocation]
-    : [activateProximityTracing]
+    ? [...baseActivationSteps, activateLocation]
+    : baseActivationSteps
 
   const activationSteps = Platform.select({
     ios: activationStepsIOS,
@@ -121,7 +133,10 @@ const ActivationStack: FunctionComponent = () => {
   }
 
   return (
-    <Stack.Navigator screenOptions={screenOptions}>
+    <Stack.Navigator
+      initialRouteName={ActivationScreens.AcceptTermsOfService}
+      screenOptions={screenOptions}
+    >
       {activationSteps.map((step, idx) => {
         const currentStep = idx + 1
         return (

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -15,7 +15,7 @@ export type NavigationProp = NavigationScreenProp<
 >
 
 export type ActivationScreen =
-  | "AcceptEula"
+  | "AcceptTermsOfService"
   | "ActivateProximityTracing"
   | "ActivateLocation"
   | "NotificationPermissions"
@@ -24,7 +24,7 @@ export type ActivationScreen =
 export const ActivationScreens: {
   [key in ActivationScreen]: ActivationScreen
 } = {
-  AcceptEula: "AcceptEula",
+  AcceptTermsOfService: "AcceptTermsOfService",
   ActivateProximityTracing: "ActivateProximityTracing",
   ActivateLocation: "ActivateLocation",
   NotificationPermissions: "NotificationPermissions",


### PR DESCRIPTION
Why:
----

The accept eula/accept terms screen on the activation stack has been removed from it. We need a way to display it based solely on the configuration variable DISPLAY_ACCEPT_TERMS_OF_SERVICE. Also the eula link is not getting any values to navigate to

This Commit:
----
- Add the configuration to the configuration context
- Point skip and get started from onboarding to `root` screen on
activation stack
- Determine to add or not accept terms of service screen to stack based
on configuration on the activation stack
- Consume eula url value from the configuration
- Show the eula link only if the eula url is available

Reviewers:
----
This depends of a PR on the resources repo. The `default` screen on the activation stack will always be the one on top of the list if the name is not the same one on `initialRoute`, we could choose to have it explicit
