### PR TITLE
Enable user to activate proximity tracing from home screen

### DIFF
--- a/src/Activation/ActivateProximityTracing.tsx
+++ b/src/Activation/ActivateProximityTracing.tsx
@@ -25,8 +25,6 @@ const ActivateProximityTracing: FunctionComponent = () => {
   const isLocationOffAndNeeded = !isLocationOn && isLocationNeeded
 
   const { exposureNotifications } = usePermissionsContext()
-  const { status } = exposureNotifications
-  console.log(status)
 
   const navigateToNextScreen = () => {
     if (Platform.OS === "ios") {

--- a/src/Activation/ActivateProximityTracing.tsx
+++ b/src/Activation/ActivateProximityTracing.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from "react"
 import {
   Platform,
-  Alert,
   ScrollView,
   SafeAreaView,
   View,
@@ -12,7 +11,6 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
 import { usePermissionsContext } from "../PermissionsContext"
-import { useApplicationName } from "../hooks/useApplicationInfo"
 import { ActivationScreens } from "../navigation"
 import { GlobalText, Button } from "../components"
 import { useSystemServicesContext } from "../SystemServicesContext"
@@ -22,19 +20,9 @@ import { Spacing, Typography, Buttons, Colors } from "../styles"
 const ActivateProximityTracing: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const { applicationName } = useApplicationName()
   const { exposureNotifications } = usePermissionsContext()
   const { isLocationOn, isLocationNeeded } = useSystemServicesContext()
   const isLocationOffAndNeeded = !isLocationOn && isLocationNeeded
-
-  const handleOnPressEnable = () => {
-    exposureNotifications.request()
-    navigateToNextScreen()
-  }
-
-  const handleOnPressDontEnable = () => {
-    navigateToNextScreen()
-  }
 
   const navigateToNextScreen = () => {
     if (Platform.OS === "ios") {
@@ -46,25 +34,13 @@ const ActivateProximityTracing: FunctionComponent = () => {
     }
   }
 
-  const showProximityTracingAlert = () => {
-    Alert.alert(
-      t("onboarding.proximity_tracing_alert_header", { applicationName }),
-      t("onboarding.proximity_tracing_alert_body", { applicationName }),
-      [
-        {
-          text: t("common.cancel"),
-          style: "cancel",
-        },
-        {
-          text: t("common.enable"),
-          onPress: handleOnPressEnable,
-        },
-      ],
-    )
+  const handleOnPressActivateProximityTracing = () => {
+    exposureNotifications.request()
+    navigateToNextScreen()
   }
 
-  const handleOnPressActivateProximityTracing = () => {
-    showProximityTracingAlert()
+  const handleOnPressDontEnable = () => {
+    navigateToNextScreen()
   }
 
   return (

--- a/src/Activation/ActivateProximityTracing.tsx
+++ b/src/Activation/ActivateProximityTracing.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from "react"
 import {
   Platform,
   ScrollView,
+  Linking,
+  Alert,
   SafeAreaView,
   View,
   StyleSheet,
@@ -20,9 +22,13 @@ import { Spacing, Typography, Buttons, Colors } from "../styles"
 const ActivateProximityTracing: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const { exposureNotifications } = usePermissionsContext()
+
   const { isLocationOn, isLocationNeeded } = useSystemServicesContext()
   const isLocationOffAndNeeded = !isLocationOn && isLocationNeeded
+
+  const { exposureNotifications } = usePermissionsContext()
+  const { status } = exposureNotifications
+  console.log(status)
 
   const navigateToNextScreen = () => {
     if (Platform.OS === "ios") {
@@ -34,8 +40,8 @@ const ActivateProximityTracing: FunctionComponent = () => {
     }
   }
 
-  const handleOnPressActivateProximityTracing = () => {
-    exposureNotifications.request()
+  const handleOnPressActivateProximityTracing = async () => {
+    await exposureNotifications.request()
     navigateToNextScreen()
   }
 

--- a/src/Activation/ActivateProximityTracing.tsx
+++ b/src/Activation/ActivateProximityTracing.tsx
@@ -2,8 +2,6 @@ import React, { FunctionComponent } from "react"
 import {
   Platform,
   ScrollView,
-  Linking,
-  Alert,
   SafeAreaView,
   View,
   StyleSheet,

--- a/src/Activation/NotificationPermissions.spec.tsx
+++ b/src/Activation/NotificationPermissions.spec.tsx
@@ -88,7 +88,7 @@ const createPermissionProviderValue = (
     exposureNotifications: {
       status: ENStatus.AUTHORIZED_ENABLED,
       check: () => {},
-      request: () => {},
+      request: () => Promise.resolve(),
     },
   }
 }

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
@@ -65,7 +65,7 @@ const createPermissionProviderValue = (enStatus: ENStatus) => {
     exposureNotifications: {
       status: enStatus,
       check: () => {},
-      request: () => {},
+      request: () => Promise.resolve(),
     },
   }
 }

--- a/src/Home/ProximityTracingActivationStatus.tsx
+++ b/src/Home/ProximityTracingActivationStatus.tsx
@@ -1,21 +1,45 @@
 import React, { FunctionComponent } from "react"
-import { Alert, Linking } from "react-native"
+import { Linking, Alert } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
 import { usePermissionsContext, ENStatus } from "../PermissionsContext"
 import { HomeScreens } from "../navigation"
 import { ActivationStatus } from "./ActivationStatus"
+import { useApplicationName } from "../hooks/useApplicationInfo"
 
 export const ProximityTracingActivationStatus: FunctionComponent = () => {
   const navigation = useNavigation()
   const { exposureNotifications } = usePermissionsContext()
   const { t } = useTranslation()
+  const { applicationName } = useApplicationName()
 
   const { status } = exposureNotifications
 
+  const isUnauthorized = status === ENStatus.UNAUTHORIZED_DISABLED
+
+  const showUnauthorizedAlert = () => {
+    Alert.alert(
+      t("home.bluetooth.unauthorized_error_title"),
+      t("home.bluetooth.unauthorized_error_message", { applicationName }),
+      [
+        {
+          text: t("common.back"),
+          style: "cancel",
+        },
+        {
+          text: t("common.settings"),
+          onPress: () => Linking.openSettings(),
+        },
+      ],
+    )
+  }
+
   const handleOnPressFix = () => {
     exposureNotifications.request()
+    if (isUnauthorized) {
+      showUnauthorizedAlert()
+    }
   }
 
   const handleOnPressShowInfo = () => {

--- a/src/Home/ProximityTracingActivationStatus.tsx
+++ b/src/Home/ProximityTracingActivationStatus.tsx
@@ -5,61 +5,21 @@ import { useTranslation } from "react-i18next"
 
 import { usePermissionsContext, ENStatus } from "../PermissionsContext"
 import { HomeScreens } from "../navigation"
-import { useApplicationName } from "../hooks/useApplicationInfo"
 import { ActivationStatus } from "./ActivationStatus"
 
 export const ProximityTracingActivationStatus: FunctionComponent = () => {
   const navigation = useNavigation()
   const { exposureNotifications } = usePermissionsContext()
-  const { applicationName } = useApplicationName()
   const { t } = useTranslation()
 
   const { status } = exposureNotifications
 
   const handleOnPressFix = () => {
-    if (status === ENStatus.UNAUTHORIZED_DISABLED) {
-      showUnauthorizedAlert()
-    } else {
-      showEnableProximityTracingAlert()
-    }
+    exposureNotifications.request()
   }
 
   const handleOnPressShowInfo = () => {
     navigation.navigate(HomeScreens.ProximityTracingInfo)
-  }
-
-  const showUnauthorizedAlert = () => {
-    Alert.alert(
-      t("home.bluetooth.unauthorized_error_title"),
-      t("home.bluetooth.unauthorized_error_message"),
-      [
-        {
-          text: t("common.back"),
-          style: "cancel",
-        },
-        {
-          text: t("common.settings"),
-          onPress: () => Linking.openSettings(),
-        },
-      ],
-    )
-  }
-
-  const showEnableProximityTracingAlert = () => {
-    Alert.alert(
-      t("onboarding.proximity_tracing_alert_header", { applicationName }),
-      t("onboarding.proximity_tracing_alert_body", { applicationName }),
-      [
-        {
-          text: t("common.cancel"),
-          style: "cancel",
-        },
-        {
-          text: t("common.enable"),
-          onPress: exposureNotifications.request,
-        },
-      ],
-    )
   }
 
   return (

--- a/src/Home/index.spec.tsx
+++ b/src/Home/index.spec.tsx
@@ -200,7 +200,7 @@ describe("Home", () => {
     })
   })
 
-  describe("When the exposure notification permissions are not enabled and the app is not authorized", () => {
+  describe("When the app is not authorized", () => {
     it("renders an inactive message and a disabled message for proximity tracing", () => {
       const isENAuthorizedAndEnabled = ENStatus.UNAUTHORIZED_DISABLED
       const permissionProviderValue = createPermissionProviderValue(
@@ -235,6 +235,31 @@ describe("Home", () => {
         "Enable Bluetooth and Proximity Tracing to get info about possible exposures",
       )
       expect(proximityTracingDisabledText).toBeDefined()
+    })
+
+    it("requests exposure notifications and shows an unauthorized alert", () => {
+      const isENAuthorizedAndEnabled = ENStatus.UNAUTHORIZED_DISABLED
+      const requestSpy = jest.fn()
+      const permissionProviderValue = createPermissionProviderValue(
+        isENAuthorizedAndEnabled,
+        requestSpy,
+      )
+
+      const { getByTestId } = render(
+        <PermissionsContext.Provider value={permissionProviderValue}>
+          <Home />
+        </PermissionsContext.Provider>,
+      )
+
+      const alertSpy = jest.spyOn(Alert, "alert")
+
+      const fixProximityTracingButton = getByTestId(
+        "home-proximity-tracing-status-container",
+      )
+
+      fireEvent.press(fixProximityTracingButton)
+      expect(requestSpy).toHaveBeenCalled()
+      expect(alertSpy).toHaveBeenCalled()
     })
   })
 

--- a/src/Home/index.spec.tsx
+++ b/src/Home/index.spec.tsx
@@ -9,7 +9,6 @@ import { PermissionsContext, ENStatus } from "../PermissionsContext"
 import { PermissionStatus } from "../permissionStatus"
 import { SystemServicesContext } from "../SystemServicesContext"
 import { ConfigurationContext } from "../ConfigurationContext"
-import { isPlatformiOS } from "../utils/index"
 import { factories } from "../factories"
 
 jest.mock("@react-navigation/native")

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -59,7 +59,7 @@ export interface PermissionsContextState {
   exposureNotifications: {
     status: ENStatus
     check: () => void
-    request: () => void
+    request: () => Promise<void>
   }
 }
 
@@ -72,7 +72,7 @@ const initialState = {
   exposureNotifications: {
     status: initialENStatus,
     check: () => {},
-    request: () => {},
+    request: () => Promise.resolve(),
   },
 }
 
@@ -83,7 +83,7 @@ export interface PermissionStrategy {
     cb: (status: ENPermissionStatus) => void,
   ) => { remove: () => void }
   check: (cb: (status: ENPermissionStatus) => void) => void
-  request: (cb: (response: string) => void) => void
+  request: () => Promise<string>
 }
 
 const PermissionsProvider: FunctionComponent = ({ children }) => {
@@ -138,9 +138,8 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
     setNotificationPermission(statusToEnum(status))
   }
 
-  const requestENPermission = () => {
-    const handleNativeResponse = () => {}
-    permissionStrategy.request(handleNativeResponse)
+  const requestENPermission = async () => {
+    permissionStrategy.request()
   }
 
   const requestNotificationPermission = async () => {

--- a/src/factories/gaenStrategy.tsx
+++ b/src/factories/gaenStrategy.tsx
@@ -20,6 +20,6 @@ export default Factory.define<GaenStrategy>(() => ({
       return { remove: () => {} }
     },
     check: () => {},
-    request: () => {},
+    request: () => Promise.resolve(""),
   },
 }))

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -165,8 +165,8 @@
       "tracing_off_subheader": "Enable Bluetooth and Proximity Tracing to get info about possible exposures",
       "tracing_off_subheader_location": "Enable Bluetooth, Proximity Tracing, and Location to get info about possible exposures",
       "tracing_on_header": "Active",
-      "unauthorized_error_message": "To activate Proximity Tracing, authorize COVID-19 Exposure Logging in the Settings app",
-      "unauthorized_error_title": "Authorize in Settings"
+      "unauthorized_error_message": "To activate Proximity Tracing, ensure \"Share Exposure Information\" is enabled in Settings > {{applicationName}} > Exposure Notifications",
+      "unauthorized_error_title": "Share Expsoure Information"
     },
     "location_info_body_1": "The Exposure Notification technology uses Bluetooth scanning to understand what devices are near one another. On all phones running Android 6.0 and above, to use Bluetooth scanning, the device location setting needs to be turned on for all apps, not just apps built with the Exposure Notifications System.",
     "location_info_header": "Location",

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -117,6 +117,7 @@ const ActivationStack: FunctionComponent = () => {
     headerTitleAlign: "left",
     headerTitle: t("onboarding.activation_header_title"),
     headerTitleStyle: style.headerTitle,
+    gestureEnabled: false,
   }
 
   return (

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -118,7 +118,10 @@ const MainNavigator: FunctionComponent = () => {
               <Stack.Screen
                 name={Stacks.Activation}
                 component={ActivationStack}
-                options={defaultScreenOptions}
+                options={{
+                  ...defaultScreenOptions,
+                  gestureEnabled: false,
+                }}
               />
             </>
           )}


### PR DESCRIPTION
## Why

Prior to this commit, on iOS, if the user did not enable exposure notifications in the onboarding flow, there was no way for them to enable exposure notifications at all.

This state was possible because, in the onboarding flow, if the user did not enable exposure notifications, exposure notification permissions were _never requested in the native layer_. This put the app in a state where it was not possible for the user to _authorize_ exposure notifications in settings.

## This Commit

- Removes the "Enable Exposure Notifications" alert on the javascript layer because the native enable exposure notifications alert makes it redundant
- Makes it so exposure notification permissions are always requested when the user tries to fix an issue with proximity tracing not working. We need to do this because it is possible for the user to not request exposure notifications during the onboarding flow. In this case, when the user tries to enable proximity tracing on the home screen, we need to first request exposure notifications, _then_ inform the user that the Pathcheck app needs to be authorized in settings in order for proximity tracing to work. If we do not first request exposure notifications, the user will find a blank screen in Settings > Pathcheck > Exposure Notifications and thus not be able to authorize the app.
- Updates various specs to test this updated functionality
- Updates the alert copy we present to the user to better inform them on how to authorize sharing of exposure information in settings
- Refactors the exposure notifications request function to use a promise instead of a callback

## Screenshots

<img width="383" alt="Screen Shot 2020-09-03 at 3 21 23 PM" src="https://user-images.githubusercontent.com/39350030/92158149-768fda00-edf9-11ea-9f15-beb11763362f.png">
<img width="364" alt="Screen Shot 2020-09-03 at 3 21 43 PM" src="https://user-images.githubusercontent.com/39350030/92158145-75f74380-edf9-11ea-813f-0cbbf352e28e.png">
<img width="370" alt="Screen Shot 2020-09-03 at 3 21 57 PM" src="https://user-images.githubusercontent.com/39350030/92158143-755ead00-edf9-11ea-9200-0e8396395679.png">
<img width="372" alt="Screen Shot 2020-09-03 at 3 22 04 PM" src="https://user-images.githubusercontent.com/39350030/92158133-72fc5300-edf9-11ea-82fa-0cb1c9733847.png">

Co-Authored-By: Amanda Beiner <aebeiner@gmail.com>