### PR TITLE
iOS Updates

### DIFF
--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -635,6 +635,43 @@ class ExposureManagerTests: XCTestCase {
     }
   }
 
+  func testRemainingFileCapacityReset() {
+    let btSecureStorageMock = BTSecureStorageMock(notificationCenter: NotificationCenter())
+    btSecureStorageMock.userStateHandler = {
+      let userState = UserState()
+      userState.remainingDailyFileProcessingCapacity = 0
+      return userState
+    }
+    let exposureManager = ExposureManager(btSecureStorage: btSecureStorageMock)
+    exposureManager.detectExposuresV1 { (result) in
+      switch result {
+      case .success:
+        XCTAssertEqual(btSecureStorageMock.userState.remainingDailyFileProcessingCapacity, Constants.dailyFileProcessingCapacity)
+      default: XCTFail()
+      }
+    }
+  }
+
+  func testRemainingFileCapacityNoResetForDetectionError() {
+    let btSecureStorageMock = BTSecureStorageMock(notificationCenter: NotificationCenter())
+    btSecureStorageMock.userStateHandler = {
+      let userState = UserState()
+      userState.remainingDailyFileProcessingCapacity = 0
+      return userState
+    }
+    let exposureManager = ExposureManager(btSecureStorage: btSecureStorageMock)
+    exposureManager.detectExposuresV1 { (result) in
+      //no op
+    }
+    exposureManager.detectExposuresV1 { (result) in
+      switch result {
+      case .failure:
+        XCTAssertEqual(btSecureStorageMock.userState.remainingDailyFileProcessingCapacity, 0)
+      default: XCTFail()
+      }
+    }
+  }
+
   func testDebugFetchDiagnosisKeys() {
     let debugAction = DebugAction.fetchDiagnosisKeys
     let enManagerMock = ENManagerMock()


### PR DESCRIPTION
### This Commit
- Removes the check for daily file processing limit for iOS >= 13.7 (per apple, that limit is removed: https://developer.apple.com/documentation/exposurenotification/enmanager/3586331-detectexposures)
- Adds unit tests confirming daily file processing limit expected behavior for `V1` exposure detection