### PR TITLE
Recent Exposures iOS

### DIFF
--- a/ios/BT/API/Model/UserState.swift
+++ b/ios/BT/API/Model/UserState.swift
@@ -23,7 +23,7 @@ class UserState: Object {
       to: Date())!
     let allExposures: [Exposure] = Array(exposures)
     return allExposures.filter { (exposure: Exposure) in
-      return Date(timeIntervalSince1970: TimeInterval(exposure.date)) > dateCutoff
+      return exposure.date.fromPosixRepresentation > dateCutoff
     }
   }
 

--- a/ios/BT/API/Model/UserState.swift
+++ b/ios/BT/API/Model/UserState.swift
@@ -16,4 +16,15 @@ class UserState: Object {
     "id"
   }
 
+  var recentExposures: [Exposure] {
+    let dateCutoff = Calendar.current.date(
+      byAdding: .hour,
+      value: -350,
+      to: Date())!
+    let allExposures: [Exposure] = Array(exposures)
+    return allExposures.filter { (exposure: Exposure) in
+      return Date(timeIntervalSince1970: TimeInterval(exposure.date)) > dateCutoff
+    }
+  }
+
 }

--- a/ios/BT/ExposureManager+Debug.swift
+++ b/ios/BT/ExposureManager+Debug.swift
@@ -69,9 +69,7 @@ extension ExposureManager: ExposureManagerDebuggable {
       }
       resolve("Exposures: \(btSecureStorage.userState.exposures)")
     case .fetchExposures:
-      getCurrentExposures { currentExposures in
-        resolve(currentExposures)
-      }
+      resolve(currentExposures)
     case .resetExposures:
       btSecureStorage.exposures = List<Exposure>()
       resolve("Exposures: \(btSecureStorage.exposures.count)")

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -156,6 +156,10 @@ final class ExposureManager: NSObject {
 
   /// Returns the current exposures as a json string representation
   @objc func getCurrentExposures(_ completion: ((String) -> Void)) {
+    // Temporary workaround for an apparent EN framework bug whereby
+    // the cached exposures call is limited to 6 per day
+    completion(exposuresV1().jsonStringRepresentation())
+    return
     if #available(iOS 13.7, *) {
       do {
         let exposures = try await(exposuresV2())
@@ -484,7 +488,7 @@ extension ExposureManager {
 private extension ExposureManager {
 
   func exposuresV1() -> [Exposure] {
-    return Array(btSecureStorage.userState.exposures)
+    btSecureStorage.userState.recentExposures
   }
 
   func activateSuccess() {

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -155,21 +155,8 @@ final class ExposureManager: NSObject {
   }
 
   /// Returns the current exposures as a json string representation
-  @objc func getCurrentExposures(_ completion: ((String) -> Void)) {
-    // Temporary workaround for an apparent EN framework bug whereby
-    // the cached exposures call is limited to 6 per day
-    completion(exposuresV1().jsonStringRepresentation())
-    return
-    if #available(iOS 13.7, *) {
-      do {
-        let exposures = try await(exposuresV2())
-        completion(exposures.jsonStringRepresentation())
-      } catch {
-        completion(String.default)
-      }
-    } else {
-      completion(exposuresV1().jsonStringRepresentation())
-    }
+  @objc var currentExposures: String {
+    return btSecureStorage.userState.recentExposures.jsonStringRepresentation()
   }
 
   ///Notifies the user to enable bluetooth to be able to exchange keys
@@ -487,10 +474,6 @@ extension ExposureManager {
 
 private extension ExposureManager {
 
-  func exposuresV1() -> [Exposure] {
-    btSecureStorage.userState.recentExposures
-  }
-
   func activateSuccess() {
     awake()
     // Ensure exposure notifications are enabled if the app is authorized. The app
@@ -639,29 +622,6 @@ extension ExposureManager {
         } else {
           fullfill(summary)
         }
-      }
-    }
-  }
-
-  func exposuresV2() -> Promise<[Exposure]> {
-    return Promise<[Exposure]>(on: .global()) { () -> [Exposure] in
-      do {
-        let exposureConfiguraton = try await(self.getExposureConfigurationV2())
-        let exposureSummary = try await(self.getCachedExposures(configuration: exposureConfiguraton.asENExposureConfiguration))
-        var newExposures: [Exposure] = []
-        if let summary = exposureSummary {
-          summary.daySummaries.forEach { (daySummary) in
-            if daySummary.isAboveScoreThreshold(with: exposureConfiguraton) &&
-                !newExposures.map({ $0.date }).contains(daySummary.date.posixRepresentation) {
-              let exposure = Exposure(id: UUID().uuidString,
-                                      date: daySummary.date.posixRepresentation)
-              newExposures.append(exposure)
-            }
-          }
-        }
-        return newExposures
-      } catch {
-        return []
       }
     }
   }

--- a/ios/BT/Extensions/Foundation/Int+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Int+Extensions.swift
@@ -1,0 +1,7 @@
+extension Int {
+
+  var fromPosixRepresentation: Date {
+    Date(timeIntervalSince1970: TimeInterval(self / 1000))
+  }
+
+}

--- a/ios/BT/bridge/ExposureHistoryModule.m
+++ b/ios/BT/bridge/ExposureHistoryModule.m
@@ -13,9 +13,7 @@ RCT_EXPORT_MODULE();
 RCT_REMAP_METHOD(getCurrentExposures,
                  getCurrentExposuresWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-  [[ExposureManager shared] getCurrentExposures:^(NSString * currentExposures) {
-    resolve(currentExposures);
-  }];
+  resolve([[ExposureManager shared] currentExposures]);
 }
 
 RCT_REMAP_METHOD(fetchLastDetectionDate,

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B52D88C0248F0FC00071ED51 /* SafePathsSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271881BF2461AF76001DE067 /* SafePathsSecureStorage.swift */; };
 		B52D88C4248F10FD0071ED51 /* BTSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52D88C3248F10FD0071ED51 /* BTSecureStorage.swift */; };
 		B54CBF32249A738500218477 /* IndexFileRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54CBF31249A738500218477 /* IndexFileRequests.swift */; };
+		B5525E5D2512B3D90093614A /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5525E5C2512B3D90093614A /* Int+Extensions.swift */; };
 		B5582D47249943E5001458A9 /* ExposureEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B5582D43249943DE001458A9 /* ExposureEventEmitter.m */; };
 		B576CC4324993F5200CDD9D9 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B576CC3D24993F4C00CDD9D9 /* Date+Extensions.swift */; };
 		B576CC4424993F5200CDD9D9 /* Encodable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B576CC4024993F4C00CDD9D9 /* Encodable+Extensions.swift */; };
