### PR TITLE
Show the callback form links on exposure details

### DIFF
--- a/src/ExposureHistory/ExposureDetail.spec.tsx
+++ b/src/ExposureHistory/ExposureDetail.spec.tsx
@@ -1,11 +1,13 @@
 import React from "react"
 import { Linking } from "react-native"
 import { render, fireEvent } from "@testing-library/react-native"
+import { useRoute, useNavigation } from "@react-navigation/native"
+
 import { DateTimeUtils } from "../utils"
 import { factories } from "../factories"
 import ExposureDetail from "./ExposureDetail"
-import { useRoute } from "@react-navigation/native"
 import { ConfigurationContext } from "../ConfigurationContext"
+import { Stacks, SettingsScreens } from "../navigation"
 
 jest.mock("@react-navigation/native")
 describe("ExposureDetail", () => {
@@ -72,6 +74,93 @@ describe("ExposureDetail", () => {
       fireEvent.press(nextStepsButton)
 
       expect(openURLSpy).toHaveBeenCalledWith(healthAuthorityAdviceUrl)
+    })
+  })
+
+  describe("when the health authority does not provide a link", () => {
+    it("does not displays the next steps link", () => {
+      const healthAuthorityAdviceUrl = ""
+      const { queryByLabelText } = render(
+        <ConfigurationContext.Provider
+          value={factories.configurationContext.build({
+            healthAuthorityAdviceUrl,
+          })}
+        >
+          <ExposureDetail />
+        </ConfigurationContext.Provider>,
+      )
+      expect(queryByLabelText("Next Steps")).toBeNull()
+    })
+  })
+
+  describe("when the health authority does not have a callback form", () => {
+    it("only shows the guidance information", () => {
+      const healthAuthorityName = "healthAuthorityName"
+      const { getByText, queryByLabelText } = render(
+        <ConfigurationContext.Provider
+          value={factories.configurationContext.build({
+            displayCallbackForm: false,
+            healthAuthorityName,
+          })}
+        >
+          <ExposureDetail />
+        </ConfigurationContext.Provider>,
+      )
+
+      expect(queryByLabelText("Speak with a contact tracer")).toBeNull()
+      expect(
+        getByText(`See guidance from ${healthAuthorityName}.`),
+      ).toBeDefined()
+    })
+  })
+
+  describe("when the health authority has a callback form", () => {
+    it("shows info about what to do next and no general guidance", () => {
+      const healthAuthorityName = "healthAuthorityName"
+      const { getByText, queryByText } = render(
+        <ConfigurationContext.Provider
+          value={factories.configurationContext.build({
+            displayCallbackForm: true,
+            healthAuthorityName,
+          })}
+        >
+          <ExposureDetail />
+        </ConfigurationContext.Provider>,
+      )
+
+      expect(
+        getByText(
+          `Schedule a call to get support from a contact tracer from the ${healthAuthorityName}.`,
+        ),
+      ).toBeDefined()
+      expect(
+        queryByText(`See guidance from ${healthAuthorityName}.`),
+      ).toBeNull()
+    })
+
+    it("allow user to navigate to the form or the connect screen", () => {
+      const navigateSpy = jest.fn()
+      ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+      const { getByLabelText } = render(
+        <ConfigurationContext.Provider
+          value={factories.configurationContext.build({
+            displayCallbackForm: true,
+          })}
+        >
+          <ExposureDetail />
+        </ConfigurationContext.Provider>,
+      )
+
+      const showCallbackFormAction = getByLabelText(
+        "Speak with a contact tracer",
+      )
+      fireEvent.press(showCallbackFormAction)
+      expect(navigateSpy).toHaveBeenCalledWith(Stacks.Settings, {
+        screen: SettingsScreens.CallbackForm,
+      })
+      const callLaterAction = getByLabelText("Call later")
+      fireEvent.press(callLaterAction)
+      expect(navigateSpy).toHaveBeenCalledWith(Stacks.Connect)
     })
   })
 })

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -1,18 +1,17 @@
 import React, { FunctionComponent } from "react"
-import { View, ScrollView, StyleSheet, Linking } from "react-native"
+import { View, ScrollView, StyleSheet } from "react-native"
 import { RouteProp, useRoute } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 
 import { ExposureHistoryStackParamList } from "../navigation"
