### PR TITLE
Add scrollview around welcome screen

### DIFF
--- a/src/Onboarding/Welcome.tsx
+++ b/src/Onboarding/Welcome.tsx
@@ -1,5 +1,11 @@
 import React, { FunctionComponent } from "react"
-import { Image, StyleSheet, View, TouchableOpacity } from "react-native"
+import {
+  Image,
+  StyleSheet,
+  View,
+  TouchableOpacity,
+  ScrollView,
+} from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import LinearGradient from "react-native-linear-gradient"
@@ -51,50 +57,60 @@ const Welcome: FunctionComponent = () => {
   return (
     <>
       <StatusBar backgroundColor={Colors.primaryLightBackground} />
-      <GradientBackground
-        gradient={Colors.gradientPrimary10}
-        angleCenterY={0.75}
+      <ScrollView
+        alwaysBounceVertical={false}
+        contentContainerStyle={style.contentContainer}
       >
-        <View style={style.container}>
-          <TouchableOpacity
-            onPress={handleOnPressSelectLanguage}
-            style={style.languageButtonContainer}
-          >
-            <LinearGradient
-              colors={Colors.gradientPrimary10}
-              useAngle
-              angle={0}
-              angleCenter={{ x: 0.5, y: 0.5 }}
+        <GradientBackground
+          gradient={Colors.gradientPrimary10}
+          angleCenterY={0.75}
+        >
+          <View style={style.mainContentContainer}>
+            <TouchableOpacity
+              onPress={handleOnPressSelectLanguage}
               style={style.languageButtonContainer}
             >
-              <GlobalText style={style.languageButtonText}>
-                {languageName}
-              </GlobalText>
-            </LinearGradient>
-          </TouchableOpacity>
-          <View>
-            <Image
-              source={Images.WelcomeImage}
-              style={style.image}
-              accessible
-              accessibilityLabel={t("onboarding.welcome_image_label")}
+              <LinearGradient
+                colors={Colors.gradientPrimary10}
+                useAngle
+                angle={0}
+                angleCenter={{ x: 0.5, y: 0.5 }}
+                style={style.languageButtonContainer}
+              >
+                <GlobalText style={style.languageButtonText}>
+                  {languageName}
+                </GlobalText>
+              </LinearGradient>
+            </TouchableOpacity>
+            <View>
+              <Image
+                source={Images.WelcomeImage}
+                style={style.image}
+                accessible
+                accessibilityLabel={t("onboarding.welcome_image_label")}
+              />
+              <GlobalText style={style.mainText}>{welcomeMessage}</GlobalText>
+              <GlobalText style={style.mainText}>{applicationName}</GlobalText>
+            </View>
+            <Button
+              label={t("label.launch_get_started")}
+              onPress={() =>
+                navigation.navigate(OnboardingScreens.Introduction)
+              }
+              hasRightArrow
             />
-            <GlobalText style={style.mainText}>{welcomeMessage}</GlobalText>
-            <GlobalText style={style.mainText}>{applicationName}</GlobalText>
           </View>
-          <Button
-            label={t("label.launch_get_started")}
-            onPress={() => navigation.navigate(OnboardingScreens.Introduction)}
-            hasRightArrow
-          />
-        </View>
-      </GradientBackground>
+        </GradientBackground>
+      </ScrollView>
     </>
   )
 }
 
 const style = StyleSheet.create({
-  container: {
+  contentContainer: {
+    flexGrow: 1,
+  },
+  mainContentContainer: {
     flex: 1,
     paddingBottom: Spacing.xxHuge,
     paddingHorizontal: Spacing.large,


### PR DESCRIPTION
Why:
----

On smaller phones the call to action on the welcome screen can not be tapped because the image and text push it out the screen. We need this button to be reachable by users when it is not reachable.

How:
----

Adding a scroll view container where the container can grow to its full height will allow users on smaller screens to scroll down as they need to.

This Commit:
----

- Add scroll view container to welcome screen

Reviewers:
----

Not sure this is a long term solution to some text size issues but it allows users to move past this step.

![Large GIF (396x656)](https://user-images.githubusercontent.com/2413802/92746395-3ed0e700-f351-11ea-9c94-d55eb95398a2.gif) <img width="540" alt="Screen Shot 2020-09-10 at 10 23 18 AM" src="https://user-images.githubusercontent.com/2413802/92746426-47292200-f351-11ea-8edf-67404ffe80e8.png">
