### PR TITLE
Avoid scrolling onboarding and home screens on small devices

### DIFF
--- a/src/Home/ActivationStatus.tsx
+++ b/src/Home/ActivationStatus.tsx
@@ -66,8 +66,8 @@ export const ActivationStatus: FunctionComponent<ActivationStatusProps> = ({
         <SvgXml
           xml={content.leftIcon}
           fill={content.leftIconFill}
-          width={Iconography.medium}
-          height={Iconography.medium}
+          width={Iconography.small}
+          height={Iconography.small}
         />
         <View style={style.activationStatusTextContainer}>
           <GlobalText style={style.bottomHeaderText}>{headerText}</GlobalText>
@@ -89,7 +89,7 @@ const style = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingVertical: Spacing.large,
+    paddingVertical: Spacing.xSmall,
     marginHorizontal: Spacing.small,
     borderBottomWidth: Outlines.hairline,
     borderBottomColor: Colors.neutral10,
@@ -106,11 +106,13 @@ const style = StyleSheet.create({
     alignItems: "center",
   },
   bottomHeaderText: {
-    ...Typography.header4,
-    marginBottom: Spacing.xxxSmall,
+    ...Typography.body1,
+    color: Colors.black,
+    lineHeight: Typography.smallLineHeight,
   },
   bottomBodyText: {
-    ...Typography.header6,
-    color: Colors.neutral100,
+    ...Typography.body2,
+    color: Colors.neutral75,
+    lineHeight: Typography.xSmallLineHeight,
   },
 })

--- a/src/Home/ShareLink.tsx
+++ b/src/Home/ShareLink.tsx
@@ -34,6 +34,7 @@ export const ShareLink: FunctionComponent = () => {
     return null
   }
 
+  const shareIconSize = 22
   return (
     <TouchableOpacity
       style={style.shareContainer}
@@ -51,8 +52,8 @@ export const ShareLink: FunctionComponent = () => {
       <View style={style.shareIconContainer}>
         <SvgXml
           xml={Icons.Share}
-          width={Iconography.small}
-          height={Iconography.small}
+          width={shareIconSize}
+          height={shareIconSize}
         />
       </View>
     </TouchableOpacity>
@@ -75,20 +76,21 @@ const style = StyleSheet.create({
     justifyContent: "center",
     backgroundColor: Colors.secondary50,
     borderRadius: Outlines.borderRadiusMax,
-    width: Iconography.medium,
-    height: Iconography.medium,
-  },
-  shareImage: {
     width: Iconography.small,
     height: Iconography.small,
+  },
+  shareImage: {
+    width: Iconography.xSmall,
+    height: Iconography.xSmall,
   },
   shareTextContainer: {
     flex: 1,
     marginLeft: Spacing.medium,
   },
   shareText: {
-    ...Typography.header4,
-    lineHeight: Typography.smallLineHeight,
+    ...Typography.body2,
+    ...Typography.mediumBold,
+    color: Colors.primaryText,
   },
   shareIconContainer: {
     width: rightColumnWidth,

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -109,8 +109,8 @@ const Home: FunctionComponent = () => {
             <View style={style.topIcon}>
               <SvgXml
                 xml={topIcon}
-                width={Iconography.large}
-                height={Iconography.large}
+                width={Iconography.medium}
+                height={Iconography.medium}
                 fill={topIconFill}
                 accessible
                 accessibilityLabel={topIconAccessibilityLabel}
@@ -178,7 +178,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.large,
   },
   headerText: {
-    ...Typography.header1,
+    ...Typography.header2,
     ...Typography.mediumBold,
     color: Colors.white,
     textAlign: "center",
@@ -202,6 +202,8 @@ const style = StyleSheet.create({
   button: {
     alignSelf: "center",
     width: "100%",
+    paddingTop: Spacing.xSmall,
+    paddingBottom: Spacing.xSmall + 1,
   },
 })
 

--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -11,23 +11,13 @@ import {
 } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
-import { SvgXml } from "react-native-svg"
 import LinearGradient from "react-native-linear-gradient"
 import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
-
 import { StatusBar, GlobalText, Button } from "../components"
 import { ModalScreens, Stacks, Stack, useStatusBarEffect } from "../navigation"
 import { getLocalNames } from "../locales/languages"
 
-import { Icons } from "../assets"
-import {
-  Layout,
-  Outlines,
-  Colors,
-  Spacing,
-  Typography,
-  Iconography,
-} from "../styles"
+import { Layout, Outlines, Colors, Spacing, Typography } from "../styles"
 
 type HowItWorksScreenContent = {
   screenNumber: number
@@ -48,7 +38,7 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
   howItWorksScreenContent,
   totalScreenCount,
   destinationOnSkip,
-}: HowItWorksScreenProps) => {
+}) => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const navigation = useNavigation()
   const {
@@ -117,28 +107,22 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
               {howItWorksScreenContent.header}
             </GlobalText>
           </View>
-          <View style={style.nextButtonContainer}>
+        </ScrollView>
+        <View style={style.bottomButtonContainer}>
+          <>
             <Button
+              customButtonStyle={style.nextButton}
               label={howItWorksScreenContent.primaryButtonLabel}
               onPress={howItWorksScreenContent.primaryButtonOnPress}
               hasRightArrow
             />
-          </View>
-        </ScrollView>
-        <TouchableOpacity
-          style={style.bottomButtonContainer}
-          onPress={handleOnPressProtectPrivacy}
-        >
-          <GlobalText style={style.bottomButtonText}>
-            {t("onboarding.protect_privacy_button")}
-          </GlobalText>
-          <SvgXml
-            xml={Icons.ChevronUp}
-            fill={Colors.primary100}
-            width={Iconography.xxxSmall}
-            height={Iconography.xxxSmall}
-          />
-        </TouchableOpacity>
+            <TouchableOpacity onPress={handleOnPressProtectPrivacy}>
+              <GlobalText style={style.bottomButtonText}>
+                {t("onboarding.protect_privacy_button")}
+              </GlobalText>
+            </TouchableOpacity>
+          </>
+        </View>
       </View>
     </>
   )
@@ -203,26 +187,24 @@ const createStyle = (insets: EdgeInsets) => {
       marginBottom: Spacing.medium,
     },
     headerText: {
-      ...Typography.header1,
+      ...Typography.header2,
       marginBottom: Spacing.xLarge,
       paddingHorizontal: Spacing.large,
     },
-    nextButtonContainer: {
-      alignSelf: "flex-start",
-      paddingHorizontal: Spacing.large,
+    nextButton: {
+      paddingTop: Spacing.xSmall,
+      paddingBottom: Spacing.xSmall + 1,
+      width: "95%",
+      alignSelf: "center",
     },
     bottomButtonContainer: {
-      backgroundColor: Colors.secondary10,
-      flexDirection: "row",
       alignItems: "center",
-      justifyContent: "center",
       paddingTop: Spacing.small,
       paddingBottom: insets.bottom + Spacing.small,
     },
     bottomButtonText: {
       ...Typography.header5,
       color: Colors.primary100,
-      marginRight: Spacing.xSmall,
     },
   })
 }

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -184,7 +184,7 @@ export const error: TextStyle = {
 
 // Tappables
 const baseButtonText: TextStyle = {
-  ...largeFont,
+  ...mediumFont,
   ...semiBold,
 }
 


### PR DESCRIPTION
#### Description:
Updates the onboarding and home screens to avoid scrolling on small screen sizes by doing the following:

- Make headline font size smaller on Onboarding screens
- Make progression buttons thinner on Onboarding screens
- Reduce side of header in the Home screen
- Reduce size of ActivationSummaries in Home screen
- Move progression buttons out of scroll view on onboarding screens

#### Linked issues:
[GAEN-280](https://pathcheck.atlassian.net/jira/software/projects/GAEN/boards/33/?selectedIssue=GAEN-280)

#### Screenshots:
Onboarding screen
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-15 at 15 29 33](https://user-images.githubusercontent.com/21161427/93256765-d9726100-f769-11ea-99d1-7212e6b6e9ff.png)

Home screen
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-15 at 15 29 26](https://user-images.githubusercontent.com/21161427/93256779-e1320580-f769-11ea-8c5e-5b9e748c221f.png)

Onboarding screen (large font)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-15 at 15 28 27](https://user-images.githubusercontent.com/21161427/93256803-ed1dc780-f769-11ea-9edf-040df04651a2.png)

Co-Authored-By devinjameson<devin@thoughtbot.com>