### PR TITLE
Handle complete call back requested flow

### DIFF
--- a/src/Callback/CallbackFormContext.tsx
+++ b/src/Callback/CallbackFormContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react"
+
+type CallbackFormContextState = {
+  callBackRequestCompleted: () => void
+}
+
+export const CallbackFormContext = createContext<CallbackFormContextState>({
+  callBackRequestCompleted: () => {},
+})
+
+export const useCallbackFormContext = (): CallbackFormContextState => {
+  const context = useContext(CallbackFormContext)
+  if (context === undefined) {
+    throw new Error("CallbackFormContext must be used with a provider")
+  }
+  return context
+}

--- a/src/Callback/Success.spec.tsx
+++ b/src/Callback/Success.spec.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { useNavigation } from "@react-navigation/native"
+import { render, fireEvent } from "@testing-library/react-native"
+
+import Success from "./Success"
+import { CallbackFormContext } from "./CallbackFormContext"
+
+jest.mock("@react-navigation/native")
+
+describe("Success", () => {
+  it("invokes the completed request property from the context", () => {
+    const callBackRequestCompletedSpy = jest.fn()
+    ;(useNavigation as jest.Mock).mockReturnValueOnce({ setOptions: jest.fn() })
+    const { getByLabelText } = render(
+      <CallbackFormContext.Provider
+        value={{ callBackRequestCompleted: callBackRequestCompletedSpy }}
+      >
+        <Success />
+      </CallbackFormContext.Provider>,
+    )
+
+    fireEvent.press(getByLabelText("Got it"))
+    expect(callBackRequestCompletedSpy).toHaveBeenCalled()
+  })
+})

--- a/src/Callback/Success.tsx
+++ b/src/Callback/Success.tsx
@@ -5,11 +5,13 @@ import { useNavigation } from "@react-navigation/native"
 
 import { GlobalText, Button } from "../components"
 import { Typography, Spacing, Colors } from "../styles"
-import { Stacks, useStatusBarEffect } from "../navigation"
+import { useStatusBarEffect } from "../navigation"
 import { Images } from "../assets"
+import { useCallbackFormContext } from "./CallbackFormContext"
 
 const Success: FunctionComponent = () => {
   const { t } = useTranslation()
+  const { callBackRequestCompleted } = useCallbackFormContext()
   const navigation = useNavigation()
   useStatusBarEffect("light-content", Colors.headerBackground)
 
@@ -19,7 +21,7 @@ const Success: FunctionComponent = () => {
   })
 
   const handleOnPressGotIt = () => {
-    navigation.navigate(Stacks.Home)
+    callBackRequestCompleted()
   }
 
   return (

--- a/src/navigation/CallbackStack.tsx
+++ b/src/navigation/CallbackStack.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next"
 import { CallbackStackScreens, CallbackStackScreen } from "./index"
 import CallbackScreen from "../Callback/Form"
 import CallbackSuccess from "../Callback/Success"
+import { CallbackFormContext } from "../Callback/CallbackFormContext"
 
 import { Colors, Headers } from "../styles"
 
@@ -32,6 +33,7 @@ const HeaderLeft = () => {
 
 const CallbackStack: FunctionComponent = () => {
   const { t } = useTranslation()
+  const navigation = useNavigation()
   const defaultScreenOptions: StackNavigationOptions = {
     headerStyle: {
       ...Headers.headerStyle,
@@ -49,16 +51,24 @@ const CallbackStack: FunctionComponent = () => {
   }
 
   return (
-    <Stack.Navigator screenOptions={defaultScreenOptions}>
-      <Stack.Screen
-        name={CallbackStackScreens.Form}
-        component={CallbackScreen}
-      />
-      <Stack.Screen
-        name={CallbackStackScreens.Success}
-        component={CallbackSuccess}
-      />
-    </Stack.Navigator>
+    <CallbackFormContext.Provider
+      value={{
+        callBackRequestCompleted: () => {
+          navigation.goBack()
+        },
+      }}
+    >
+      <Stack.Navigator screenOptions={defaultScreenOptions}>
+        <Stack.Screen
+          name={CallbackStackScreens.Form}
+          component={CallbackScreen}
+        />
+        <Stack.Screen
+          name={CallbackStackScreens.Success}
+          component={CallbackSuccess}
+        />
+      </Stack.Navigator>
+    </CallbackFormContext.Provider>
   )
 }
 


### PR DESCRIPTION
Why:
----

The call back request flow needs to redirect to the origin of the start of such flow. Since it can be from the exposure details screen or the settings/connect screens.

How:
----

Using a simple context surrounding the flow will allow us to pivot the strategy, with extra layers of logic if we need to change it in the future, right now is a simple function that uses the context where the stack is defined to just navigate back from that point.

This Commit:
----

- Add a CallbackFormContext with a completed request handler
- Use the context from the callback form flow to navigate back after completing the flow


![Large GIF (428x886)](https://user-images.githubusercontent.com/2413802/93220236-3a824080-f73a-11ea-8c32-a4ac177cceb6.gif)
![Large GIF (428x886)](https://user-images.githubusercontent.com/2413802/93220265-42da7b80-f73a-11ea-9a8d-6fa446b3df0b.gif)
