### PR TITLE
Check for Already Stored Exposures on a Given Date

### DIFF
--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -337,9 +337,10 @@ final class ExposureManager: NSObject {
       var newExposures: [Exposure] = []
       if let summary = exposureSummary {
         summary.daySummaries.forEach { (daySummary) in
-          if daySummary.isAboveScoreThreshold(with: exposureConfiguraton) {
+          if daySummary.isAboveScoreThreshold(with: exposureConfiguraton) &&
+              self.btSecureStorage.canStoreExposure(for: daySummary.date) {
             let exposure = Exposure(id: UUID().uuidString,
-                                    date: daySummary.date.posixRepresentation)
+                                    date: daySummary.date.toMidnight.posixRepresentation)
             newExposures.append(exposure)
           }
         }
@@ -588,7 +589,7 @@ private extension ExposureManager {
         } else {
           let newExposures = (exposures ?? []).map { exposure in
             Exposure(id: UUID().uuidString,
-                     date: exposure.date.posixRepresentation)
+                     date: exposure.date.toMidnight.posixRepresentation)
           }
           fullfill(newExposures)
         }

--- a/ios/BT/Extensions/Foundation/Date+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Date+Extensions.swift
@@ -2,9 +2,14 @@ extension Date {
   var posixRepresentation: Int {
     Int(timeIntervalSince1970) * 1000
   }
-
+  
   static func hourDifference(from startDate: Date, to endDate: Date) -> Int {
     Calendar.current.dateComponents([.hour], from: startDate, to: endDate).hour ?? 0
   }
-
+  
+  var toMidnight: Date {
+    let cal = Calendar(identifier: .gregorian)
+    return cal.startOfDay(for: self)
+  }
+  
 }

--- a/ios/BT/Storage/BTSecureStorage.swift
+++ b/ios/BT/Storage/BTSecureStorage.swift
@@ -81,6 +81,11 @@ class BTSecureStorage: SafePathsSecureStorage {
     }
   }
 
+  func canStoreExposure(for date: Date) -> Bool {
+    let posixToMidnight = date.toMidnight.posixRepresentation
+    return !userState.exposures.map { $0.date }.contains(posixToMidnight)
+  }
+
   @Persisted(keyPath: .remainingDailyFileProcessingCapacity, notificationName: .remainingDailyFileProcessingCapacityDidChange, defaultValue: Constants.dailyFileProcessingCapacity)
   var remainingDailyFileProcessingCapacity: Int
 


### PR DESCRIPTION
Per @lmartensson a user should not be notified for exposures on days for which they have already been notified. This PR checks the database on iOS for existing exposures on a given date before notifying the user and storing the exposure.