### PR TITLE
Fix line height on code input

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -298,7 +298,6 @@ const style = StyleSheet.create({
     ...Typography.mediumBold,
     fontSize: Typography.xLarge,
     textAlignVertical: "center",
-    lineHeight: 0,
     letterSpacing: 8,
   },
   codeInputFocused: {


### PR DESCRIPTION
#### Description:
Why:
There is currently a bug on android where you cannot see the code you have inputted.

This commit:
Removes a `lineHeight: 0`, on the code input, which was causing the number code to not display.

#### Screenshots:
Before:
![not working](https://user-images.githubusercontent.com/21161427/92166126-1b181900-ee06-11ea-8e52-1bb7c655fd2d.png)

After:
![working](https://user-images.githubusercontent.com/21161427/92166134-1eaba000-ee06-11ea-9cb2-857cd93be61e.png)
