### PR TITLE
Add call back form shown per configuration

### DIFF
--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -6,6 +6,7 @@ export interface Configuration {
   appDownloadLink: string
   appPackageName: string
   displayAcceptTermsOfService: boolean
+  displayCallbackForm: boolean
   displayReportAnIssue: boolean
   displaySelfAssessment: boolean
   healthAuthorityAdviceUrl: string
@@ -19,6 +20,7 @@ const initialState = {
   appDownloadLink: "",
   appPackageName: "",
   displayAcceptTermsOfService: false,
+  displayCallbackForm: false,
   displayReportAnIssue: false,
   displaySelfAssessment: false,
   healthAuthorityAdviceUrl: "",
@@ -47,6 +49,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
     android: env.ANDROID_APPLICATION_ID,
   }) as string
   const regionCodes = env.REGION_CODES.split(",")
+  const displayCallbackForm = env.DISPLAY_CALLBACK_FORM === "true"
 
   return (
     <ConfigurationContext.Provider
@@ -54,6 +57,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         appDownloadLink,
         appPackageName,
         displayAcceptTermsOfService,
+        displayCallbackForm,
         displayReportAnIssue,
         displaySelfAssessment,
         healthAuthorityAdviceUrl,

--- a/src/More/CallbackForm.tsx
+++ b/src/More/CallbackForm.tsx
@@ -1,0 +1,237 @@
+import React, { useState, FunctionComponent } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  StyleSheet,
+  Platform,
+  TextInput,
+  View,
+  ScrollView,
+  Keyboard,
+} from "react-native"
+
+import { useStatusBarEffect } from "../navigation"
+import { useConfigurationContext } from "../ConfigurationContext"
+import { Button, GlobalText } from "../components"
+import * as API from "./callbackAPI"
+
+import { Spacing, Layout, Forms, Colors, Outlines, Typography } from "../styles"
+
+const defaultErrorMessage = " "
+
+const CallbackForm: FunctionComponent = () => {
+  useStatusBarEffect("light-content", Colors.headerBackground)
+  const { t } = useTranslation()
+  const { healthAuthorityName } = useConfigurationContext()
+
+  const [firstname, setFirstname] = useState("")
+  const [lastname, setLastname] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState(defaultErrorMessage)
+
+  const isIOS = Platform.OS === "ios"
+
+  const handleOnChangeFirstname = (name: string) => {
+    setErrorMessage("")
+    setFirstname(name)
+  }
+
+  const handleOnChangeLastname = (name: string) => {
+    setErrorMessage("")
+    setLastname(name)
+  }
+
+  const handleOnChangePhoneNumber = (phoneNumber: string) => {
+    setErrorMessage("")
+    setPhoneNumber(phoneNumber)
+  }
+
+  const handleOnPressSubmit = async () => {
+    setIsLoading(true)
+    setErrorMessage(defaultErrorMessage)
+
+    const fakeExposureDate = "2020-01-01"
+    try {
+      const response = await API.postCallbackInfo({
+        firstname,
+        lastname,
+        phoneNumber,
+        exposureDate: fakeExposureDate,
+      })
+
+      if (response.kind === "success") {
+        Alert.alert(t("common.success"))
+      } else {
+        setErrorMessage(showError(response.error))
+      }
+      setIsLoading(false)
+    } catch (e) {
+      Alert.alert(t("common.something_went_wrong"), e.message)
+      setIsLoading(false)
+    }
+  }
+
+  const showError = (error: string): string => {
+    switch (error) {
+      default: {
+        return t("common.something_went_wrong")
+      }
+    }
+  }
+
+  return (
+    <ScrollView
+      style={style.container}
+      contentContainerStyle={style.contentContainer}
+    >
+      <KeyboardAvoidingView
+        keyboardVerticalOffset={Spacing.tiny}
+        behavior={isIOS ? "padding" : undefined}
+      >
+        <View>
+          <View style={style.headerContainer}>
+            <GlobalText style={style.header}>
+              {t("callback_form.well_get_in_touch")}
+            </GlobalText>
+            <GlobalText style={style.subheader}>
+              {t("callback_form.fill_out_the_info", {
+                healthAuthorityName,
+              })}
+            </GlobalText>
+          </View>
+
+          <View style={style.inputContainer}>
+            <GlobalText style={style.inputLabel}>
+              {t("callback_form.firstname")}
+            </GlobalText>
+            <TextInput
+              value={firstname}
+              style={style.textInput}
+              keyboardType={"default"}
+              returnKeyType={"done"}
+              onChangeText={handleOnChangeFirstname}
+              blurOnSubmit={false}
+              onSubmitEditing={Keyboard.dismiss}
+              autoCapitalize={"none"}
+            />
+          </View>
+
+          <View style={style.inputContainer}>
+            <GlobalText style={style.inputLabel}>
+              {t("callback_form.lastname")}
+            </GlobalText>
+            <TextInput
+              value={lastname}
+              style={style.textInput}
+              keyboardType={"default"}
+              returnKeyType={"done"}
+              onChangeText={handleOnChangeLastname}
+              blurOnSubmit={false}
+              onSubmitEditing={Keyboard.dismiss}
+              autoCapitalize={"none"}
+            />
+          </View>
+
+          <View style={style.inputContainer}>
+            <GlobalText style={style.inputLabel}>
+              {t("callback_form.phone_number_required")}
+            </GlobalText>
+            <TextInput
+              value={phoneNumber}
+              style={style.textInput}
+              keyboardType={"phone-pad"}
+              returnKeyType={"done"}
+              onChangeText={handleOnChangePhoneNumber}
+              blurOnSubmit={false}
+              onSubmitEditing={Keyboard.dismiss}
+              multiline
+            />
+          </View>
+
+          <GlobalText style={style.errorSubtitle}>{errorMessage}</GlobalText>
+        </View>
+        {isLoading ? <LoadingIndicator /> : null}
+
+        <Button
+          onPress={handleOnPressSubmit}
+          label={t("common.submit")}
+          loading={isLoading}
+        />
+      </KeyboardAvoidingView>
+    </ScrollView>
+  )
+}
+
+const LoadingIndicator = () => {
+  return (
+    <View style={style.activityIndicatorContainer}>
+      <ActivityIndicator
+        size={"large"}
+        color={Colors.neutral100}
+        style={style.activityIndicator}
+        testID={"loading-indicator"}
+      />
+    </View>
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    height: "100%",
+    paddingHorizontal: Spacing.medium,
+    paddingTop: Spacing.large,
+    backgroundColor: Colors.primaryLightBackground,
+  },
+  contentContainer: {
+    justifyContent: "space-between",
+    paddingBottom: Spacing.xxHuge,
+  },
+  headerContainer: {
+    marginBottom: Spacing.small,
+  },
+  header: {
+    ...Typography.header2,
+    marginBottom: Spacing.xxSmall,
+  },
+  subheader: {
+    ...Typography.header4,
+    marginBottom: Spacing.xxSmall,
+  },
+  errorSubtitle: {
+    ...Typography.error,
+    paddingTop: Spacing.xxSmall,
+  },
+  inputContainer: {
+    marginTop: Spacing.large,
+  },
+  inputLabel: {
+    ...Typography.formInputLabel,
+    paddingBottom: Spacing.xxSmall,
+  },
+  textInput: {
+    ...Forms.textInput,
+  },
+  activityIndicatorContainer: {
+    position: "absolute",
+    zIndex: Layout.zLevel1,
+    alignItems: "center",
+    justifyContent: "center",
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    width: "100%",
+    height: "100%",
+  },
+  activityIndicator: {
+    width: 100,
+    height: 100,
+    backgroundColor: Colors.transparentNeutral30,
+    borderRadius: Outlines.baseBorderRadius,
+  },
+})
+
+export default CallbackForm

