### PR TITLE
Handle rejected promise on request exposure notification permissions

### DIFF
--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -83,7 +83,7 @@ export interface PermissionStrategy {
     cb: (status: ENPermissionStatus) => void,
   ) => { remove: () => void }
   check: (cb: (status: ENPermissionStatus) => void) => void
-  request: () => Promise<string>
+  request: () => Promise<void>
 }
 
 const PermissionsProvider: FunctionComponent = ({ children }) => {
@@ -139,7 +139,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
   }
 
   const requestENPermission = async () => {
-    permissionStrategy.request()
+    permissionStrategy.request().catch(() => {})
   }
 
   const requestNotificationPermission = async () => {

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -139,7 +139,11 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
   }
 
   const requestENPermission = async () => {
-    permissionStrategy.request().catch(() => {})
+    permissionStrategy.request().catch((error) => {
+      if (error.message !== "Error enabling notifications") {
+        throw Error(error)
+      }
+    })
   }
 
   const requestNotificationPermission = async () => {

--- a/src/factories/gaenStrategy.tsx
+++ b/src/factories/gaenStrategy.tsx
@@ -20,6 +20,6 @@ export default Factory.define<GaenStrategy>(() => ({
       return { remove: () => {} }
     },
     check: () => {},
-    request: () => Promise.resolve(""),
+    request: () => Promise.resolve(),
   },
 }))

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -60,7 +60,7 @@ const toStatus = (data: string[]): ENPermissionStatus => {
 // Permissions Module
 const permissionsModule = NativeModules.ENPermissionsModule
 
-export const requestAuthorization = async (): Promise<string> => {
+export const requestAuthorization = async (): Promise<void> => {
   return permissionsModule.requestExposureNotificationAuthorization()
 }
 


### PR DESCRIPTION
Why: prior to this commit, a warning showed on iOS when the promise was rejected when requesting exposure notification permissions.

This commit:
- Handles the promise rejection when requesting exposure notification permissions
- Updates the `requestAuthorization` method in the native module to return `Promise<void>` instead of 'Promise<string>`