### PR TITLE
Add button to open settings in order to enable Bluetooth

### DIFF
--- a/src/Home/BluetoothActivationStatus.tsx
+++ b/src/Home/BluetoothActivationStatus.tsx
@@ -5,6 +5,7 @@ import { ActivationStatus } from "./ActivationStatus"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { HomeScreens } from "../navigation"
+import { openAppSettings } from "../gaen/nativeModule"
 
 export const BluetoothActivationStatus: FunctionComponent = () => {
   const { t } = useTranslation()
@@ -25,7 +26,12 @@ export const BluetoothActivationStatus: FunctionComponent = () => {
       t("home.bluetooth.bluetooth_disabled_error_message"),
       [
         {
-          text: t("common.okay"),
+          text: t("common.back"),
+          style: "cancel",
+        },
+        {
+          text: t("common.settings"),
+          onPress: () => openAppSettings(),
         },
       ],
     )

--- a/src/Home/LocationActivationStatus.tsx
+++ b/src/Home/LocationActivationStatus.tsx
@@ -30,7 +30,7 @@ export const LocationActivationStatus: FunctionComponent = () => {
       t("home.bluetooth.location_disabled_error_message"),
       [
         {
-          text: t("common.cancel"),
+          text: t("common.back"),
           style: "cancel",
         },
         {

--- a/src/Home/index.spec.tsx
+++ b/src/Home/index.spec.tsx
@@ -165,7 +165,10 @@ describe("Home", () => {
       expect(alertSpy).toHaveBeenCalledWith(
         "Enable Bluetooth in Settings",
         "Go to the Settings app and enable Bluetooth to fix this error",
-        [{ text: "Okay" }],
+        [
+          expect.objectContaining({ text: "Back" }),
+          expect.objectContaining({ text: "Open Settings" }),
+        ],
       )
     })
   })


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
The dialog to enable Location already had a button to "Open settings".
This PR adds the button to the Bluetooth dialog.

**Note:**
I haven't changed the copy, we should confirm with Art which copy we should use for these type of dialogs.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/GAEN-237

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->
![device-2020-09-08-173447](https://user-images.githubusercontent.com/9491378/92525098-9d834d00-f1f9-11ea-9c1c-9d9811e1f941.png)

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
- Disable Bluetooth
- Tap on the Fix icon
- Tap on Open Settings