--- a/src/More/callbackAPI.tsx
+++ b/src/More/callbackAPI.tsx
@@ -1,0 +1,76 @@
+import env from "react-native-config"
+
+const {
+  CALLBACK_FORM_URL: callbackFormUrl,
+  CALLBACK_OAUTH_URL: callbackOAuthUrl,
+  CALLBACK_USERNAME: callbackUsername,
+  CALLBACK_PASSWORD: callbackPassword,
+  CALLBACK_CLIENT_ID: callbackClientId,
+  CALLBACK_CLIENT_SECRET: callbackClientSecret,
+} = env
+
+interface NetworkSuccess {
+  kind: "success"
+}
+interface NetworkFailure<U> {
+  kind: "failure"
+  error: U
+  message?: string
+}
+
+export type NetworkResponse<U = "Unknown"> = NetworkSuccess | NetworkFailure<U>
+
+export type PostCallbackInfoError = "Unknown"
+
+interface CallbackInfo {
+  firstname: string
+  lastname: string
+  phoneNumber: string
+  exposureDate: string
+}
+
+export const postCallbackInfo = async ({
+  firstname,
+  lastname,
+  phoneNumber,
+  exposureDate = "2020-06-16",
+}: CallbackInfo): Promise<NetworkResponse<PostCallbackInfoError>> => {
+  const postOAuth = async () => {
+    const oauthBody = `grant_type=password&client_id=${callbackClientId}&client_secret=${callbackClientSecret}&username=${callbackUsername}&password=${callbackPassword}`
+
+    return fetch(callbackOAuthUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: oauthBody,
+    })
+  }
+
+  const requestBody = {
+    LA_First_Name__c: firstname,
+    LA_Last_Name__c: lastname,
+    LA_Mobile_Phone__c: phoneNumber,
+    LA_Exposure_Date__c: exposureDate,
+  }
+
+  try {
+    const oauthResponse = await postOAuth()
+    const data = await oauthResponse.json()
+
+    const response = await fetch(callbackFormUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: "Bearer " + data.access_token,
+      },
+      body: JSON.stringify(requestBody),
+    })
+
+    if (response.ok) {
+      return { kind: "success" }
+    } else {
+      return { kind: "failure", error: "Unknown" }
+    }
+  } catch (e) {
+    return { kind: "failure", error: "Unknown", message: e.message }
+  }
+}