-import { GlobalText, Button } from "../components"
+import { GlobalText } from "../components"
 import { useStatusBarEffect } from "../navigation"
 import { ExposureDatum, exposureWindowBucket } from "../exposure"
-import { useConnectionStatus } from "../hooks/useConnectionStatus"
 
 import { Colors, Iconography, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
-import { useConfigurationContext } from "../ConfigurationContext"
+import ExposureActions from "./detail/ExposureActions"
 
 const ExposureDetail: FunctionComponent = () => {
   const route = useRoute<
@@ -20,12 +19,6 @@ const ExposureDetail: FunctionComponent = () => {
   >()
   useStatusBarEffect("light-content", Colors.headerBackground)
   const { t } = useTranslation()
-  const {
-    healthAuthorityName,
-    healthAuthorityAdviceUrl,
-  } = useConfigurationContext()
-
-  const isInternetReachable = useConnectionStatus()
 
   const { exposureDatum } = route.params
 
@@ -45,11 +38,6 @@ const ExposureDetail: FunctionComponent = () => {
       }
     }
   }
-  const handleOnPressNextStep = () => {
-    Linking.openURL(healthAuthorityAdviceUrl)
-  }
-
-  const displayNextStepsLink = healthAuthorityAdviceUrl !== ""
 
   return (
     <ScrollView style={style.container}>
@@ -75,74 +63,11 @@ const ExposureDetail: FunctionComponent = () => {
         </GlobalText>
       </View>
       <View style={style.bottomContainer}>
-        <GlobalText style={style.bottomHeaderText}>
-          {t("exposure_history.exposure_detail.ha_guidance_header")}
-        </GlobalText>
-        <GlobalText style={style.bottomSubheaderText}>
-          {t("exposure_history.exposure_detail.ha_guidance_subheader", {
-            healthAuthorityName,
-          })}
-        </GlobalText>
-        <View style={style.recommendations}>
-          <RecommendationBubble
-            icon={Icons.IsolateBubbles}
-            text={t("exposure_history.exposure_detail.isolate")}
-          />
-          <RecommendationBubble
-            icon={Icons.Mask}
-            text={t("exposure_history.exposure_detail.wear_a_mask")}
-          />
-          <RecommendationBubble
-            icon={Icons.SixFeet}
-            text={t("exposure_history.exposure_detail.6ft_apart")}
-          />
-          <RecommendationBubble
-            icon={Icons.WashHands}
-            text={t("exposure_history.exposure_detail.wash_your_hands")}
-          />
-        </View>
-        {displayNextStepsLink && (
-          <View style={style.buttonContainer}>
-            <Button
-              onPress={handleOnPressNextStep}
-              label={t("exposure_history.exposure_detail.next_steps")}
-              disabled={!isInternetReachable}
-              hasRightArrow
-            />
-          </View>
-        )}
-        {!isInternetReachable && (
-          <GlobalText style={style.connectivityWarningText}>
-            {t("exposure_history.no_connectivity_message")}
-          </GlobalText>
-        )}
+        <ExposureActions />
       </View>
     </ScrollView>
   )
 }
-
-type RecommendationBubbleProps = {
-  text: string
-  icon: string
-}
-const RecommendationBubble: FunctionComponent<RecommendationBubbleProps> = ({
-  text,
-  icon,
-}) => {
-  return (
-    <View style={style.recommendation}>
-      <View style={style.recommendationBubbleCircle}>
-        <SvgXml
-          xml={icon}
-          width={Iconography.small}
-          height={Iconography.small}
-        />
-      </View>
-      <GlobalText style={style.recommendationText}>{text}</GlobalText>
-    </View>
-  )
-}
-
 const style = StyleSheet.create({
   container: {
     flex: 1,
@@ -178,42 +103,6 @@ const style = StyleSheet.create({
     paddingTop: Spacing.medium,
     paddingBottom: Spacing.xLarge,
     marginTop: Spacing.xxSmall,
-  },
-  bottomHeaderText: {
-    ...Typography.header5,
-    marginBottom: Spacing.xxSmall,
-  },
-  bottomSubheaderText: {
-    ...Typography.body2,
-    color: Colors.neutral100,
-    marginBottom: Spacing.medium,
-  },
-  recommendations: {
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "space-between",
-    marginBottom: Spacing.xxxLarge,
-  },
-  recommendation: {
-    display: "flex",
-    alignItems: "center",
-  },
-  recommendationBubbleCircle: {
-    ...Iconography.smallIcon,
-    borderRadius: 50,
-    backgroundColor: Colors.primaryLightBackground,
-    padding: Spacing.xLarge,
-    marginBottom: Spacing.xSmall,
-  },
-  recommendationText: {
-    ...Typography.body3,
-  },
-  buttonContainer: {
-    alignSelf: "flex-start",
-  },
-  connectivityWarningText: {
-    ...Typography.error,
-    marginTop: Spacing.small,
   },
 })
 

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -1,0 +1,203 @@
+import React, { FunctionComponent } from "react"
+import { View, StyleSheet, Linking, TouchableOpacity } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { useTranslation } from "react-i18next"
+import { SvgXml } from "react-native-svg"
+
+import { SettingsScreens, Stacks } from "../../navigation"
+import { GlobalText, Button } from "../../components"
+import { useConnectionStatus } from "../../hooks/useConnectionStatus"
+
+import { Colors, Iconography, Spacing, Typography, Buttons } from "../../styles"
+import { Icons } from "../../assets"
+import { useConfigurationContext } from "../../ConfigurationContext"
+
+const ExposureActions: FunctionComponent = () => {
+  const { t } = useTranslation()
+  const isInternetReachable = useConnectionStatus()
+  const {
+    displayCallbackForm,
+    healthAuthorityName,
+    healthAuthorityAdviceUrl,
+  } = useConfigurationContext()
+
+  const handleOnPressNextStep = () => {
+    Linking.openURL(healthAuthorityAdviceUrl)
+  }
+
+  const displayNextStepsLink = healthAuthorityAdviceUrl !== ""
+
+  return (
+    <>
+      <GlobalText style={style.bottomHeaderText}>
+        {t("exposure_history.exposure_detail.ha_guidance_header")}
+      </GlobalText>
+      {displayCallbackForm ? (
+        <RequestCallBackActions healthAuthorityName={healthAuthorityName} />
+      ) : (
+        <>
+          <GlobalText style={style.bottomSubheaderText}>
+            {t("exposure_history.exposure_detail.ha_guidance_subheader", {
+              healthAuthorityName,
+            })}
+          </GlobalText>
+          <View style={style.recommendations}>
+            <RecommendationBubble
+              icon={Icons.IsolateBubbles}
+              text={t("exposure_history.exposure_detail.isolate")}
+            />
+            <RecommendationBubble
+              icon={Icons.Mask}
+              text={t("exposure_history.exposure_detail.wear_a_mask")}
+            />
+            <RecommendationBubble
+              icon={Icons.SixFeet}
+              text={t("exposure_history.exposure_detail.6ft_apart")}
+            />
+            <RecommendationBubble
+              icon={Icons.WashHands}
+              text={t("exposure_history.exposure_detail.wash_your_hands")}
+            />
+          </View>
+          {displayNextStepsLink && (
+            <View style={style.buttonContainer}>
+              <Button
+                onPress={handleOnPressNextStep}
+                label={t("exposure_history.exposure_detail.next_steps")}
+                disabled={!isInternetReachable}
+                hasRightArrow
+              />
+            </View>
+          )}
+          {!isInternetReachable && (
+            <GlobalText style={style.connectivityWarningText}>
+              {t("exposure_history.no_connectivity_message")}
+            </GlobalText>
+          )}
+        </>
+      )}
+    </>
+  )
+}
+
+type RequestCallBackActionsProps = {
+  healthAuthorityName: string
+}
+
+const RequestCallBackActions: FunctionComponent<RequestCallBackActionsProps> = ({
+  healthAuthorityName,
+}) => {
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+
+  const navigateToCallbackForm = () => {
+    navigation.navigate(Stacks.Settings, {
+      screen: SettingsScreens.CallbackForm,
+    })
+  }
+
+  const navigateToConnectStack = () => {
+    navigation.navigate(Stacks.Connect)
+  }
+  return (
+    <>
+      <GlobalText style={style.bottomSubheaderText}>
+        {t("exposure_history.exposure_detail.schedule_callback", {
+          healthAuthorityName,
+        })}
+      </GlobalText>
+      <Button
+        customButtonStyle={style.requestCallbackButton}
+        onPress={navigateToCallbackForm}
+        label={t("exposure_history.exposure_detail.speak_with_contact_tracer")}
+        hasRightArrow
+      />
+      <TouchableOpacity
+        onPress={navigateToConnectStack}
+        accessibilityLabel={t("exposure_history.exposure_detail.call_later")}
+        style={style.callLaterButton}
+      >
+        <GlobalText style={style.callLaterButtonText}>
+          {t("exposure_history.exposure_detail.call_later")}
+        </GlobalText>
+      </TouchableOpacity>
+    </>
+  )
+}
+
+type RecommendationBubbleProps = {
+  text: string
+  icon: string
+}
+const RecommendationBubble: FunctionComponent<RecommendationBubbleProps> = ({
+  text,
+  icon,
+}) => {
+  return (
+    <View style={style.recommendation}>
+      <View style={style.recommendationBubbleCircle}>
+        <SvgXml
+          xml={icon}
+          width={Iconography.small}
+          height={Iconography.small}
+        />
+      </View>
+      <GlobalText style={style.recommendationText}>{text}</GlobalText>
+    </View>
+  )
+}
+
+const style = StyleSheet.create({
+  bottomHeaderText: {
+    ...Typography.header5,
+    marginBottom: Spacing.xxSmall,
+  },
+  bottomSubheaderText: {
+    ...Typography.body2,
+    color: Colors.neutral100,
+    marginBottom: Spacing.medium,
+  },
+  recommendations: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: Spacing.xxxLarge,
+  },
+  recommendation: {
+    display: "flex",
+    alignItems: "center",
+  },
+  recommendationBubbleCircle: {
+    ...Iconography.smallIcon,
+    borderRadius: 50,
+    backgroundColor: Colors.primaryLightBackground,
+    padding: Spacing.xLarge,
+    marginBottom: Spacing.xSmall,
+  },
+  recommendationText: {
+    ...Typography.body3,
+  },
+  buttonContainer: {
+    alignSelf: "flex-start",
+  },
+  connectivityWarningText: {
+    ...Typography.error,
+    marginTop: Spacing.small,
+  },
+  requestCallbackButton: {
+    marginBottom: Spacing.small,
+    padding: Spacing.small,
+  },
+  callLaterButton: {
+    ...Buttons.primary,
+    backgroundColor: Colors.secondary50,
+    minWidth: "100%",
+  },
+  callLaterButtonText: {
+    ...Typography.body1,
+    ...Typography.bold,
+    color: Colors.primary100,
+  },
+})
+
+export default ExposureActions

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -118,7 +118,10 @@
       "isolate": "Isolate",
       "next_steps": "Next Steps",
       "wash_your_hands": "Wash your hands",
-      "wear_a_mask": "Wear a mask"
+      "wear_a_mask": "Wear a mask",
+      "schedule_callback": "Schedule a call to get support from a contact tracer from the {{healthAuthorityName}}.",
+      "speak_with_contact_tracer": "Speak with a contact tracer",
+      "call_later": "Call later"
     },
     "exposure_window": {
       "four_to_six_days_ago": "4 to 6 days ago",


### PR DESCRIPTION
Why:
----

When an authority has a call back form available to its users. This should be the default action for them when they are reviewing an exposure detail.

This Commit:
----
- Add the component for the callback form links
- Add basic styles

Reviewers:
----

Designs are the first pass, and there is still work pending in order to move the callback form from the settings stack to the connect stack.

<img width="300" alt="Screen Shot 2020-09-14 at 3 49 22 PM" src="https://user-images.githubusercontent.com/2413802/93131567-4c180980-f6a2-11ea-812d-b1184abde5b4.png"> <img width="300" alt="Screen Shot 2020-09-14 at 3 52 17 PM" src="https://user-images.githubusercontent.com/2413802/93131578-4fab9080-f6a2-11ea-9634-97b72d97bec7.png">

Co-authored-by: John Schoeman<johnschoeman1617@gmail.com>