### PR TITLE
Remove unused code from ExposureContext

### DIFF
--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -26,12 +26,8 @@ export interface ExposureState {
   getCurrentExposures: () => Promise<ExposureInfo>
   getExposureKeys: () => Promise<ExposureKey[]>
   getRevisionToken: () => Promise<string>
-  hasBeenExposed: boolean
   lastExposureDetectionDate: Posix | null
-  observeExposures: () => void
-  resetExposures: () => void
   storeRevisionToken: (revisionToken: string) => Promise<void>
-  userHasNewExposure: boolean
 }
 
 const initialState = {
@@ -45,14 +41,10 @@ const initialState = {
   getRevisionToken: () => {
     return Promise.resolve("")
   },
-  hasBeenExposed: false,
   lastExposureDetectionDate: null,
-  observeExposures: (): void => {},
-  resetExposures: (): void => {},
   storeRevisionToken: () => {
     return Promise.resolve()
   },
-  userHasNewExposure: true,
 }
 
 export const ExposureContext = createContext<ExposureState>(initialState)
@@ -64,7 +56,6 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
   } = exposureEventsStrategy
 
   const [exposureInfo, setExposureInfo] = useState<ExposureInfo>([])
-  const [userHasNewExposure, setUserHasNewExposure] = useState<boolean>(false)
 
   const [
     lastExposureDetectionDate,
@@ -105,15 +96,6 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
     return subscription.remove
   }, [exposureInfoSubscription, getLastExposureDetectionDate])
 
-  const observeExposures = () => {
-    setUserHasNewExposure(false)
-  }
-
-  const resetExposures = () => {
-    setUserHasNewExposure(true)
-  }
-
-  const hasBeenExposed = false
   return (
     <ExposureContext.Provider
       value={{
@@ -121,12 +103,8 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
         getCurrentExposures,
         getExposureKeys,
         getRevisionToken,
-        hasBeenExposed,
         lastExposureDetectionDate,
-        observeExposures,
-        resetExposures,
         storeRevisionToken,
-        userHasNewExposure,
       }}
     >
       {children}

--- a/src/factories/exposureContext.tsx
+++ b/src/factories/exposureContext.tsx
@@ -3,10 +3,6 @@ import { ExposureState } from "../ExposureContext"
 
 export default Factory.define<ExposureState>(() => ({
   exposureInfo: [],
-  hasBeenExposed: false,
-  userHasNewExposure: true,
-  observeExposures: (): void => {},
-  resetExposures: (): void => {},
   getCurrentExposures: () => Promise.resolve([]),
   getExposureKeys: () => Promise.resolve([]),
   lastExposureDetectionDate: null,

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent } from "react"
-import { View, StyleSheet } from "react-native"
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
 import { useTranslation } from "react-i18next"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -11,38 +10,21 @@ import HomeStack from "./HomeStack"
 import MoreStack from "./MoreStack"
 import ReportIssueStack from "./ReportIssueStack"
 
-import { useExposureContext } from "../ExposureContext"
 import { useConfigurationContext } from "../ConfigurationContext"
 
 import { Screens, Stacks } from "./index"
 import { TabBarIcons } from "../assets/svgs/TabBarNav"
-import { Affordances, Colors } from "../styles"
+import { Colors } from "../styles"
 
 const Tab = createBottomTabNavigator()
 
 const MainTabNavigator: FunctionComponent = () => {
   const { t } = useTranslation()
-  const { userHasNewExposure } = useExposureContext()
   const insets = useSafeAreaInsets()
   const {
     displaySelfAssessment,
     displayReportAnIssue,
   } = useConfigurationContext()
-
-  const applyBadge = (icon: JSX.Element) => {
-    return (
-      <>
-        {icon}
-        <View style={style.iconBadge} />
-      </>
-    )
-  }
-
-  const style = StyleSheet.create({
-    iconBadge: {
-      ...Affordances.iconBadge,
-    },
-  })
 
   interface TabIconProps extends TabBarIconProps {
     icon: string
@@ -95,7 +77,7 @@ const MainTabNavigator: FunctionComponent = () => {
         size={size}
       />
     )
-    return userHasNewExposure ? applyBadge(tabIcon) : tabIcon
+    return tabIcon
   }
 
   const QuestionMarkIcon: FunctionComponent<TabBarIconProps> = ({


### PR DESCRIPTION
## Why

We have a lot of unused code in the `ExposureContext`, likely a result of half-finished features that got dropped when priorities changed.

## This Commit

Removes this unused code.