### PR TITLE
Center more menu title

### DIFF
--- a/src/navigation/MoreStack.tsx
+++ b/src/navigation/MoreStack.tsx
@@ -30,6 +30,7 @@ const SCREEN_OPTIONS: StackNavigationOptions = {
   },
   headerBackTitleVisible: false,
   headerTintColor: Colors.headerText,
+  headerTitleAlign: "center",
 }
 
 const MoreStack: FunctionComponent = () => {


### PR DESCRIPTION
#### Description:
Centers the more menu on Android

#### Linked issues:

Fixes [GAEN-150](https://pathcheck.atlassian.net/jira/software/projects/GAEN/boards/33/?selectedIssue=GAEN-150)

#### Screenshots:
iOS:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-03 at 15 54 52](https://user-images.githubusercontent.com/21161427/92162245-dc7f6000-edff-11ea-92e8-51dcacdb93f9.png)

Android:
![Screenshot_20200903-155505](https://user-images.githubusercontent.com/21161427/92162449-2f591780-ee00-11ea-949c-5b986e5d7b33.png)

