### PR TITLE
Check GPS or network on devices running Android 8.1 or lower

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DeviceInfoModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DeviceInfoModule.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.location.LocationManager;
 import androidx.annotation.NonNull;
+import androidx.core.location.LocationManagerCompat;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -72,7 +73,7 @@ public class DeviceInfoModule extends ReactContextBaseJavaModule {
     final LocationManager manager =
         (LocationManager) getReactApplicationContext().getSystemService(Context.LOCATION_SERVICE);
     if (manager != null) {
-      promise.resolve(manager.isProviderEnabled(LocationManager.GPS_PROVIDER));
+      promise.resolve(LocationManagerCompat.isLocationEnabled(manager));
     } else {
       promise.reject(new Exception("Location manager not found"));
     }


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
On Android version 8.1 or lower there is a setting to get the location from mobile networks instead of using GPS.
We were only checking if the GPS provider is enabled.

This PR uses `LocationManagerCompat` and it implements this logic:
```
return locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
                || locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
```

![device-2020-09-08-120456](https://user-images.githubusercontent.com/9491378/92504258-c8a97480-f1d8-11ea-9fe5-e18072aea2e5.png)

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/GAEN-238