--- a/src/Settings/Menu.tsx
+++ b/src/Settings/Menu.tsx
@@ -12,6 +12,7 @@ import { useStatusBarEffect } from "../navigation/index"
 
 import { Icons } from "../assets"
 import { Iconography, Colors, Spacing, Typography, Outlines } from "../styles"
+import { useConfigurationContext } from "../ConfigurationContext"
 
 const MenuScreen: FunctionComponent = () => {
   useStatusBarEffect("light-content", Colors.headerBackground)
@@ -21,6 +22,7 @@ const MenuScreen: FunctionComponent = () => {
     i18n: { language: localeCode },
   } = useTranslation()
   const languageName = getLocalNames()[localeCode]
+  const { displayCallbackForm } = useConfigurationContext()
   const showDebugMenu = env.STAGING === "true" || __DEV__
 
   const handleOnPressSelectLanguage = () => {
@@ -60,6 +62,13 @@ const MenuScreen: FunctionComponent = () => {
           onPress={() => navigation.navigate(SettingsScreens.Legal)}
           lastItem
         />
+        {displayCallbackForm && (
+          <SettingsListItem
+            label={t("screen_titles.callback_form")}
+            onPress={() => navigation.navigate(SettingsScreens.CallbackForm)}
+            lastItem
+          />
+        )}
       </View>
       {showDebugMenu ? (
         <View style={style.section}>

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -7,6 +7,7 @@ export default Factory.define<Configuration>(() => ({
   displayAcceptTermsOfService: false,
   displayReportAnIssue: false,
   displaySelfAssessment: false,
+  displayCallbackForm: false,
   healthAuthorityAdviceUrl: "authorityAdviceUrl",
   healthAuthorityEulaUrl: "healthAuthorityEulaUrl",
   healthAuthorityName: "authorityName",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -40,6 +40,13 @@
     "start_title": "Answer questions about your symptoms and medical history to learn what to do next about COVID-19",
     "share_cta_skip": "No thanks, I don't want to share data"
   },
+  "callback_form": {
+    "well_get_in_touch": "We'll get in touch",
+    "fill_out_the_info": "Fill out the information below and a contact tracer from {{ healthAuthorityName }} will get in touch.",
+    "firstname": "First name",
+    "lastname": "Last name",
+    "phone_number_required": "Phone number (required)"
+  },
   "common": {
     "alert": "Alert",
     "back": "Back",
@@ -276,6 +283,7 @@
   },
   "screen_titles": {
     "about": "About",
+    "callback_form": "Callback Form",
     "debug": "Debug",
     "exposure_history": "Exposure History",
     "exposures": "Exposures",

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -9,6 +9,7 @@ import MenuScreen from "../Settings/Menu"
 import AboutScreen from "../Settings/About"
 import LegalScreen from "../Settings/Legal"
 import ENDebugMenu from "../Settings/ENDebugMenu"
+import CallbackFormScreen from "../More/CallbackForm"
 import ENLocalDiagnosisKeyScreen from "../Settings/ENLocalDiagnosisKeyScreen"
 import ExposureListDebugScreen from "../Settings/ExposureListDebugScreen"
 
@@ -46,6 +47,10 @@ const SettingsStack: FunctionComponent = () => {
         }}
       />
       <Stack.Screen name={SettingsScreens.About} component={AboutScreen} />
+      <Stack.Screen
+        name={SettingsScreens.CallbackForm}
+        component={CallbackFormScreen}
+      />
       <Stack.Screen
         name={SettingsScreens.Legal}
         component={LegalScreen}

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -106,9 +106,10 @@ export type SettingsScreen =
   | "Menu"
   | "About"
   | "Legal"
+  | "AffectedUserFlow"
+  | "CallbackForm"
   | "ENDebugMenu"
   | "ENSubmitDebugForm"
-  | "AffectedUserFlow"
   | "ExposureListDebugScreen"
   | "ENLocalDiagnosisKey"
 
@@ -118,6 +119,7 @@ export const SettingsScreens: {
   Menu: "Menu",
   About: "About",
   Legal: "Legal",
+  CallbackForm: "CallbackForm",
   ENDebugMenu: "ENDebugMenu",
   ENSubmitDebugForm: "ENSubmitDebugForm",
   AffectedUserFlow: "AffectedUserFlow",

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -166,7 +166,6 @@ export const body3: TextStyle = {
 }
 
 // Forms
-
 export const formInputLabel: TextStyle = {
   ...smallFont,
   color: Colors.primaryText,


### PR DESCRIPTION
Why:
----
There is a need for one of the authorities to submit a call back flow from inside the application. The form should be available when requested on build time and it should submit, name and phone number from a customer to that endpoint using provided credentials from the authority. The form will have a final spot inside the exposure details flow, but for starters we will have it on the settings screen.

Reviewers:
----
The form is currently complete but the data is not being pulled from the right spot(namely the date). There are still some flow missing, like from where to show the form and limits on who/how can it be used. This body of work is the form to gather the data and the communication with the backend service to submit such data.

This Commit:
----
- Add the callback form screen
- Add the helper to submit the form data to the provided endpoint via environment
- Use configuration to hide/show the form
- Move displayCallbackForm to configuration context

Co-authored-by: Devin Jameson <devin@thoughtbot.com>
Co-authored-by: Alejandro Dustet <alejandro@thoughtbot.com>
Co-authored-by: Matt Buckley <matt.buckley@rocketinsights.com>