### PR TITLE
Fix unresolved promise issue in SystemServicesContext

### DIFF
--- a/src/SystemServicesContext.tsx
+++ b/src/SystemServicesContext.tsx
@@ -59,7 +59,7 @@ const SystemServicesProvider: FunctionComponent = ({ children }) => {
     }
   }
 
-  const supportsLocationlessScanning = async (): Promise<boolean> => {
+  const fetchSupportsLocationlessScanning = async (): Promise<boolean> => {
     if (Platform.OS === "android") {
       return doesDeviceSupportLocationlessScanning()
     } else {
@@ -84,8 +84,8 @@ const SystemServicesProvider: FunctionComponent = ({ children }) => {
 
   useEffect(() => {
     const determineIsLocationNeeded = async () => {
-      const doesSupportLocationlessScanning = await supportsLocationlessScanning()
-      setIsLocationNeeded(!doesSupportLocationlessScanning)
+      const supportsLocationlessScanning = await fetchSupportsLocationlessScanning()
+      setIsLocationNeeded(!supportsLocationlessScanning)
     }
 
     determineIsLocationNeeded()

--- a/src/SystemServicesContext.tsx
+++ b/src/SystemServicesContext.tsx
@@ -52,15 +52,19 @@ const SystemServicesProvider: FunctionComponent = ({ children }) => {
   }, [])
 
   const fetchIsLocationOn = async (): Promise<boolean> => {
-    return isLocationEnabled()
+    if (Platform.OS === "android") {
+      return isLocationEnabled()
+    } else {
+      return Promise.resolve(true)
+    }
   }
 
-  const fetchSupportsLocationlessScanning = async (): Promise<boolean> => {
-    return Platform.select({
-      android: doesDeviceSupportLocationlessScanning(),
-      ios: new Promise(() => true),
-      default: new Promise(() => true),
-    })
+  const supportsLocationlessScanning = async (): Promise<boolean> => {
+    if (Platform.OS === "android") {
+      return doesDeviceSupportLocationlessScanning()
+    } else {
+      return Promise.resolve(true)
+    }
   }
 
   useEffect(() => {
@@ -80,8 +84,8 @@ const SystemServicesProvider: FunctionComponent = ({ children }) => {
 
   useEffect(() => {
     const determineIsLocationNeeded = async () => {
-      const supportsLocationlessScanning = await fetchSupportsLocationlessScanning()
-      setIsLocationNeeded(!supportsLocationlessScanning)
+      const doesSupportLocationlessScanning = await supportsLocationlessScanning()
+      setIsLocationNeeded(!doesSupportLocationlessScanning)
     }
 
     determineIsLocationNeeded()


### PR DESCRIPTION
`doesDeviceSupportLocationlessScanning()` is not present in the iOS version of the native module and was the root cause of the warning. This is technically still an issue, but it doesn't matter as the iOS builds shouldn't be invoking the function at all.

Co-Authored-By: John Schoeman <johnschoeman1617@gmail.com>