### PR TITLE
Show error when there is no internet connection

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -131,8 +131,8 @@ const CodeInputForm: FunctionComponent = () => {
       case "VerificationCodeUsed": {
         return t("export.error.verification_code_used")
       }
-      case "InvalidVerificationUrl": {
-        return "Invalid Verification Url"
+      case "NetworkConnection": {
+        return t("export.error.network_connection_error")
       }
       default: {
         return t("export.error.unknown_code_verification_error")
@@ -144,6 +144,9 @@ const CodeInputForm: FunctionComponent = () => {
     switch (error) {
       case "TokenMetaDataMismatch": {
         return "token meta data mismatch"
+      }
+      case "NetworkConnection": {
+        return t("export.error.network_connection_error")
       }
       default: {
         return t("export.error.unknown_code_verification_error")

--- a/src/AffectedUserFlow/verificationAPI.ts
+++ b/src/AffectedUserFlow/verificationAPI.ts
@@ -31,7 +31,7 @@ type CodeVerificationSuccess = VerifiedCodeResponse
 export type CodeVerificationError =
   | "InvalidCode"
   | "VerificationCodeUsed"
-  | "InvalidVerificationUrl"
+  | "NetworkConnection"
   | "Unknown"
 
 type TestType = "confirmed" | "likely"
@@ -77,7 +77,11 @@ export const postCode = async (
       }
     }
   } catch (e) {
-    return { kind: "failure", error: "Unknown" }
+    if (e.message === "Network request failed") {
+      return { kind: "failure", error: "NetworkConnection" }
+    } else {
+      return { kind: "failure", error: "Unknown" }
+    }
   }
 }
 
@@ -88,7 +92,10 @@ interface TokenVerificationResponse {
 
 type TokenVerificationSuccess = TokenVerificationResponse
 
-export type TokenVerificationError = "TokenMetaDataMismatch" | "Unknown"
+export type TokenVerificationError =
+  | "TokenMetaDataMismatch"
+  | "Unknown"
+  | "NetworkConnection"
 
 export const postTokenAndHmac = async (
   token: Token,
@@ -126,6 +133,10 @@ export const postTokenAndHmac = async (
       }
     }
   } catch (e) {
-    return { kind: "failure", error: "Unknown" }
+    if (e.message === "Network request failed") {
+      return { kind: "failure", error: "NetworkConnection" }
+    } else {
+      return { kind: "failure", error: "Unknown" }
+    }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -85,6 +85,7 @@
       "invalid_code": "Try a different code",
       "invalid_format": "Invalid format",
       "unknown_code_verification_error": "Try a different code",
+      "network_connection_error": "There is no internet connection",
       "verification_code_used": "Verification code has already been used"
     },
     "publish_consent_title_bluetooth": "Notify others in your community",


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
When the user tries to submit a verification code and there is no internet connection we are showing the error "Try a different code".
This PR shows an error saying "There is no internet connection" when that happens.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/GAEN-260

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->
![device-2020-09-08-220158](https://user-images.githubusercontent.com/9491378/92542369-f0bbc680-f21e-11ea-85ab-23b7b2d5232b.png)

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
Disable WiFi and mobile data and try to submit a verification code