### PR TITLE
Remove title from the activation stack

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -207,7 +207,6 @@
     "app_setup_complete_body": "{{applicationName}} is active. Thank you for helping break the chain of infection.",
     "app_setup_incomplete_body": "{{applicationName}} requires Proximity Tracing and Bluetooth permissions to know when  and where you have been exposed to COVID 19. You can authorize this in Settings.",
     "app_setup_incomplete_location_body": "{{applicationName}} requires Proximity Tracing, Bluetooth, and Location permissions to know when and where you have been exposed to COVID 19. You can authorize this in Settings.",
-    "activation_header_title": "App Setup",
     "eula_agree_terms_of_use": "I agree that I have read and accepted the terms of use",
     "location_alert_header": "Enable Location access from \"{{applicationName}}\"",
     "location_alert_body": "To use Bluetooth scanning, the device location setting needs to be turned on.",

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -115,8 +115,7 @@ const ActivationStack: FunctionComponent = () => {
     headerShown: true,
     headerLeft: () => null,
     headerTitleAlign: "left",
-    headerTitle: t("onboarding.activation_header_title"),
-    headerTitleStyle: style.headerTitle,
+    headerTitle: () => null,
   }
 
   return (
@@ -150,11 +149,6 @@ const ActivationStack: FunctionComponent = () => {
 }
 
 const style = StyleSheet.create({
-  headerTitle: {
-    ...Typography.header4,
-    color: Colors.neutral100,
-    maxWidth: "50%",
-  },
   headerRight: {
     flexDirection: "row",
     alignItems: "center",


### PR DESCRIPTION
Why:
----
The navigation title on the activation stack is all the way to the left and truncated.

This Commit:
----
- Remove the title from the activation screens

Reviewers:
----
Not sure if the solution is to remove it or to center it and make it fit, but it seemed like the affected screens all had an inline title.

<img width="350" alt="Screen Shot 2020-09-03 at 4 39 44 PM" src="https://user-images.githubusercontent.com/2413802/92168495-aabec700-ee08-11ea-9c5e-2ec8a0ea57ac.png"><img width="350" alt="Screen Shot 2020-09-03 at 4 40 28 PM" src="https://user-images.githubusercontent.com/2413802/92168534-ad212100-ee08-11ea-82a3-1fd8297f54b9.png">

