### PR TITLE
Add support for callback success configuration

### DIFF
--- a/src/Callback/Success.spec.tsx
+++ b/src/Callback/Success.spec.tsx
@@ -4,10 +4,42 @@ import { render, fireEvent } from "@testing-library/react-native"
 
 import Success from "./Success"
 import { CallbackFormContext } from "./CallbackFormContext"
+import { ConfigurationContext } from "../ConfigurationContext"
+import { factories } from "../factories"
 
 jest.mock("@react-navigation/native")
 
 describe("Success", () => {
+  it("displays the title and body for the call back success", () => {
+    const healthAuthorityName = "healthAuthorityName"
+    const setOptionsSpy = jest.fn()
+    ;(useNavigation as jest.Mock).mockReturnValueOnce({
+      setOptions: setOptionsSpy,
+    })
+    const { getByText } = render(
+      <ConfigurationContext.Provider
+        value={factories.configurationContext.build({ healthAuthorityName })}
+      >
+        <CallbackFormContext.Provider
+          value={{ callBackRequestCompleted: jest.fn() }}
+        >
+          <Success />
+        </CallbackFormContext.Provider>
+      </ConfigurationContext.Provider>,
+    )
+
+    expect(getByText("You're in the queue")).toBeDefined()
+    expect(
+      getByText(
+        `Our contact tracers are working hard to keep you and your community safe. The ${healthAuthorityName} has received your request for a call back. An expert will contact you within 24 hours.`,
+      ),
+    ).toBeDefined()
+    expect(setOptionsSpy).toHaveBeenCalledWith({
+      headerLeft: null,
+      title: "Call Back Requested",
+    })
+  })
+
   it("invokes the completed request property from the context", () => {
     const callBackRequestCompletedSpy = jest.fn()
     ;(useNavigation as jest.Mock).mockReturnValueOnce({ setOptions: jest.fn() })

--- a/src/Callback/Success.tsx
+++ b/src/Callback/Success.tsx
@@ -4,16 +4,32 @@ import { ScrollView, StyleSheet, Image } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 
 import { GlobalText, Button } from "../components"
-import { Typography, Spacing, Colors } from "../styles"
 import { useStatusBarEffect } from "../navigation"
-import { Images } from "../assets"
 import { useCallbackFormContext } from "./CallbackFormContext"
+import {
+  loadAuthorityCopy,
+  authorityCopyTranslation,
+} from "../configuration/authorityCopy"
+
+import { Images } from "../assets"
+import { Typography, Spacing, Colors } from "../styles"
+import { useConfigurationContext } from "../ConfigurationContext"
 
 const Success: FunctionComponent = () => {
-  const { t } = useTranslation()
+  const {
+    t,
+    i18n: { language: localeCode },
+  } = useTranslation()
   const { callBackRequestCompleted } = useCallbackFormContext()
   const navigation = useNavigation()
   useStatusBarEffect("light-content", Colors.headerBackground)
+  const { healthAuthorityName } = useConfigurationContext()
+
+  const successMessage = authorityCopyTranslation(
+    loadAuthorityCopy("callback_success"),
+    localeCode,
+    t("callback.success_body", { healthAuthorityName }),
+  )
 
   navigation.setOptions({
     headerLeft: null,
@@ -35,7 +51,7 @@ const Success: FunctionComponent = () => {
       <GlobalText style={style.header}>
         {t("callback.success_header")}
       </GlobalText>
-      <GlobalText style={style.body}>{t("callback.success_body")}</GlobalText>
+      <GlobalText style={style.body}>{successMessage}</GlobalText>
       <Button
         label={t("callback.success_got_it")}
         onPress={handleOnPressGotIt}

--- a/src/configuration/authorityCopy.ts
+++ b/src/configuration/authorityCopy.ts
@@ -1,7 +1,7 @@
 import copy from "./copy.json"
 
 const DEFAULT_LOCALE = "en"
-type CopyKey = "welcome_message" | "about" | "legal"
+type CopyKey = "welcome_message" | "about" | "legal" | "callback_success"
 type CopyValues = Record<string, string>
 type AuthorityCopyContent = Record<CopyKey, CopyValues>
 
@@ -14,10 +14,15 @@ const authorityCopyTranslation = (
   localeCode: string,
   defaultValue: string,
 ): string => {
-  const overrideCopy =
-    authorityCopyOverrides[localeCode] || authorityCopyOverrides[DEFAULT_LOCALE]
+  try {
+    const overrideCopy =
+      authorityCopyOverrides[localeCode] ||
+      authorityCopyOverrides[DEFAULT_LOCALE]
 
-  return overrideCopy?.length > 0 ? overrideCopy : defaultValue
+    return overrideCopy?.length > 0 ? overrideCopy : defaultValue
+  } catch {
+    return defaultValue
+  }
 }
 
 export { loadAuthorityCopy, authorityCopyTranslation }

--- a/src/configuration/copy.json
+++ b/src/configuration/copy.json
@@ -7,5 +7,8 @@
   },
   "legal": {
     "en": ""
+  },
+  "callback_success": {
+    "en": ""
   }
 }


### PR DESCRIPTION
Why:
----

The call back request success message should be configured independently per authority.

This Commit:
----

- Add support for a new key on the authority copy helper
- Use copy override on the call back success screen

Reviewers:
----

This depends on a new configuration value on this PR https://github.com/Path-Check/pathcheck-mobile-resources/pull/68 but there's no need to update the repo commit since we don't have any overrides at the moment
