### PR TITLE
Resolve promises after the user denies/accepts the permissions dialog

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/MainActivity.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/MainActivity.java
@@ -1,46 +1,17 @@
 package org.pathcheck.covidsafepaths;
 
-import android.app.Activity;
 import android.content.Intent;
-import android.content.IntentSender;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
-import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactContext;
-import com.google.android.gms.common.api.ApiException;
-import com.google.android.gms.nearby.exposurenotification.ExposureNotificationStatusCodes;
-import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey;
-import com.google.common.collect.ImmutableList;
-import com.google.common.io.BaseEncoding;
-import com.google.common.util.concurrent.FluentFuture;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.devio.rn.splashscreen.SplashScreen;
-import org.jetbrains.annotations.NotNull;
 import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
-import org.pathcheck.covidsafepaths.exposurenotifications.common.AppExecutors;
-import org.pathcheck.covidsafepaths.exposurenotifications.common.TaskToFutureAdapter;
-import org.pathcheck.covidsafepaths.exposurenotifications.dto.RNExposureKey;
-import org.pathcheck.covidsafepaths.exposurenotifications.network.DiagnosisKey;
-import org.pathcheck.covidsafepaths.exposurenotifications.utils.RequestCodes;
-import org.pathcheck.covidsafepaths.exposurenotifications.utils.Util;
-import org.threeten.bp.Duration;
 
 public class MainActivity extends ReactActivity {
-
-  private static final Duration GET_TEKS_TIMEOUT = Duration.ofSeconds(10);
-  private static final BaseEncoding BASE64 = BaseEncoding.base64();
-  private static final int DEFAULT_PERIOD = DiagnosisKey.DEFAULT_PERIOD;
-  private static final int DEFAULT_TRANSMISSION_RISK = 1;
-  private Promise getExposureKeysPromise;
 
   public static final String ACTION_LAUNCH_FROM_EXPOSURE_NOTIFICATION =
       "org.pathcheck.covidsafepaths.ACTION_LAUNCH_FROM_EXPOSURE_NOTIFICATION";
@@ -91,126 +62,11 @@ public class MainActivity extends ReactActivity {
         );
   }
 
-  public void showPermissionShareKeys(ApiException apiException) {
-    try {
-      apiException
-          .getStatus()
-          .startResolutionForResult(
-              this, RequestCodes.REQUEST_CODE_GET_TEMP_EXPOSURE_KEY_HISTORY);
-    } catch (IntentSender.SendIntentException e) {
-      getExposureKeysPromise.reject(e);
-    }
-  }
-
   @Override
   public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
