### PR TITLE
Ensure platform is iOS before showing unauthorized alert

### DIFF
--- a/src/Activation/ActivateProximityTracing.tsx
+++ b/src/Activation/ActivateProximityTracing.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from "react"
 import {
-  Platform,
   ScrollView,
   SafeAreaView,
   View,
@@ -14,6 +13,7 @@ import { usePermissionsContext } from "../PermissionsContext"
 import { ActivationScreens } from "../navigation"
 import { GlobalText, Button } from "../components"
 import { useSystemServicesContext } from "../SystemServicesContext"
+import { isPlatformiOS } from "../utils"
 
 import { Spacing, Typography, Buttons, Colors } from "../styles"
 
@@ -27,7 +27,7 @@ const ActivateProximityTracing: FunctionComponent = () => {
   const { exposureNotifications } = usePermissionsContext()
 
   const navigateToNextScreen = () => {
-    if (Platform.OS === "ios") {
+    if (isPlatformiOS()) {
       navigation.navigate(ActivationScreens.NotificationPermissions)
     } else {
       isLocationOffAndNeeded

--- a/src/Activation/ActivationSummary.tsx
+++ b/src/Activation/ActivationSummary.tsx
@@ -9,7 +9,10 @@ import {
 } from "react-native"
 import { useTranslation } from "react-i18next"
 
-import { usePermissionsContext, ENStatus } from "../PermissionsContext"
+import {
+  usePermissionsContext,
+  ENPermissionStatus,
+} from "../PermissionsContext"
 import { useOnboardingContext } from "../OnboardingContext"
 import { useApplicationName } from "../hooks/useApplicationInfo"
 import { GlobalText, Button } from "../components"
@@ -32,7 +35,7 @@ const ActivationSummary: FunctionComponent = () => {
   const {
     exposureNotifications: { status },
   } = usePermissionsContext()
-  const isProximityTracingOn = status === ENStatus.AUTHORIZED_ENABLED
+  const isProximityTracingOn = status === ENPermissionStatus.ENABLED
 
   const handleOnPressGoToHome = () => {
     completeOnboarding()

--- a/src/Activation/ActivationSummary.tsx
+++ b/src/Activation/ActivationSummary.tsx
@@ -35,7 +35,7 @@ const ActivationSummary: FunctionComponent = () => {
   const {
     exposureNotifications: { status },
   } = usePermissionsContext()
-  const isProximityTracingOn = status === ENPermissionStatus.ENABLED
+  const isENEnabled = status === ENPermissionStatus.ENABLED
 
   const handleOnPressGoToHome = () => {
     completeOnboarding()
@@ -93,7 +93,7 @@ const ActivationSummary: FunctionComponent = () => {
   }
 
   const isAppSetupComplete =
-    isProximityTracingOn && isBluetoothOn && !isLocationOffAndNeeded
+    isENEnabled && isBluetoothOn && !isLocationOffAndNeeded
 
   const screenContent = isAppSetupComplete
     ? appSetupCompleteContent

--- a/src/Activation/NotificationPermissions.spec.tsx
+++ b/src/Activation/NotificationPermissions.spec.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from "@react-navigation/native"
 import {
   PermissionsContext,
   PermissionsContextState,
-  ENStatus,
+  ENPermissionStatus,
 } from "../PermissionsContext"
 import { PermissionStatus } from "../permissionStatus"
 import NotificationPermissions from "./NotificationPermissions"
@@ -86,7 +86,7 @@ const createPermissionProviderValue = (
       request: requestPermission,
     },
     exposureNotifications: {
-      status: ENStatus.AUTHORIZED_ENABLED,
+      status: ENPermissionStatus.ENABLED,
       check: () => {},
       request: () => Promise.resolve(),
     },

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
@@ -4,7 +4,10 @@ import "@testing-library/jest-native/extend-expect"
 
 import CodeInputScreen from "./CodeInputScreen"
 import { AffectedUserProvider } from "../AffectedUserContext"
-import { PermissionsContext, ENStatus } from "../../PermissionsContext"
+import {
+  PermissionsContext,
+  ENPermissionStatus,
+} from "../../PermissionsContext"
 import { PermissionStatus } from "../../permissionStatus"
 
 jest.mock("@react-navigation/native")
@@ -12,7 +15,7 @@ jest.mock("@react-navigation/native")
 describe("CodeInputScreen", () => {
   describe("when the user has exposure notifications enabled", () => {
     it("shows the CodeInputForm", () => {
-      const isENAuthorizedAndEnabled = ENStatus.AUTHORIZED_ENABLED
+      const isENAuthorizedAndEnabled = ENPermissionStatus.ENABLED
       const permissionProviderValue = createPermissionProviderValue(
         isENAuthorizedAndEnabled,
       )
@@ -34,7 +37,7 @@ describe("CodeInputScreen", () => {
 
   describe("when the user does not have exposure notifications enabled", () => {
     it("shows the EnableExposureNotifications screen", () => {
-      const isEnAuthorizedAndEnabled = ENStatus.AUTHORIZED_DISABLED
+      const isEnAuthorizedAndEnabled = ENPermissionStatus.DISABLED
       const permissionProviderValue = createPermissionProviderValue(
         isEnAuthorizedAndEnabled,
       )
@@ -55,7 +58,9 @@ describe("CodeInputScreen", () => {
   })
 })
 
-const createPermissionProviderValue = (enStatus: ENStatus) => {
+const createPermissionProviderValue = (
+  enPermissionStatus: ENPermissionStatus,
+) => {
   return {
     notification: {
       status: PermissionStatus.UNKNOWN,
@@ -63,7 +68,7 @@ const createPermissionProviderValue = (enStatus: ENStatus) => {
       request: () => {},
     },
     exposureNotifications: {
-      status: enStatus,
+      status: enPermissionStatus,
       check: () => {},
       request: () => Promise.resolve(),
     },

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -1,7 +1,10 @@
 import React, { FunctionComponent } from "react"
 import { View, StyleSheet } from "react-native"
 
-import { usePermissionsContext, ENStatus } from "../../PermissionsContext"
+import {
+  usePermissionsContext,
+  ENPermissionStatus,
+} from "../../PermissionsContext"
 import CodeInputForm from "./CodeInputForm"
 import EnableExposureNotifications from "./EnableExposureNotifications"
 
@@ -10,7 +13,7 @@ import { Colors } from "../../styles"
 const CodeInputScreen: FunctionComponent = () => {
   const { exposureNotifications } = usePermissionsContext()
 
-  const isEnabled = exposureNotifications.status === ENStatus.AUTHORIZED_ENABLED
+  const isEnabled = exposureNotifications.status === ENPermissionStatus.ENABLED
 
   return (
     <View style={style.container}>

--- a/src/Home/ProximityTracingActivationStatus.tsx
+++ b/src/Home/ProximityTracingActivationStatus.tsx
@@ -7,6 +7,7 @@ import { usePermissionsContext, ENStatus } from "../PermissionsContext"
 import { HomeScreens } from "../navigation"
 import { ActivationStatus } from "./ActivationStatus"
 import { useApplicationName } from "../hooks/useApplicationInfo"
+import { isPlatformiOS } from "../utils"
 
 export const ProximityTracingActivationStatus: FunctionComponent = () => {
   const navigation = useNavigation()
@@ -37,7 +38,7 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
 
   const handleOnPressFix = () => {
     exposureNotifications.request()
-    if (isUnauthorized) {
+    if (isUnauthorized && isPlatformiOS()) {
       showUnauthorizedAlert()
     }
   }

--- a/src/Home/ProximityTracingActivationStatus.tsx
+++ b/src/Home/ProximityTracingActivationStatus.tsx
@@ -49,10 +49,12 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
     navigation.navigate(HomeScreens.ProximityTracingInfo)
   }
 
+  const isENEnabled = status === ENPermissionStatus.ENABLED
+
   return (
     <ActivationStatus
       headerText={t("home.bluetooth.proximity_tracing_header")}
-      isActive={status === ENPermissionStatus.ENABLED}
+      isActive={isENEnabled}
       infoAction={handleOnPressShowInfo}
       fixAction={handleOnPressFix}
       testID={"home-proximity-tracing-status-container"}

--- a/src/Home/ProximityTracingActivationStatus.tsx
+++ b/src/Home/ProximityTracingActivationStatus.tsx
@@ -19,9 +19,9 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
 
   const { status } = exposureNotifications
 
-  const isUnauthorized = status === ENPermissionStatus.NOT_AUTHORIZED
+  const isNotAuthorized = status === ENPermissionStatus.NOT_AUTHORIZED
 
-  const showUnauthorizedAlert = () => {
+  const showNotAuthorizedAlert = () => {
     Alert.alert(
       t("home.bluetooth.unauthorized_error_title"),
       t("home.bluetooth.unauthorized_error_message", { applicationName }),
@@ -40,8 +40,8 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
 
   const handleOnPressFix = () => {
     exposureNotifications.request()
-    if (isUnauthorized) {
-      showUnauthorizedAlert()
+    if (isNotAuthorized) {
+      showNotAuthorizedAlert()
     }
   }
 

--- a/src/Home/ProximityTracingActivationStatus.tsx
+++ b/src/Home/ProximityTracingActivationStatus.tsx
@@ -7,7 +7,6 @@ import { usePermissionsContext, ENStatus } from "../PermissionsContext"
 import { HomeScreens } from "../navigation"
 import { ActivationStatus } from "./ActivationStatus"
 import { useApplicationName } from "../hooks/useApplicationInfo"
-import { isPlatformiOS } from "../utils"
 
 export const ProximityTracingActivationStatus: FunctionComponent = () => {
   const navigation = useNavigation()
@@ -38,7 +37,7 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
 
   const handleOnPressFix = () => {
     exposureNotifications.request()
-    if (isUnauthorized && isPlatformiOS()) {
+    if (isUnauthorized) {
       showUnauthorizedAlert()
     }
   }

--- a/src/Home/ProximityTracingActivationStatus.tsx
+++ b/src/Home/ProximityTracingActivationStatus.tsx
@@ -3,7 +3,10 @@ import { Linking, Alert } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
-import { usePermissionsContext, ENStatus } from "../PermissionsContext"
+import {
+  usePermissionsContext,
+  ENPermissionStatus,
+} from "../PermissionsContext"
 import { HomeScreens } from "../navigation"
 import { ActivationStatus } from "./ActivationStatus"
 import { useApplicationName } from "../hooks/useApplicationInfo"
@@ -16,7 +19,7 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
 
   const { status } = exposureNotifications
 
-  const isUnauthorized = status === ENStatus.UNAUTHORIZED_DISABLED
+  const isUnauthorized = status === ENPermissionStatus.NOT_AUTHORIZED
 
   const showUnauthorizedAlert = () => {
     Alert.alert(
@@ -49,7 +52,7 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
   return (
     <ActivationStatus
       headerText={t("home.bluetooth.proximity_tracing_header")}
-      isActive={status === ENStatus.AUTHORIZED_ENABLED}
+      isActive={status === ENPermissionStatus.ENABLED}
       infoAction={handleOnPressShowInfo}
       fixAction={handleOnPressFix}
       testID={"home-proximity-tracing-status-container"}

--- a/src/Home/index.spec.tsx
+++ b/src/Home/index.spec.tsx
@@ -10,11 +10,8 @@ import { PermissionStatus } from "../permissionStatus"
 import { SystemServicesContext } from "../SystemServicesContext"
 import { ConfigurationContext } from "../ConfigurationContext"
 import { factories } from "../factories"
-import { isPlatformiOS } from "../utils"
 
 jest.mock("@react-navigation/native")
-
-jest.mock("../utils/index")
 
 const mockedApplicationName = "applicationName"
 jest.mock("../hooks/useApplicationInfo", () => {
@@ -241,14 +238,13 @@ describe("Home", () => {
       expect(proximityTracingDisabledText).toBeDefined()
     })
 
-    it("requests exposure notifications and shows an unauthorized alert on ios", () => {
+    it("requests exposure notifications and shows an unauthorized alert", () => {
       const isENAuthorizedAndEnabled = ENStatus.UNAUTHORIZED_DISABLED
       const requestSpy = jest.fn()
       const permissionProviderValue = createPermissionProviderValue(
         isENAuthorizedAndEnabled,
         requestSpy,
       )
-      ;(isPlatformiOS as jest.Mock).mockReturnValueOnce(true)
 
       const { getByTestId } = render(
         <PermissionsContext.Provider value={permissionProviderValue}>
@@ -271,31 +267,6 @@ describe("Home", () => {
           expect.objectContaining({ text: "Open Settings" }),
         ],
       )
-    })
-
-    it("requests exposure notifications and does not show an unauthorized alert on android", () => {
-      const isENAuthorizedAndEnabled = ENStatus.UNAUTHORIZED_DISABLED
-      const requestSpy = jest.fn()
-      const permissionProviderValue = createPermissionProviderValue(
-        isENAuthorizedAndEnabled,
-        requestSpy,
-      )
-      ;(isPlatformiOS as jest.Mock).mockReturnValueOnce(false)
-
-      const { getByTestId } = render(
-        <PermissionsContext.Provider value={permissionProviderValue}>
-          <Home />
-        </PermissionsContext.Provider>,
-      )
-
-      const alertSpy = jest.spyOn(Alert, "alert")
-      const fixProximityTracingButton = getByTestId(
-        "home-proximity-tracing-status-container",
-      )
-
-      fireEvent.press(fixProximityTracingButton)
-      expect(requestSpy).toHaveBeenCalled()
-      expect(alertSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/src/Home/index.spec.tsx
+++ b/src/Home/index.spec.tsx
@@ -238,7 +238,7 @@ describe("Home", () => {
       expect(proximityTracingDisabledText).toBeDefined()
     })
 
-    it("requests exposure notifications and shows an unauthorized alert", () => {
+    it("requests exposure notifications and shows a not authorized alert", () => {
       const enPermissionStatus = ENPermissionStatus.NOT_AUTHORIZED
       const requestSpy = jest.fn()
       const permissionProviderValue = createPermissionProviderValue(

--- a/src/Home/index.spec.tsx
+++ b/src/Home/index.spec.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from "@react-navigation/native"
 import "@testing-library/jest-native/extend-expect"
 
 import Home from "."
-import { PermissionsContext, ENStatus } from "../PermissionsContext"
+import { PermissionsContext, ENPermissionStatus } from "../PermissionsContext"
 import { PermissionStatus } from "../permissionStatus"
 import { SystemServicesContext } from "../SystemServicesContext"
 import { ConfigurationContext } from "../ConfigurationContext"
@@ -32,7 +32,7 @@ describe("Home", () => {
   it("allows users to share the application", () => {
     const configuration = factories.configurationContext.build()
     const permissionProviderValue = createPermissionProviderValue(
-      ENStatus.AUTHORIZED_ENABLED,
+      ENPermissionStatus.ENABLED,
     )
 
     const shareSpy = jest.spyOn(Share, "share")
@@ -56,9 +56,9 @@ describe("Home", () => {
 
   describe("When the exposure notification permissions are enabled, the app is authorized, Bluetooth is on, and Location is on", () => {
     it("renders an active message", () => {
-      const isENAuthorizedAndEnabled = ENStatus.AUTHORIZED_ENABLED
+      const enPermissionStatus = ENPermissionStatus.ENABLED
       const permissionProviderValue = createPermissionProviderValue(
-        isENAuthorizedAndEnabled,
+        enPermissionStatus,
       )
 
       const { getByTestId } = render(
@@ -102,9 +102,9 @@ describe("Home", () => {
 
   describe("When Bluetooth is off", () => {
     it("renders an inactive message and a disabled message for bluetooth", () => {
-      const isENAuthorizedAndEnabled = ENStatus.AUTHORIZED_ENABLED
+      const enPermissionStatus = ENPermissionStatus.ENABLED
       const permissionProviderValue = createPermissionProviderValue(
-        isENAuthorizedAndEnabled,
+        enPermissionStatus,
       )
 
       const { getByTestId } = render(
@@ -139,9 +139,9 @@ describe("Home", () => {
     })
 
     it("prompts the user to enable Bluetooth", () => {
-      const isENAuthorizedAndEnabled = ENStatus.AUTHORIZED_ENABLED
+      const enPermissionStatus = ENPermissionStatus.ENABLED
       const permissionProviderValue = createPermissionProviderValue(
-        isENAuthorizedAndEnabled,
+        enPermissionStatus,
       )
 
       const { getByTestId } = render(
@@ -175,9 +175,9 @@ describe("Home", () => {
       const navigationSpy = jest.fn()
       ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigationSpy })
 
-      const isENAuthorizedAndEnabled = ENStatus.AUTHORIZED_ENABLED
+      const enPermissionStatus = ENPermissionStatus.ENABLED
       const permissionProviderValue = createPermissionProviderValue(
-        isENAuthorizedAndEnabled,
+        enPermissionStatus,
       )
 
       const { getByTestId } = render(
@@ -203,9 +203,9 @@ describe("Home", () => {
 
   describe("When the app is not authorized", () => {
     it("renders an inactive message and a disabled message for proximity tracing", () => {
-      const isENAuthorizedAndEnabled = ENStatus.UNAUTHORIZED_DISABLED
+      const enPermissionStatus = ENPermissionStatus.NOT_AUTHORIZED
       const permissionProviderValue = createPermissionProviderValue(
-        isENAuthorizedAndEnabled,
+        enPermissionStatus,
       )
 
       const { getByTestId } = render(
@@ -239,10 +239,10 @@ describe("Home", () => {
     })
 
     it("requests exposure notifications and shows an unauthorized alert", () => {
-      const isENAuthorizedAndEnabled = ENStatus.UNAUTHORIZED_DISABLED
+      const enPermissionStatus = ENPermissionStatus.NOT_AUTHORIZED
       const requestSpy = jest.fn()
       const permissionProviderValue = createPermissionProviderValue(
-        isENAuthorizedAndEnabled,
+        enPermissionStatus,
         requestSpy,
       )
 
@@ -272,10 +272,10 @@ describe("Home", () => {
 
   describe("When the app is not enabled", () => {
     it("requests exposure notification permissions", () => {
-      const isENAuthorizedAndEnabled = ENStatus.AUTHORIZED_DISABLED
+      const enPermissionStatus = ENPermissionStatus.DISABLED
       const requestSpy = jest.fn()
       const permissionProviderValue = createPermissionProviderValue(
-        isENAuthorizedAndEnabled,
+        enPermissionStatus,
         requestSpy,
       )
 
@@ -301,9 +301,9 @@ describe("Home", () => {
         navigate: navigationSpy,
       })
 
-      const isENAuthorizedAndEnabled = ENStatus.AUTHORIZED_ENABLED
+      const enPermissionStatus = ENPermissionStatus.ENABLED
       const permissionProviderValue = createPermissionProviderValue(
-        isENAuthorizedAndEnabled,
+        enPermissionStatus,
       )
 
       const { getByTestId } = render(
@@ -395,7 +395,7 @@ describe("Home", () => {
 })
 
 const createPermissionProviderValue = (
-  enStatus: ENStatus,
+  enPermissionStatus: ENPermissionStatus,
   requestPermission: () => Promise<void> = () => Promise.resolve(),
 ) => {
   return {
@@ -405,7 +405,7 @@ const createPermissionProviderValue = (
       request: () => {},
     },
     exposureNotifications: {
-      status: enStatus,
+      status: enPermissionStatus,
       check: () => {},
       request: requestPermission,
     },

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -4,7 +4,10 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
-import { usePermissionsContext, ENStatus } from "../PermissionsContext"
+import {
+  usePermissionsContext,
+  ENPermissionStatus,
+} from "../PermissionsContext"
 import { useSystemServicesContext } from "../SystemServicesContext"
 import { Screens, useStatusBarEffect, Stacks } from "../navigation"
 import { useApplicationName } from "../hooks/useApplicationInfo"
@@ -44,7 +47,7 @@ const Home: FunctionComponent = () => {
 
   const { exposureNotifications } = usePermissionsContext()
   const isProximityTracingOn =
-    exposureNotifications.status === ENStatus.AUTHORIZED_ENABLED
+    exposureNotifications.status === ENPermissionStatus.ENABLED
 
   const appIsActive =
     isProximityTracingOn && isBluetoothOn && !isLocationOffAndNeeded

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -18,40 +18,38 @@ import { isPlatformiOS } from "./utils"
 
 type ENAuthorizationStatus = `UNAUTHORIZED` | `AUTHORIZED`
 type ENEnablementStatus = `DISABLED` | `ENABLED`
-export type ENPermissionStatus = [ENAuthorizationStatus, ENEnablementStatus]
-const initialENPermissionStatus: ENPermissionStatus = [
+export type RawENPermissionStatus = [ENAuthorizationStatus, ENEnablementStatus]
+const initialENPermissionStatus: RawENPermissionStatus = [
   "UNAUTHORIZED",
   "DISABLED",
 ]
 
-export enum ENStatus {
-  UNAUTHORIZED_DISABLED,
-  AUTHORIZED_DISABLED,
-  AUTHORIZED_ENABLED,
+export enum ENPermissionStatus {
+  NOT_AUTHORIZED,
+  DISABLED,
+  ENABLED,
 }
 
-const toENStatus = (enPermissionStatus: ENPermissionStatus): ENStatus => {
+const toENPermissionStatusEnum = (
+  enPermissionStatus: RawENPermissionStatus,
+): ENPermissionStatus => {
   const isAuthorized = enPermissionStatus[0] === "AUTHORIZED"
   const isEnabled = enPermissionStatus[1] === "ENABLED"
 
-  if (!isAuthorized && !isEnabled) {
+  if (!isAuthorized) {
     return isPlatformiOS()
-      ? ENStatus.UNAUTHORIZED_DISABLED
-      : ENStatus.AUTHORIZED_DISABLED
+      ? ENPermissionStatus.NOT_AUTHORIZED
+      : ENPermissionStatus.DISABLED
+  } else if (!isEnabled) {
+    return ENPermissionStatus.DISABLED
+  } else {
+    return ENPermissionStatus.ENABLED
   }
-
-  if (isAuthorized && !isEnabled) {
-    return ENStatus.AUTHORIZED_DISABLED
-  }
-
-  if (isAuthorized && isEnabled) {
-    return ENStatus.AUTHORIZED_ENABLED
-  }
-
-  return ENStatus.UNAUTHORIZED_DISABLED
 }
 
-const initialENStatus: ENStatus = toENStatus(initialENPermissionStatus)
+const initialENStatus: ENPermissionStatus = toENPermissionStatusEnum(
+  initialENPermissionStatus,
+)
 
 export interface PermissionsContextState {
   notification: {
@@ -60,7 +58,7 @@ export interface PermissionsContextState {
     request: () => void
   }
   exposureNotifications: {
-    status: ENStatus
+    status: ENPermissionStatus
     check: () => void
     request: () => Promise<void>
   }
@@ -83,9 +81,9 @@ const PermissionsContext = createContext<PermissionsContextState>(initialState)
 
 export interface PermissionStrategy {
   statusSubscription: (
-    cb: (status: ENPermissionStatus) => void,
+    cb: (status: RawENPermissionStatus) => void,
   ) => { remove: () => void }
-  check: (cb: (status: ENPermissionStatus) => void) => void
+  check: (cb: (status: RawENPermissionStatus) => void) => void
   request: () => Promise<void>
 }
 
@@ -93,7 +91,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
   const [
     exposureNotificationsPermissionStatus,
     setExposureNotificationsPermissionStatus,
-  ] = useState<ENPermissionStatus>(initialENPermissionStatus)
+  ] = useState<RawENPermissionStatus>(initialENPermissionStatus)
 
   const [notificationPermission, setNotificationPermission] = useState(
     PermissionStatus.UNKNOWN,
@@ -102,7 +100,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
   const { permissionStrategy } = gaenStrategy
 
   const checkENPermission = useCallback(() => {
-    const handleNativeResponse = (status: ENPermissionStatus) => {
+    const handleNativeResponse = (status: RawENPermissionStatus) => {
       setExposureNotificationsPermissionStatus(status)
     }
     permissionStrategy.check(handleNativeResponse)
@@ -115,7 +113,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
 
     AppState.addEventListener("change", handleAppStateChange)
     const subscription = permissionStrategy.statusSubscription(
-      (status: ENPermissionStatus) => {
+      (status: RawENPermissionStatus) => {
         setExposureNotificationsPermissionStatus(status)
       },
     )
@@ -155,7 +153,9 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
     return status
   }
 
-  const enStatus: ENStatus = toENStatus(exposureNotificationsPermissionStatus)
+  const enPermission: ENPermissionStatus = toENPermissionStatusEnum(
+    exposureNotificationsPermissionStatus,
+  )
 
   return (
     <PermissionsContext.Provider
@@ -166,7 +166,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
           request: requestNotificationPermission,
         },
         exposureNotifications: {
-          status: enStatus,
+          status: enPermission,
           check: checkENPermission,
           request: requestENPermission,
         },

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -14,6 +14,7 @@ import {
 
 import { PermissionStatus, statusToEnum } from "./permissionStatus"
 import gaenStrategy from "./gaen"
+import { isPlatformiOS } from "./utils"
 
 type ENAuthorizationStatus = `UNAUTHORIZED` | `AUTHORIZED`
 type ENEnablementStatus = `DISABLED` | `ENABLED`
@@ -34,7 +35,9 @@ const toENStatus = (enPermissionStatus: ENPermissionStatus): ENStatus => {
   const isEnabled = enPermissionStatus[1] === "ENABLED"
 
   if (!isAuthorized && !isEnabled) {
-    return ENStatus.UNAUTHORIZED_DISABLED
+    return isPlatformiOS()
+      ? ENStatus.UNAUTHORIZED_DISABLED
+      : ENStatus.AUTHORIZED_DISABLED
   }
 
   if (isAuthorized && !isEnabled) {
@@ -152,9 +155,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
     return status
   }
 
-  const isENAuthorizedAndEnabled: ENStatus = toENStatus(
-    exposureNotificationsPermissionStatus,
-  )
+  const enStatus: ENStatus = toENStatus(exposureNotificationsPermissionStatus)
 
   return (
     <PermissionsContext.Provider
@@ -165,7 +166,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
           request: requestNotificationPermission,
         },
         exposureNotifications: {
-          status: isENAuthorizedAndEnabled,
+          status: enStatus,
           check: checkENPermission,
           request: requestENPermission,
         },

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -4,7 +4,7 @@ import {
   EventSubscription,
 } from "react-native"
 
-import { ENPermissionStatus } from "../PermissionsContext"
+import { RawENPermissionStatus } from "../PermissionsContext"
 import { ExposureInfo, Posix } from "../exposure"
 import { ENDiagnosisKey } from "../More/ENLocalDiagnosisKeyScreen"
 import { ExposureKey } from "../exposureKey"
@@ -28,7 +28,7 @@ export const subscribeToExposureEvents = (
 }
 
 export const subscribeToEnabledStatusEvents = (
-  cb: (status: ENPermissionStatus) => void,
+  cb: (status: RawENPermissionStatus) => void,
 ): EventSubscription => {
   const ExposureEvents = new NativeEventEmitter(
     NativeModules.ExposureEventEmitter,
@@ -44,10 +44,10 @@ export const subscribeToEnabledStatusEvents = (
   )
 }
 
-const toStatus = (data: string[]): ENPermissionStatus => {
+const toStatus = (data: string[]): RawENPermissionStatus => {
   const networkAuthorization = data[0]
   const networkEnablement = data[1]
-  const result: ENPermissionStatus = ["UNAUTHORIZED", "DISABLED"]
+  const result: RawENPermissionStatus = ["UNAUTHORIZED", "DISABLED"]
   if (networkAuthorization === "AUTHORIZED") {
     result[0] = "AUTHORIZED"
   }
@@ -65,7 +65,7 @@ export const requestAuthorization = async (): Promise<void> => {
 }
 
 export const getCurrentENPermissionsStatus = async (
-  cb: (status: ENPermissionStatus) => void,
+  cb: (status: RawENPermissionStatus) => void,
 ): Promise<void> => {
   const response = await permissionsModule.getCurrentENPermissionsStatus()
   cb(toStatus(response))

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -167,7 +167,7 @@
       "tracing_off_subheader_location": "Enable Bluetooth, Proximity Tracing, and Location to get info about possible exposures",
       "tracing_on_header": "Active",
       "unauthorized_error_message": "To activate Proximity Tracing, ensure \"Share Exposure Information\" is enabled in Settings > {{applicationName}} > Exposure Notifications",
-      "unauthorized_error_title": "Share Expsoure Information"
+      "unauthorized_error_title": "Share Exposure Information"
     },
     "location_info_body_1": "The Exposure Notification technology uses Bluetooth scanning to understand what devices are near one another. On all phones running Android 6.0 and above, to use Bluetooth scanning, the device location setting needs to be turned on for all apps, not just apps built with the Exposure Notifications System.",
     "location_info_header": "Location",


### PR DESCRIPTION
## Why
Prior to this commit, we were not ensuring the platform was iOS before showing an unauthorized alert on the home screen.

## This Commit
- Checks to see if the platform is iOS before showing an unauthorized alert.
- Updates the home screen spec to test this behavior
- Uses `isPlatformiOS()` to avoid having to mock `Platform`