@@ -229,6 +230,7 @@
 		B51D8D2624E43AE4001C28E1 /* KeySubmissionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySubmissionResponse.swift; sourceTree = "<group>"; };
 		B52D88C3248F10FD0071ED51 /* BTSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSecureStorage.swift; sourceTree = "<group>"; };
 		B54CBF31249A738500218477 /* IndexFileRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexFileRequests.swift; sourceTree = "<group>"; };
+		B5525E5C2512B3D90093614A /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
 		B5582D43249943DE001458A9 /* ExposureEventEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExposureEventEmitter.m; sourceTree = "<group>"; };
 		B576CC3D24993F4C00CDD9D9 /* Date+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		B576CC4024993F4C00CDD9D9 /* Encodable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Encodable+Extensions.swift"; sourceTree = "<group>"; };
@@ -552,6 +554,7 @@
 				B5FBB0D224916B3600433980 /* String+Extensions.swift */,
 				B5E79436249E666B00BD8596 /* Array+Extensions.swift */,
 				B576CC3D24993F4C00CDD9D9 /* Date+Extensions.swift */,
+				B5525E5C2512B3D90093614A /* Int+Extensions.swift */,
 				B576CC4024993F4C00CDD9D9 /* Encodable+Extensions.swift */,
 				B59F4C3624BE0658007B09D5 /* List+Extensions.swift */,
 				B5FBB0D624916DE100433980 /* Notification+Extensions.swift */,
@@ -1001,6 +1004,7 @@
 				B5E79437249E666B00BD8596 /* Array+Extensions.swift in Sources */,
 				B5FC37CA2489B1C1006474EB /* JSON.swift in Sources */,
 				B5081E4A24D9B8E300121884 /* DeviceInfoModule.m in Sources */,
+				B5525E5D2512B3D90093614A /* Int+Extensions.swift in Sources */,
 				B5FC37D02489B3DE006474EB /* StructuredError.swift in Sources */,
 				B5C9723024B8A909007F4C0B /* Constants.swift in Sources */,
 			);

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -566,6 +566,19 @@ class ExposureManagerTests: XCTestCase {
     wait(for: [addNotificatiionRequestExpectation, removeNotificationsExpectation], timeout: 0)
   }
 
+  func testRecentExposures() {
+    let btSecureStorageMock = BTSecureStorageMock(notificationCenter: NotificationCenter())
+    btSecureStorageMock.userStateHandler = {
+      let userState = UserState()
+      userState.exposures.append(Exposure(id: "1",
+                                          date: halloween.posixRepresentation))
+      userState.exposures.append(Exposure(id: "2",
+                                          date: Date().posixRepresentation))
+      return userState
+    }
+    XCTAssertEqual(btSecureStorageMock.userState.recentExposures.count, 1)
+  }
+
   func testBluetoothNotificationOff() {
     let addNotificatiionRequestExpectation = self.expectation(description: "A notification request is added with the proper title and body")
     let removeNotificationsExpectation = self.expectation(description: "when is not authorized and bluetooth is not off we just remove all delivered notifications")

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -428,8 +428,6 @@ class ExposureManagerTests: XCTestCase {
   }
 
   func testCurrentExposures() {
-    let getCurrentExposuresExpectation = self.expectation(description: "Get current exposures")
-
     let enManagerMock = ENManagerMock()
 
     enManagerMock.detectExposuresHandler = { configuration, diagnosisKeys, completionHandler in
@@ -469,11 +467,8 @@ class ExposureManagerTests: XCTestCase {
     let exposureManager = ExposureManager(exposureNotificationManager: enManagerMock,
                                           apiClient: apiClientMock,
                                           btSecureStorage: btSecureStorageMock)
-    exposureManager.getCurrentExposures { exposures in
-      XCTAssertNoThrow(try! JSONDecoder().decode(Array<Exposure>.self, from: exposures.data(using: .utf8) ?? Data()))
-      getCurrentExposuresExpectation.fulfill()
-    }
-    wait(for: [getCurrentExposuresExpectation], timeout: 2)
+    let currentExposures = exposureManager.currentExposures
+    XCTAssertNoThrow(try! JSONDecoder().decode(Array<Exposure>.self, from: currentExposures.data(using: .utf8) ?? Data()))
   }
 
   func testEnableNotificationsSuccess() {


### PR DESCRIPTION
- Only return most recent 2 weeks of exposures from the iOS layer

- Workaround for an undocumented EN framework limitation whereby the cached exposures call (https://developer.apple.com/documentation/exposurenotification/enmanager/3650384-detectexposures) is limited to 6 per day. 