### PR TITLE
Refactor method of re-rendering Exposure History screen on focus

### DIFF
--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -57,6 +57,10 @@ const History: FunctionComponent<HistoryProps> = ({
     previousExposuresRef.current = exposures
   }, [exposures])
 
+  const refreshControl = (
+    <RefreshControl refreshing={refreshing} onRefresh={handleOnRefresh} />
+  )
+
   const showExposureHistory = exposures.length > 0
 
   return (
@@ -65,9 +69,7 @@ const History: FunctionComponent<HistoryProps> = ({
       <ScrollView
         contentContainerStyle={style.contentContainer}
         style={style.container}
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={handleOnRefresh} />
-        }
+        refreshControl={refreshControl}
       >
         <View>
           <View style={style.headerRow}>

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -40,10 +40,6 @@ const History: FunctionComponent<HistoryProps> = ({
   const [refreshing, setRefreshing] = useState(false)
   const previousExposuresRef = useRef<ExposureDatum[]>()
 
-  useEffect(() => {
-    previousExposuresRef.current = exposures
-  })
-
   const handleOnPressMoreInfo = () => {
     navigation.navigate(Screens.MoreInfo)
   }
@@ -58,6 +54,10 @@ const History: FunctionComponent<HistoryProps> = ({
   }
 
   const showExposureHistory = exposures.length > 0
+
+  useEffect(() => {
+    previousExposuresRef.current = exposures
+  })
 
   return (
     <>

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -53,11 +53,11 @@ const History: FunctionComponent<HistoryProps> = ({
     setRefreshing(false)
   }
 
-  const showExposureHistory = exposures.length > 0
-
   useEffect(() => {
     previousExposuresRef.current = exposures
-  })
+  }, [exposures])
+
+  const showExposureHistory = exposures.length > 0
 
   return (
     <>

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-native"
 import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
-import { useNavigation } from "@react-navigation/native"
+import { useNavigation, useIsFocused } from "@react-navigation/native"
 import isEqual from "lodash.isequal"
 
 import { ExposureDatum } from "../../exposure"
@@ -34,6 +34,7 @@ const History: FunctionComponent<HistoryProps> = ({
   lastDetectionDate,
   exposures,
 }) => {
+  useIsFocused()
   useStatusBarEffect("dark-content", Colors.secondary10)
   const { t } = useTranslation()
   const navigation = useNavigation()

--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent } from "react"
-import { useIsFocused } from "@react-navigation/native"
 
 import { useExposureContext } from "../ExposureContext"
 import History from "./History"
@@ -11,7 +10,6 @@ const toExposureList = (exposureInfo: ExposureInfo): ExposureDatum[] => {
 }
 
 const ExposureHistoryScreen: FunctionComponent = () => {
-  useIsFocused()
   const { lastExposureDetectionDate, exposureInfo } = useExposureContext()
 
   const exposures = toExposureList(exposureInfo)

--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -1,4 +1,5 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent, useCallback } from "react"
+import { useFocusEffect } from "@react-navigation/native"
 
 import { useExposureContext } from "../ExposureContext"
 import History from "./History"
@@ -10,9 +11,19 @@ const toExposureList = (exposureInfo: ExposureInfo): ExposureDatum[] => {
 }
 
 const ExposureHistoryScreen: FunctionComponent = () => {
-  const { lastExposureDetectionDate, exposureInfo } = useExposureContext()
+  const {
+    lastExposureDetectionDate,
+    exposureInfo,
+    observeExposures,
+  } = useExposureContext()
 
   const exposures = toExposureList(exposureInfo)
+
+  useFocusEffect(
+    useCallback(() => {
+      observeExposures()
+    }, [observeExposures]),
+  )
 
   return (
     <History

--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent, useCallback } from "react"
-import { useFocusEffect } from "@react-navigation/native"
+import React, { FunctionComponent } from "react"
+import { useIsFocused } from "@react-navigation/native"
 
 import { useExposureContext } from "../ExposureContext"
 import History from "./History"
@@ -11,19 +11,10 @@ const toExposureList = (exposureInfo: ExposureInfo): ExposureDatum[] => {
 }
 
 const ExposureHistoryScreen: FunctionComponent = () => {
-  const {
-    lastExposureDetectionDate,
-    exposureInfo,
-    observeExposures,
-  } = useExposureContext()
+  useIsFocused()
+  const { lastExposureDetectionDate, exposureInfo } = useExposureContext()
 
   const exposures = toExposureList(exposureInfo)
-
-  useFocusEffect(
-    useCallback(() => {
-      observeExposures()
-    }, [observeExposures]),
-  )
 
   return (
     <History

--- a/src/navigation/ExposureHistoryStack.tsx
+++ b/src/navigation/ExposureHistoryStack.tsx
@@ -1,8 +1,6 @@
-import React, { FunctionComponent, useState, useEffect } from "react"
+import React, { FunctionComponent } from "react"
 import { createStackNavigator } from "@react-navigation/stack"
-import { useNavigation } from "@react-navigation/native"
 
-import { useExposureContext } from "../ExposureContext"
 import ExposureHistoryScreen from "../ExposureHistory/index"
 
 import {
@@ -20,24 +18,6 @@ const SCREEN_OPTIONS = {
 }
 
 const ExposureHistoryStack: FunctionComponent = () => {
-  const navigation = useNavigation()
-  const { observeExposures } = useExposureContext()
-  const [, setIsFocused] = useState(false)
-
-  useEffect(() => {
-    const unsubscribeTabPress = navigation.addListener("focus", () => {
-      setIsFocused(true)
-      observeExposures()
-    })
-    const unsubscribeTabBlur = navigation.addListener("blur", () => {
-      setIsFocused(false)
-    })
-    return () => {
-      unsubscribeTabPress()
-      unsubscribeTabBlur()
-    }
-  }, [navigation, observeExposures])
-
   return (
     <Stack.Navigator
       screenOptions={{


### PR DESCRIPTION
Why: prior to this commit, we were using `navigation.addListener` to check if the Exposure History screen was focused and updating state to trigger a re-render.

This commit:
- Uses `useIsFocused()` to trigger a re-render of the Exposure History screen on focus
- Removes the call to `observeExposures()` on the Exposure History Stack because it doesn't seem to be doing anything at the moment, given that we are not rendering a badge on the exposure history tab icon