### PR TITLE
Add Accept Eula to activation flow

### DIFF
--- a/src/Onboarding/ValueProposition.tsx
+++ b/src/Onboarding/ValueProposition.tsx
@@ -22,7 +22,7 @@ const ValueProposition: FunctionComponent = () => {
   const onboardingScreenActions = {
     primaryButtonOnPress: () => {
       return navigation.navigate(Stacks.Activation, {
-        screen: ActivationScreens.ActivateProximityTracing,
+        screen: ActivationScreens.AcceptEula,
       })
     },
   }

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -19,6 +19,7 @@ import ActivationSummary from "../Activation/ActivationSummary"
 
 import { Icons } from "../assets"
 import { Spacing, Colors, Typography } from "../styles"
+import AcceptEula from "../Activation/AcceptEula"
 
 type ActivationStackParams = {
   [key in ActivationScreen]: undefined
@@ -36,6 +37,11 @@ const ActivationStack: FunctionComponent = () => {
     component: FunctionComponent
   }
 
+  const acceptEulaStep: ActivationStep = {
+    screenName: ActivationScreens.AcceptEula,
+    component: AcceptEula,
+  }
+
   const activateProximityTracing: ActivationStep = {
     screenName: ActivationScreens.ActivateProximityTracing,
     component: ActivateProximityTracing,
@@ -51,14 +57,16 @@ const ActivationStack: FunctionComponent = () => {
     component: NotificationPermissions,
   }
 
+  const defaultSteps = [acceptEulaStep, activateProximityTracing]
+
   const activationStepsIOS: ActivationStep[] = [
-    activateProximityTracing,
+    ...defaultSteps,
     notificationPermissions,
   ]
 
   const activationStepsAndroid: ActivationStep[] = isLocationNeeded
-    ? [activateProximityTracing, activateLocation]
-    : [activateProximityTracing]
+    ? [...defaultSteps, activateLocation]
+    : defaultSteps
 
   const activationSteps = Platform.select({
     ios: activationStepsIOS,


### PR DESCRIPTION
Why:
----

The accept terms of service screen is not shown on the flow because we
don't have links in place for the eula for all authorities. We need to
be ready to turn it on when we need to.

This Commit:
----

- Add the AcceptEula screen to the ActivationStack