### PR TITLE
Add learn more URL when it is present

### DIFF
--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -11,6 +11,7 @@ export interface Configuration {
   displaySelfAssessment: boolean
   displaySymptomChecker: boolean
   healthAuthorityAdviceUrl: string
+  healthAuthorityLearnMoreUrl: string
   healthAuthorityEulaUrl: string | null
   healthAuthorityName: string
   healthAuthorityPrivacyPolicyUrl: string
@@ -27,6 +28,7 @@ const initialState = {
   displaySelfAssessment: false,
   displaySymptomChecker: false,
   healthAuthorityAdviceUrl: "",
+  healthAuthorityLearnMoreUrl: "",
   healthAuthorityEulaUrl: null,
   healthAuthorityName: "",
   healthAuthorityPrivacyPolicyUrl: "",
@@ -39,6 +41,7 @@ const ConfigurationContext = createContext<Configuration>(initialState)
 const ConfigurationProvider: FunctionComponent = ({ children }) => {
   const {
     AUTHORITY_ADVICE_URL: healthAuthorityAdviceUrl,
+    LEARN_MORE_URL: healthAuthorityLearnMoreUrl,
     GAEN_AUTHORITY_NAME: healthAuthorityName,
     PRIVACY_POLICY_URL: healthAuthorityPrivacyPolicyUrl,
     LEGAL_PRIVACY_POLICY_URL: legalPrivacyPolicyUrl,
@@ -68,6 +71,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         displaySelfAssessment,
         displaySymptomChecker,
         healthAuthorityAdviceUrl,
+        healthAuthorityLearnMoreUrl,
         healthAuthorityEulaUrl: eulaUrl || null,
         healthAuthorityName,
         healthAuthorityLegalPrivacyPolicyUrl: legalPrivacyPolicyUrl || null,

--- a/src/ExposureHistory/History/NoExposures.spec.tsx
+++ b/src/ExposureHistory/History/NoExposures.spec.tsx
@@ -24,29 +24,54 @@ describe("NoExposures", () => {
     expect(queryByText("Wash your hands often")).not.toBeNull()
   })
 
-  describe("when the HA has provided a link", () => {
-    it("prompts the user to see HA guidance", () => {
-      expect.assertions(2)
-      const healthAuthorityAdviceUrl = "https://www.health.state.mn.us/"
-      const healthAuthorityName = "healthAuthorityName"
-      const openURLSpy = jest.spyOn(Linking, "openURL")
+  describe("clicking the Learn more link", () => {
+    describe("when the health authority has provided a learn more url", () => {
+      it("prompts the user to see HA guidance", () => {
+        expect.assertions(2)
+        const healthAuthorityLearnMoreUrl = "https://www.example.com/"
+        const healthAuthorityName = "healthAuthorityName"
+        const openURLSpy = jest.spyOn(Linking, "openURL")
 
-      const { queryByText, getByText } = render(
-        <ConfigurationContext.Provider
-          value={factories.configurationContext.build({
-            healthAuthorityAdviceUrl,
-            healthAuthorityName,
-          })}
-        >
-          <NoExposures />
-        </ConfigurationContext.Provider>,
-      )
+        const { queryByText, getByText } = render(
+          <ConfigurationContext.Provider
+            value={factories.configurationContext.build({
+              healthAuthorityLearnMoreUrl,
+              healthAuthorityName,
+            })}
+          >
+            <NoExposures />
+          </ConfigurationContext.Provider>,
+        )
 
-      expect(
-        queryByText(`Review guidance from ${healthAuthorityName}`),
-      ).not.toBeNull()
-      fireEvent.press(getByText("Learn More"))
-      expect(openURLSpy).toHaveBeenCalledWith(healthAuthorityAdviceUrl)
+        expect(
+          queryByText(`Review guidance from ${healthAuthorityName}`),
+        ).not.toBeNull()
+        fireEvent.press(getByText("Learn More"))
+        expect(openURLSpy).toHaveBeenCalledWith(healthAuthorityLearnMoreUrl)
+      })
+    })
+
+    describe("when the health authority has not provided a link", () => {
+      it("does not display a Learn More link", () => {
+        expect.assertions(1)
+        const healthAuthorityAdviceUrl = ""
+        const healthAuthorityLearnMoreUrl = ""
+        const healthAuthorityName = "healthAuthorityName"
+
+        const { queryByText } = render(
+          <ConfigurationContext.Provider
+            value={factories.configurationContext.build({
+              healthAuthorityAdviceUrl,
+              healthAuthorityLearnMoreUrl,
+              healthAuthorityName,
+            })}
+          >
+            <NoExposures />
+          </ConfigurationContext.Provider>,
+        )
+
+        expect(queryByText("Learn More")).toBeNull()
+      })
     })
   })
 })

--- a/src/ExposureHistory/History/NoExposures.tsx
+++ b/src/ExposureHistory/History/NoExposures.tsx
@@ -29,11 +29,11 @@ const HealthGuidelines: FunctionComponent = () => {
   const { t } = useTranslation()
   const {
     healthAuthorityName,
-    healthAuthorityAdviceUrl,
+    healthAuthorityLearnMoreUrl,
   } = useConfigurationContext()
 
   const handleOnPressHALink = () => {
-    Linking.openURL(healthAuthorityAdviceUrl)
+    Linking.openURL(healthAuthorityLearnMoreUrl)
   }
 
   return (
@@ -41,7 +41,7 @@ const HealthGuidelines: FunctionComponent = () => {
       <GlobalText style={style.cardHeaderText}>
         {t("exposure_history.protect_yourself_and_others")}
       </GlobalText>
-      {Boolean(healthAuthorityAdviceUrl) && (
+      {Boolean(healthAuthorityLearnMoreUrl) && (
         <>
           <GlobalText style={style.cardSubheaderText}>
             {t("exposure_history.review_guidance_from_ha", {

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -10,6 +10,7 @@ export default Factory.define<Configuration>(() => ({
   displayCallbackForm: false,
   displaySymptomChecker: false,
   healthAuthorityAdviceUrl: "authorityAdviceUrl",
+  healthAuthorityLearnMoreUrl: "authorityLearnMoreUrl",
   healthAuthorityEulaUrl: "healthAuthorityEulaUrl",
   healthAuthorityName: "authorityName",
   healthAuthorityPrivacyPolicyUrl: "authorityPrivacyPolicyUrl",


### PR DESCRIPTION
## Description:
We want health authorities to be able to specify a "learn more" url that is different than the general authority advice url. This PR reads the LEARN_MORE_URL value from the environment, and sets it on the configuration context. If a learn more url is not provided, it default to the authority advice url.

#### Linked issues:

[GAEN-263](https://pathcheck.atlassian.net/jira/software/projects/GAEN/boards/33/?selectedIssue=GAEN-263)

### TODO:
Update `mobile_resources_commit` after [update](https://github.com/Path-Check/pathcheck-mobile-resources/pull/55) merges.