-    onResolutionComplete(requestCode, resultCode);
-  }
-
-  /**
-   * Called when opt-in resolution is completed by user.
-   *
-   * <p>Modeled after {@code Activity#onActivityResult} as that's how the API sends callback to
-   * apps.
-   */
-  public void onResolutionComplete(int requestCode, int resultCode) {
-    if (requestCode == RequestCodes.REQUEST_CODE_START_EXPOSURE_NOTIFICATION) {
-      ReactContext context = getReactContext();
-      ExposureNotificationClientWrapper exposureNotificationClient =
-          ExposureNotificationClientWrapper.get(context);
-      if (resultCode == Activity.RESULT_OK) {
-        exposureNotificationClient.start(context);
-      } else {
-        exposureNotificationClient.onExposureNotificationStateChanged(context, false);
-      }
-    } else if (requestCode == RequestCodes.REQUEST_CODE_GET_TEMP_EXPOSURE_KEY_HISTORY) {
-      if (resultCode == RESULT_OK) {
-        getExposureKeys(getExposureKeysPromise);
-      } else {
-        // Don't share.
-        getExposureKeysPromise.reject("CANCEL", "Operation cancelled by the user");
-      }
-    }
-  }
-
-  public void getExposureKeys(final Promise promise) {
-    getExposureKeysPromise = promise;
-    FluentFuture<ImmutableList<DiagnosisKey>> getKeys =
-        FluentFuture.from(getRecentKeys())
-            .transform(
-                this::toDiagnosisKeysWithTransmissionRisk, AppExecutors.getLightweightExecutor());
-
-    Futures.addCallback(
-        getKeys,
-        new FutureCallback<ImmutableList<DiagnosisKey>>() {
-          @Override
-          public void onSuccess(ImmutableList<DiagnosisKey> shared) {
-            final List<RNExposureKey> exposureKeys = new ArrayList<>();
-
-            for (DiagnosisKey k : shared) {
-              final String key = BASE64.encode(k.getKeyBytes());
-              final int rollingStartNumber = k.getIntervalNumber();
-
-              exposureKeys.add(new RNExposureKey(
-                  key,
-                  DEFAULT_PERIOD,
-                  rollingStartNumber,
-                  DEFAULT_TRANSMISSION_RISK
-              ));
-            }
-
-            getExposureKeysPromise.resolve(Util.convertListToWritableArray(exposureKeys));
-          }
-
-          @Override
-          public void onFailure(@NotNull Throwable exception) {
-            if (!(exception instanceof ApiException)) {
-              getExposureKeysPromise.reject(exception);
-              return;
-            }
-            ApiException apiException = (ApiException) exception;
-            if (apiException.getStatusCode()
-                == ExposureNotificationStatusCodes.RESOLUTION_REQUIRED) {
-              showPermissionShareKeys(apiException);
-            } else {
-              getExposureKeysPromise.reject(exception);
-            }
-          }
-        },
-        AppExecutors.getLightweightExecutor());
-  }
-
-  /**
-   * Gets recent (initially 14 days) Temporary Exposure Keys from Google Play Services.
-   */
-  private ListenableFuture<List<TemporaryExposureKey>> getRecentKeys() {
-    return TaskToFutureAdapter.getFutureWithTimeout(
-        ExposureNotificationClientWrapper.get(this).getTemporaryExposureKeyHistory(),
-        GET_TEKS_TIMEOUT.toMillis(),
-        TimeUnit.MILLISECONDS,
-        AppExecutors.getScheduledExecutor());
-  }
-
-  /**
-   * Transforms from EN API's TEK object to our network package's expression of it, applying a
-   * default transmission risk. This default TR is temporary, while we determine that part of the EN
-   * API's contract.
-   */
-  private ImmutableList<DiagnosisKey> toDiagnosisKeysWithTransmissionRisk(
-      List<TemporaryExposureKey> recentKeys) {
-    ImmutableList.Builder<DiagnosisKey> builder = new ImmutableList.Builder<>();
-    for (TemporaryExposureKey k : recentKeys) {
-      builder.add(
-          DiagnosisKey.newBuilder()
-              .setKeyBytes(k.getKeyData())
-              .setIntervalNumber(k.getRollingStartIntervalNumber())
-              .setRollingPeriod(k.getRollingPeriod())
-              // Accepting the default transmission risk for now, which the DiagnosisKey.Builder
-              // comes with pre-set.
-              .build());
-    }
-    return builder.build();
+    ExposureNotificationClientWrapper.get(this)
+        .onPermissionDialogResult(getReactContext(), requestCode, resultCode == RESULT_OK);
   }
 
   @Nullable

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/DiagnosisKey.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/DiagnosisKey.java
@@ -56,11 +56,17 @@ public abstract class DiagnosisKey {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setKey(ByteArrayValue key);
+
     public abstract Builder setIntervalNumber(int intervalNumber);
+
     public abstract Builder setRollingPeriod(int rollingPeriod);
+
     public abstract Builder setTransmissionRisk(int risk);
+
     abstract int getRollingPeriod();
+
     abstract int getTransmissionRisk();
+
     abstract DiagnosisKey autoBuild();
 
     public DiagnosisKey build() {

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/DiagnosisKey.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/DiagnosisKey.java
@@ -31,8 +31,9 @@ import org.jetbrains.annotations.NotNull;
 public abstract class DiagnosisKey {
   private static final BaseEncoding BASE16 = BaseEncoding.base16().lowerCase();
   private static final BaseEncoding BASE64 = BaseEncoding.base64();
-  // The number of 10-minute intervals the key is valid for
+  // The number of 10-minute intervals the key is valid for, by default.
   public static final int DEFAULT_PERIOD = 144;
+  private static final int DEFAULT_TRANSMISSION_RISK = 1;
 
   public abstract ByteArrayValue getKey();
 
@@ -40,8 +41,12 @@ public abstract class DiagnosisKey {
 
   public abstract int getRollingPeriod();
 
+  public abstract int getTransmissionRisk();
+
   public static Builder newBuilder() {
-    return new AutoValue_DiagnosisKey.Builder().setRollingPeriod(DEFAULT_PERIOD);
+    return new AutoValue_DiagnosisKey.Builder()
+        .setRollingPeriod(DEFAULT_PERIOD)
+        .setTransmissionRisk(DEFAULT_TRANSMISSION_RISK);
   }
 
   public byte[] getKeyBytes() {
@@ -51,12 +56,20 @@ public abstract class DiagnosisKey {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setKey(ByteArrayValue key);
-
     public abstract Builder setIntervalNumber(int intervalNumber);
-
     public abstract Builder setRollingPeriod(int rollingPeriod);
+    public abstract Builder setTransmissionRisk(int risk);
+    abstract int getRollingPeriod();
+    abstract int getTransmissionRisk();
+    abstract DiagnosisKey autoBuild();
 
-    public abstract DiagnosisKey build();
+    public DiagnosisKey build() {
+      // Both transmission risk and rolling period need to be positive ints. If they're zero, they
+      // probably were unset in the source data, so we use defaults.
+      setTransmissionRisk(getTransmissionRisk() > 0 ? getTransmissionRisk() : DEFAULT_TRANSMISSION_RISK);
+      setRollingPeriod(getRollingPeriod() > 0 ? getRollingPeriod() : DEFAULT_PERIOD);
+      return autoBuild();
+    }
 
     public Builder setKeyBytes(byte[] keyBytes) {
       setKey(new ByteArrayValue(keyBytes));
@@ -71,6 +84,7 @@ public abstract class DiagnosisKey {
         .add("key:base64", "[" + BASE64.encode(getKeyBytes()) + "]")
         .add("interval_number", getIntervalNumber())
         .add("rolling_period", getRollingPeriod())
+        .add("transmission_risk", getTransmissionRisk())
         .toString();
   }
 

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureKeyModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureKeyModule.java
@@ -1,19 +1,32 @@
 package org.pathcheck.covidsafepaths.exposurenotifications.reactmodules;
 
-import android.app.Activity;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.module.annotations.ReactModule;
+import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.BaseEncoding;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nonnull;
-import org.pathcheck.covidsafepaths.MainActivity;
+import org.jetbrains.annotations.NotNull;
+import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
+import org.pathcheck.covidsafepaths.exposurenotifications.common.AppExecutors;
+import org.pathcheck.covidsafepaths.exposurenotifications.dto.RNExposureKey;
+import org.pathcheck.covidsafepaths.exposurenotifications.network.DiagnosisKey;
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.RealmSecureStorageBte;
+import org.pathcheck.covidsafepaths.exposurenotifications.utils.Util;
 
 @SuppressWarnings("unused")
 @ReactModule(name = ExposureKeyModule.MODULE_NAME)
 public class ExposureKeyModule extends ReactContextBaseJavaModule {
   public static final String MODULE_NAME = "ExposureKeyModule";
+  private static final BaseEncoding BASE64 = BaseEncoding.base64();
 
   public ExposureKeyModule(ReactApplicationContext context) {
     super(context);
@@ -27,10 +40,57 @@ public class ExposureKeyModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void fetchExposureKeys(final Promise promise) {
-    Activity activity = getCurrentActivity();
-    if (activity instanceof MainActivity) {
-      ((MainActivity) activity).getExposureKeys(promise);
+    ListenableFuture<List<TemporaryExposureKey>> future =
+        ExposureNotificationClientWrapper.get(getReactApplicationContext())
+            .requestPermissionToGetExposureKeys(getReactApplicationContext());
+
+    FutureCallback<List<TemporaryExposureKey>> callback = new FutureCallback<List<TemporaryExposureKey>>() {
+      @Override
+      public void onSuccess(List<TemporaryExposureKey> result) {
+        final List<RNExposureKey> exposureKeys = new ArrayList<>();
+
+        List<DiagnosisKey> diagnosisKeys = toDiagnosisKeysWithTransmissionRisk(result);
+        for (DiagnosisKey k : diagnosisKeys) {
+          final String key = BASE64.encode(k.getKeyBytes());
+
+          exposureKeys.add(new RNExposureKey(
+              key,
+              k.getRollingPeriod(),
+              k.getIntervalNumber(),
+              k.getTransmissionRisk()
+          ));
+        }
+
+        promise.resolve(Util.convertListToWritableArray(exposureKeys));
+      }
+
+      @Override
+      public void onFailure(@NotNull Throwable exception) {
+        promise.reject(exception);
+      }
+    };
+    Futures.addCallback(future, callback, AppExecutors.getLightweightExecutor());
+  }
+
+  /**
+   * Transforms from EN API's TEK object to our network package's expression of it, applying a
+   * default transmission risk. This default TR is temporary, while we determine that part of the EN
+   * API's contract.
+   */
+  private List<DiagnosisKey> toDiagnosisKeysWithTransmissionRisk(
+      List<TemporaryExposureKey> recentKeys) {
+    ImmutableList.Builder<DiagnosisKey> builder = new ImmutableList.Builder<>();
+    for (TemporaryExposureKey k : recentKeys) {
+      builder.add(
+          DiagnosisKey.newBuilder()
+              .setKeyBytes(k.getKeyData())
+              .setIntervalNumber(k.getRollingStartIntervalNumber())
+              .setRollingPeriod(k.getRollingPeriod())
+              // Accepting the default transmission risk for now, which the DiagnosisKey.Builder
+              // comes with pre-set.
+              .build());
     }
+    return builder.build();
   }
 
   @ReactMethod

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/utils/RequestCodes.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/utils/RequestCodes.java
@@ -4,7 +4,6 @@ public final class RequestCodes {
 
   public static final int REQUEST_CODE_START_EXPOSURE_NOTIFICATION = 1111;
   public static final int REQUEST_CODE_GET_TEMP_EXPOSURE_KEY_HISTORY = 2222;
-  public static final int REQUEST_GET_DIAGNOSIS_KEYS = 4444;
 
   private RequestCodes() {
   }


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
There are some GAEN API methods that require permission from the user.
We were resolving JS promises before the user accepted/denied that permissions Dialog, and that wasn't reflecting the correct state.

This PR waits until the dialog is accepted/denied to return the result to the JS layer.
It mostly impacts some options in the debug menu and shouldn't have any impact in the main flow.

This PR also:
- Moves some code from `MainActivity` to `ExposureNotificationsClientWrapper`
-  Uses the `rollingPeriod` returned by the API instead of a default value