### PR TITLE
Add symptom selection functionality to symptom checker

### DIFF
--- a/src/SymptomChecker/AtRiskRecommendation.tsx
+++ b/src/SymptomChecker/AtRiskRecommendation.tsx
@@ -1,0 +1,79 @@
+import React, { FunctionComponent } from "react"
+import { TouchableOpacity, View, StyleSheet, ScrollView } from "react-native"
+import { useTranslation } from "react-i18next"
+import { useNavigation } from "@react-navigation/native"
+import { SvgXml } from "react-native-svg"
+
+import { useStatusBarEffect, SymptomCheckerStackScreens } from "../navigation"
+import { GlobalText, StatusBar } from "../components"
+
+import { Icons } from "../assets"
+import { Layout, Colors, Spacing, Typography, Iconography } from "../styles"
+
+const AtRiskRecommendationScreen: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
+  const { t } = useTranslation()
+  const navigation = useNavigation()
+
+  const handleOnPressCancel = () => {
+    navigation.navigate(SymptomCheckerStackScreens.SymptomChecker)
+  }
+
+  return (
+    <>
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
+      >
+        <View style={style.cancelButtonContainer}>
+          <TouchableOpacity
+            onPress={handleOnPressCancel}
+            accessible
+            accessibilityLabel={t("export.code_input_button_cancel")}
+          >
+            <View style={style.cancelButtonInnerContainer}>
+              <SvgXml
+                xml={Icons.X}
+                fill={Colors.black}
+                width={Iconography.xxSmall}
+                height={Iconography.xxSmall}
+              />
+            </View>
+          </TouchableOpacity>
+        </View>
+        <GlobalText style={style.headerText}>
+          {t("symptom_checker.get_tested")}
+        </GlobalText>
+      </ScrollView>
+    </>
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.primaryLightBackground,
+  },
+  contentContainer: {
+    flexGrow: 1,
+    backgroundColor: Colors.primaryLightBackground,
+    paddingTop: Spacing.xxxHuge,
+    paddingHorizontal: Spacing.large,
+    justifyContent: "center",
+  },
+  cancelButtonContainer: {
+    position: "absolute",
+    top: Spacing.medium,
+    right: Spacing.medium,
+    zIndex: Layout.zLevel1,
+  },
+  cancelButtonInnerContainer: {
+    padding: Spacing.medium,
+  },
+  headerText: {
+    ...Typography.header2,
+  },
+})
+
+export default AtRiskRecommendationScreen

--- a/src/SymptomChecker/CheckIn.spec.tsx
+++ b/src/SymptomChecker/CheckIn.spec.tsx
@@ -1,7 +1,12 @@
 import React from "react"
 import { render, fireEvent } from "@testing-library/react-native"
+import { useNavigation } from "@react-navigation/native"
+
+import { SymptomCheckerStackScreens } from "../navigation"
 
 import CheckIn from "./CheckIn"
+
+jest.mock("@react-navigation/native")
 
 describe("CheckIn", () => {
   it("shows a glad to hear it message when the user says they feel good", () => {
@@ -12,9 +17,16 @@ describe("CheckIn", () => {
   })
 
   it("shows a sorry to hear you're not feeling well message when the user says they feel not well", () => {
-    const { getByLabelText, getByText } = render(<CheckIn />)
+    const navigateSpy = jest.fn()
+    ;(useNavigation as jest.Mock).mockReturnValue({
+      navigate: navigateSpy,
+    })
+
+    const { getByLabelText } = render(<CheckIn />)
 
     fireEvent.press(getByLabelText("Not well"))
-    expect(getByText("Sorry to hear you're not feeling well!")).toBeDefined()
+    expect(navigateSpy).toHaveBeenCalledWith(
+      SymptomCheckerStackScreens.SelectSymptoms,
+    )
   })
 })

--- a/src/SymptomChecker/CheckIn.tsx
+++ b/src/SymptomChecker/CheckIn.tsx
@@ -224,9 +224,11 @@ const style = StyleSheet.create({
   },
   checkInEyebrowText: {
     ...Typography.body1,
+    marginBottom: Spacing.xxxSmall,
   },
   checkInHeaderText: {
     ...Typography.header3,
+    paddingRight: Spacing.xxLarge,
   },
   feelingButtonsContainer: {
     flexDirection: "row",

--- a/src/SymptomChecker/CheckIn.tsx
+++ b/src/SymptomChecker/CheckIn.tsx
@@ -11,10 +11,11 @@ import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
 import { GlobalText } from "../components"
+import { useSymptomCheckerContext } from "./SymptomCheckerContext"
+import { SymptomCheckerStackScreens } from "../navigation"
 
 import { Outlines, Colors, Typography, Spacing, Iconography } from "../styles"
 import { Icons, Images } from "../assets"
-import { SymptomCheckerStackScreens } from "../navigation"
 
 enum CheckInStatus {
   NotCheckedIn,
@@ -25,6 +26,7 @@ enum CheckInStatus {
 const CheckIn: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
+  const { symptoms } = useSymptomCheckerContext()
 
   const [checkInStatus, setCheckInStatus] = useState<CheckInStatus>(
     CheckInStatus.NotCheckedIn,
@@ -51,14 +53,22 @@ const CheckIn: FunctionComponent = () => {
       case CheckInStatus.FeelingGood:
         return <FeelingGoodContent />
       case CheckInStatus.FeelingNotWell:
-        return <FeelingNotWellContent />
+        if (symptoms.length !== 0) {
+          return <FeelingNotWellContent symptoms={symptoms} />
+        } else {
+          return (
+            <SelectFeeling
+              handleOnPressGood={handleOnPressGood}
+              handleOnPressNotWell={handleOnPressNotWell}
+            />
+          )
+        }
     }
   }
 
-  const iconFill =
-    checkInStatus === CheckInStatus.NotCheckedIn
-      ? Colors.secondary50
-      : Colors.primary100
+  const showFilledIcon =
+    checkInStatus === CheckInStatus.NotCheckedIn && symptoms.length !== 0
+  const iconFill = showFilledIcon ? Colors.secondary50 : Colors.primary100
 
   return (
     <>
@@ -115,7 +125,7 @@ const SelectFeeling: FunctionComponent<SelectFeelingProps> = ({
   )
 }
 
-const FeelingGoodContent = () => {
+const FeelingGoodContent: FunctionComponent = () => {
   const { t } = useTranslation()
 
   return (
@@ -125,13 +135,24 @@ const FeelingGoodContent = () => {
   )
 }
 
-const FeelingNotWellContent = () => {
+interface FeelingNotWellContentProps {
+  symptoms: string[]
+}
+
+const FeelingNotWellContent: FunctionComponent<FeelingNotWellContentProps> = ({
+  symptoms,
+}) => {
   const { t } = useTranslation()
 
   return (
-    <GlobalText style={style.checkInHeaderText}>
-      {t("symptom_checker.sorry_to_hear_it")}
-    </GlobalText>
+    <>
+      <GlobalText style={style.checkInHeaderText}>
+        {t("symptom_checker.sorry_to_hear_it")}
+      </GlobalText>
+      {symptoms.map((value) => {
+        return <GlobalText key={value}>{value}</GlobalText>
+      })}
+    </>
   )
 }
 

--- a/src/SymptomChecker/CheckIn.tsx
+++ b/src/SymptomChecker/CheckIn.tsx
@@ -151,9 +151,9 @@ const FeelingNotWellContent: FunctionComponent<FeelingNotWellContentProps> = ({
 
   const determineHealthAssessmentText = () => {
     switch (healthAssessment) {
-      case HealthAssessment.GetTested:
+      case HealthAssessment.AtRisk:
         return t("symptom_checker.get_tested")
-      case HealthAssessment.FollowHAGuidance:
+      case HealthAssessment.NotAtRisk:
         return t("symptom_checker.follow_ha_guidance")
     }
   }

--- a/src/SymptomChecker/CheckIn.tsx
+++ b/src/SymptomChecker/CheckIn.tsx
@@ -7,12 +7,14 @@ import {
   ImageSourcePropType,
 } from "react-native"
 import { useTranslation } from "react-i18next"
+import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
 import { GlobalText } from "../components"
 
 import { Outlines, Colors, Typography, Spacing, Iconography } from "../styles"
 import { Icons, Images } from "../assets"
+import { SymptomCheckerStackScreens } from "../navigation"
 
 enum CheckInStatus {
   NotCheckedIn,
@@ -22,6 +24,7 @@ enum CheckInStatus {
 
 const CheckIn: FunctionComponent = () => {
   const { t } = useTranslation()
+  const navigation = useNavigation()
 
   const [checkInStatus, setCheckInStatus] = useState<CheckInStatus>(
     CheckInStatus.NotCheckedIn,
@@ -33,6 +36,7 @@ const CheckIn: FunctionComponent = () => {
 
   const handleOnPressNotWell = () => {
     setCheckInStatus(CheckInStatus.FeelingNotWell)
+    navigation.navigate(SymptomCheckerStackScreens.SelectSymptoms)
   }
 
   const determineStatusContent = () => {

--- a/src/SymptomChecker/CheckIn.tsx
+++ b/src/SymptomChecker/CheckIn.tsx
@@ -12,7 +12,7 @@ import { SvgXml } from "react-native-svg"
 
 import { GlobalText } from "../components"
 import { useSymptomCheckerContext } from "./SymptomCheckerContext"
-import { HealthRecommendation, determineHealthRecommendation } from "./symptoms"
+import { HealthRecommendation } from "./symptoms"
 import { SymptomCheckerStackScreens } from "../navigation"
 
 import { Outlines, Colors, Typography, Spacing, Iconography } from "../styles"

--- a/src/SymptomChecker/CheckIn.tsx
+++ b/src/SymptomChecker/CheckIn.tsx
@@ -62,7 +62,7 @@ const CheckIn: FunctionComponent = () => {
         return (
           <FeelingNotWellContent
             symptoms={symptoms}
-            healthAssessment={healthRecommendation}
+            healthAssessment={healthAssessment}
           />
         )
     }

--- a/src/SymptomChecker/CheckIn.tsx
+++ b/src/SymptomChecker/CheckIn.tsx
@@ -258,8 +258,9 @@ const style = StyleSheet.create({
   },
   healthRecommendationText: {
     ...Typography.header5,
+    ...Typography.base,
     marginTop: Spacing.medium,
-    marginBottom: Spacing.large,
+    marginBottom: Spacing.xxLarge,
   },
   symptomsContainer: {
     flexDirection: "row",

--- a/src/SymptomChecker/CheckIn.tsx
+++ b/src/SymptomChecker/CheckIn.tsx
@@ -12,7 +12,7 @@ import { SvgXml } from "react-native-svg"
 
 import { GlobalText } from "../components"
 import { useSymptomCheckerContext } from "./SymptomCheckerContext"
-import { HealthRecommendation } from "./symptoms"
+import { HealthAssessment } from "./symptoms"
 import { SymptomCheckerStackScreens } from "../navigation"
 
 import { Outlines, Colors, Typography, Spacing, Iconography } from "../styles"
@@ -27,7 +27,7 @@ enum CheckInStatus {
 const CheckIn: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const { symptoms, healthRecommendation } = useSymptomCheckerContext()
+  const { symptoms, healthAssessment } = useSymptomCheckerContext()
 
   const [checkInStatus, setCheckInStatus] = useState<CheckInStatus>(
     CheckInStatus.NotCheckedIn,
@@ -62,7 +62,7 @@ const CheckIn: FunctionComponent = () => {
         return (
           <FeelingNotWellContent
             symptoms={symptoms}
-            healthRecommendation={healthRecommendation}
+            healthAssessment={healthRecommendation}
           />
         )
     }
@@ -140,20 +140,20 @@ const FeelingGoodContent: FunctionComponent = () => {
 
 interface FeelingNotWellContentProps {
   symptoms: string[]
-  healthRecommendation: HealthRecommendation
+  healthAssessment: HealthAssessment
 }
 
 const FeelingNotWellContent: FunctionComponent<FeelingNotWellContentProps> = ({
   symptoms,
-  healthRecommendation,
+  healthAssessment,
 }) => {
   const { t } = useTranslation()
 
-  const determineHealthRecommendationText = () => {
-    switch (healthRecommendation) {
-      case HealthRecommendation.GetTested:
+  const determineHealthAssessmentText = () => {
+    switch (healthAssessment) {
+      case HealthAssessment.GetTested:
         return t("symptom_checker.get_tested")
-      case HealthRecommendation.FollowHAGuidance:
+      case HealthAssessment.FollowHAGuidance:
         return t("symptom_checker.follow_ha_guidance")
     }
   }
@@ -163,8 +163,8 @@ const FeelingNotWellContent: FunctionComponent<FeelingNotWellContentProps> = ({
       <GlobalText style={style.checkInHeaderText}>
         {t("symptom_checker.sorry_to_hear_it")}
       </GlobalText>
-      <GlobalText style={style.healthRecommendationText}>
-        {determineHealthRecommendationText()}
+      <GlobalText style={style.healthAssessmentText}>
+        {determineHealthAssessmentText()}
       </GlobalText>
       <View style={style.symptomsContainer}>
         {symptoms.map((value) => {
@@ -256,7 +256,7 @@ const style = StyleSheet.create({
     height: Iconography.small,
     marginBottom: Spacing.xxSmall,
   },
-  healthRecommendationText: {
+  healthAssessmentText: {
     ...Typography.header5,
     ...Typography.base,
     marginTop: Spacing.medium,

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -73,7 +73,11 @@ const SelectSymptomsScreen: FunctionComponent = () => {
             </TouchableOpacity>
           )
         })}
-        <Button onPress={handleOnPressSave} label={t("common.save")} />
+        <Button
+          onPress={handleOnPressSave}
+          label={t("common.save")}
+          disabled={selectedSymptoms.length === 0}
+        />
       </ScrollView>
     </>
   )

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -118,7 +118,6 @@ const style = StyleSheet.create({
     marginBottom: Spacing.medium,
   },
   symptomButton: {
-    alignSelf: "flex-start",
     borderWidth: Outlines.hairline,
     borderColor: Colors.neutral25,
     borderRadius: Outlines.borderRadiusMax,

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -48,7 +48,7 @@ const SelectSymptomsScreen: FunctionComponent = () => {
   const handleOnPressSave = () => {
     updateSymptoms(selectedSymptoms)
     const currentHealthAssessment = determineHealthAssessment(selectedSymptoms)
-    if (currentHealthAssessment === HealthAssessment.GetTested) {
+    if (currentHealthAssessment === HealthAssessment.AtRisk) {
       navigation.navigate(SymptomCheckerStackScreens.AtRiskRecommendation)
     } else {
       navigation.goBack()

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -1,16 +1,20 @@
 import React, { FunctionComponent, useState } from "react"
 import { TouchableOpacity, StyleSheet, ScrollView } from "react-native"
 import { useTranslation } from "react-i18next"
+import { useNavigation } from "@react-navigation/native"
 
 import { useStatusBarEffect } from "../navigation"
-import { GlobalText } from "../components"
+import { GlobalText, Button } from "../components"
+import { useSymptomCheckerContext } from "./SymptomCheckerContext"
 
 import { Colors, Spacing } from "../styles"
 
 const SelectSymptomsScreen: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const { t } = useTranslation()
+  const navigation = useNavigation()
   const [selectedSymptoms, setSelectedSymptoms] = useState<string[]>([])
+  const { updateSymptoms } = useSymptomCheckerContext()
 
   const symptoms = [
     t("symptoms.chest_pain_or_pressure"),
@@ -40,6 +44,11 @@ const SelectSymptomsScreen: FunctionComponent = () => {
     }
   }
 
+  const handleOnPressSave = () => {
+    updateSymptoms(selectedSymptoms)
+    navigation.goBack()
+  }
+
   const determineSymptomButtonStyle = (symptom: string) => {
     return selectedSymptoms.includes(symptom)
       ? style.symptomButtonSelected
@@ -64,6 +73,7 @@ const SelectSymptomsScreen: FunctionComponent = () => {
             </TouchableOpacity>
           )
         })}
+        <Button onPress={handleOnPressSave} label={t("common.save")} />
       </ScrollView>
     </>
   )

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -68,38 +68,36 @@ const SelectSymptomsScreen: FunctionComponent = () => {
   }
 
   return (
-    <>
-      <ScrollView
-        style={style.container}
-        contentContainerStyle={style.contentContainer}
-        alwaysBounceVertical={false}
-      >
-        <GlobalText style={style.headerText}>
-          {t("symptom_checker.what_symptoms")}
-        </GlobalText>
-        <View style={style.symptomButtonsContainer}>
-          {symptoms.map((value) => {
-            return (
-              <TouchableHighlight
-                key={value}
-                onPress={() => handleOnPressSymptom(value)}
-                style={determineSymptomButtonStyle(value)}
-                underlayColor={Colors.neutral10}
-              >
-                <GlobalText style={determineSymptomButtonTextStyle(value)}>
-                  {value}
-                </GlobalText>
-              </TouchableHighlight>
-            )
-          })}
-        </View>
-        <Button
-          onPress={handleOnPressSave}
-          label={t("common.save")}
-          disabled={selectedSymptoms.length === 0}
-        />
-      </ScrollView>
-    </>
+    <ScrollView
+      style={style.container}
+      contentContainerStyle={style.contentContainer}
+      alwaysBounceVertical={false}
+    >
+      <GlobalText style={style.headerText}>
+        {t("symptom_checker.what_symptoms")}
+      </GlobalText>
+      <View style={style.symptomButtonsContainer}>
+        {symptoms.map((value) => {
+          return (
+            <TouchableHighlight
+              key={value}
+              onPress={() => handleOnPressSymptom(value)}
+              style={determineSymptomButtonStyle(value)}
+              underlayColor={Colors.neutral10}
+            >
+              <GlobalText style={determineSymptomButtonTextStyle(value)}>
+                {value}
+              </GlobalText>
+            </TouchableHighlight>
+          )
+        })}
+      </View>
+      <Button
+        onPress={handleOnPressSave}
+        label={t("common.save")}
+        disabled={selectedSymptoms.length === 0}
+      />
+    </ScrollView>
   )
 }
 

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -1,24 +1,24 @@
 import React, { FunctionComponent } from "react"
 import { StyleSheet, ScrollView } from "react-native"
+import { useTranslation } from "react-i18next"
 
 import { useStatusBarEffect } from "../navigation"
-import { StatusBar } from "../components"
-import CheckIn from "./CheckIn"
+import { GlobalText } from "../components"
 
 import { Colors, Spacing } from "../styles"
 
-const SymptomCheckerScreen: FunctionComponent = () => {
+const SelectSymptomsScreen: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
+  const { t } = useTranslation()
 
   return (
     <>
-      <StatusBar backgroundColor={Colors.primaryLightBackground} />
       <ScrollView
         style={style.container}
         contentContainerStyle={style.contentContainer}
         alwaysBounceVertical={false}
       >
-        <CheckIn />
+        <GlobalText>{t("common.continue")}</GlobalText>
       </ScrollView>
     </>
   )
@@ -36,4 +36,4 @@ const style = StyleSheet.create({
   },
 })
 
-export default SymptomCheckerScreen
+export default SelectSymptomsScreen

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from "@react-navigation/native"
 import { useStatusBarEffect, SymptomCheckerStackScreens } from "../navigation"
 import { GlobalText, Button } from "../components"
 import { useSymptomCheckerContext } from "./SymptomCheckerContext"
-import { HealthRecommendation, determineHealthRecommendation } from "./symptoms"
+import { HealthAssessment, determineHealthAssessment } from "./symptoms"
 
 import { Colors, Spacing, Typography, Outlines } from "../styles"
 
@@ -15,7 +15,7 @@ const SelectSymptomsScreen: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
   const [selectedSymptoms, setSelectedSymptoms] = useState<string[]>([])
-  const { updateSymptoms, healthRecommendation } = useSymptomCheckerContext()
+  const { updateSymptoms } = useSymptomCheckerContext()
 
   const symptoms = [
     t("symptoms.chest_pain_or_pressure"),
@@ -47,10 +47,8 @@ const SelectSymptomsScreen: FunctionComponent = () => {
 
   const handleOnPressSave = () => {
     updateSymptoms(selectedSymptoms)
-    const currentHealthRecommendation = determineHealthRecommendation(
-      selectedSymptoms,
-    )
-    if (currentHealthRecommendation === HealthRecommendation.GetTested) {
+    const currentHealthAssessment = determineHealthAssessment(selectedSymptoms)
+    if (currentHealthAssessment === HealthAssessment.GetTested) {
       navigation.navigate(SymptomCheckerStackScreens.AtRiskRecommendation)
     } else {
       navigation.goBack()

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useState } from "react"
-import { TouchableOpacity, StyleSheet, ScrollView } from "react-native"
+import { View, TouchableHighlight, StyleSheet, ScrollView } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
@@ -7,7 +7,7 @@ import { useStatusBarEffect } from "../navigation"
 import { GlobalText, Button } from "../components"
 import { useSymptomCheckerContext } from "./SymptomCheckerContext"
 
-import { Colors, Spacing } from "../styles"
+import { Colors, Spacing, Typography, Outlines } from "../styles"
 
 const SelectSymptomsScreen: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
@@ -51,8 +51,14 @@ const SelectSymptomsScreen: FunctionComponent = () => {
 
   const determineSymptomButtonStyle = (symptom: string) => {
     return selectedSymptoms.includes(symptom)
-      ? style.symptomButtonSelected
+      ? { ...style.symptomButton, ...style.symptomButtonSelected }
       : style.symptomButton
+  }
+
+  const determineSymptomButtonTextStyle = (symptom: string) => {
+    return selectedSymptoms.includes(symptom)
+      ? { ...style.symptomButtonText, ...style.symptomButtonTextSelected }
+      : style.symptomButtonText
   }
 
   return (
@@ -62,17 +68,25 @@ const SelectSymptomsScreen: FunctionComponent = () => {
         contentContainerStyle={style.contentContainer}
         alwaysBounceVertical={false}
       >
-        {symptoms.map((value) => {
-          return (
-            <TouchableOpacity
-              key={value}
-              onPress={() => handleOnPressSymptom(value)}
-              style={determineSymptomButtonStyle(value)}
-            >
-              <GlobalText>{value}</GlobalText>
-            </TouchableOpacity>
-          )
-        })}
+        <GlobalText style={style.headerText}>
+          {t("symptom_checker.what_symptoms")}
+        </GlobalText>
+        <View style={style.symptomButtonsContainer}>
+          {symptoms.map((value) => {
+            return (
+              <TouchableHighlight
+                key={value}
+                onPress={() => handleOnPressSymptom(value)}
+                style={determineSymptomButtonStyle(value)}
+                underlayColor={Colors.neutral10}
+              >
+                <GlobalText style={determineSymptomButtonTextStyle(value)}>
+                  {value}
+                </GlobalText>
+              </TouchableHighlight>
+            )
+          })}
+        </View>
         <Button
           onPress={handleOnPressSave}
           label={t("common.save")}
@@ -92,10 +106,36 @@ const style = StyleSheet.create({
     backgroundColor: Colors.primaryLightBackground,
     paddingTop: Spacing.xxxHuge,
     paddingHorizontal: Spacing.large,
+    paddingBottom: Spacing.xxHuge,
   },
-  symptomButton: {},
+  headerText: {
+    ...Typography.header2,
+    marginBottom: Spacing.large,
+  },
+  symptomButtonsContainer: {
+    flexWrap: "wrap",
+    flexDirection: "row",
+    marginBottom: Spacing.medium,
+  },
+  symptomButton: {
+    alignSelf: "flex-start",
+    borderWidth: Outlines.hairline,
+    borderColor: Colors.neutral25,
+    borderRadius: Outlines.borderRadiusMax,
+    paddingVertical: Spacing.xxSmall,
+    paddingHorizontal: Spacing.medium,
+    marginBottom: Spacing.small,
+    marginRight: Spacing.small,
+  },
   symptomButtonSelected: {
-    backgroundColor: Colors.success100,
+    backgroundColor: Colors.primary100,
+    borderColor: Colors.primary100,
+  },
+  symptomButtonText: {
+    ...Typography.body1,
+  },
+  symptomButtonTextSelected: {
+    color: Colors.white,
   },
 })
 

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent } from "react"
-import { StyleSheet, ScrollView } from "react-native"
+import React, { FunctionComponent, useState } from "react"
+import { TouchableOpacity, StyleSheet, ScrollView } from "react-native"
 import { useTranslation } from "react-i18next"
 
 import { useStatusBarEffect } from "../navigation"
@@ -10,6 +10,41 @@ import { Colors, Spacing } from "../styles"
 const SelectSymptomsScreen: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const { t } = useTranslation()
+  const [selectedSymptoms, setSelectedSymptoms] = useState<string[]>([])
+
+  const symptoms = [
+    t("symptoms.chest_pain_or_pressure"),
+    t("symptoms.difficulty_breathing"),
+    t("symptoms.lightheadedness"),
+    t("symptoms.disorientation_or_unresponsiveness"),
+    t("symptoms.fever"),
+    t("symptoms.chills"),
+    t("symptoms.cough"),
+    t("symptoms.loss_of_smell"),
+    t("symptoms.loss_of_taste"),
+    t("symptoms.loss_of_appetite"),
+    t("symptoms.vomiting"),
+    t("symptoms.diarrhea"),
+    t("symptoms.body_aches"),
+    t("symptoms.other"),
+  ]
+
+  const handleOnPressSymptom = (selectedSymptom: string) => {
+    const indexOfSelectedSymptom = selectedSymptoms.indexOf(selectedSymptom)
+    if (indexOfSelectedSymptom >= 0) {
+      const newSelectedSymptoms = [...selectedSymptoms]
+      newSelectedSymptoms.splice(indexOfSelectedSymptom, 1)
+      setSelectedSymptoms(newSelectedSymptoms)
+    } else {
+      setSelectedSymptoms([...selectedSymptoms, selectedSymptom])
+    }
+  }
+
+  const determineSymptomButtonStyle = (symptom: string) => {
+    return selectedSymptoms.includes(symptom)
+      ? style.symptomButtonSelected
+      : style.symptomButton
+  }
 
   return (
     <>
@@ -18,7 +53,17 @@ const SelectSymptomsScreen: FunctionComponent = () => {
         contentContainerStyle={style.contentContainer}
         alwaysBounceVertical={false}
       >
-        <GlobalText>{t("common.continue")}</GlobalText>
+        {symptoms.map((value) => {
+          return (
+            <TouchableOpacity
+              key={value}
+              onPress={() => handleOnPressSymptom(value)}
+              style={determineSymptomButtonStyle(value)}
+            >
+              <GlobalText>{value}</GlobalText>
+            </TouchableOpacity>
+          )
+        })}
       </ScrollView>
     </>
   )
@@ -33,6 +78,10 @@ const style = StyleSheet.create({
     backgroundColor: Colors.primaryLightBackground,
     paddingTop: Spacing.xxxHuge,
     paddingHorizontal: Spacing.large,
+  },
+  symptomButton: {},
+  symptomButtonSelected: {
+    backgroundColor: Colors.success100,
   },
 })
 

--- a/src/SymptomChecker/SelectSymptoms.tsx
+++ b/src/SymptomChecker/SelectSymptoms.tsx
@@ -3,9 +3,10 @@ import { View, TouchableHighlight, StyleSheet, ScrollView } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
-import { useStatusBarEffect } from "../navigation"
+import { useStatusBarEffect, SymptomCheckerStackScreens } from "../navigation"
 import { GlobalText, Button } from "../components"
 import { useSymptomCheckerContext } from "./SymptomCheckerContext"
+import { HealthRecommendation, determineHealthRecommendation } from "./symptoms"
 
 import { Colors, Spacing, Typography, Outlines } from "../styles"
 
@@ -14,7 +15,7 @@ const SelectSymptomsScreen: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
   const [selectedSymptoms, setSelectedSymptoms] = useState<string[]>([])
-  const { updateSymptoms } = useSymptomCheckerContext()
+  const { updateSymptoms, healthRecommendation } = useSymptomCheckerContext()
 
   const symptoms = [
     t("symptoms.chest_pain_or_pressure"),
@@ -46,7 +47,14 @@ const SelectSymptomsScreen: FunctionComponent = () => {
 
   const handleOnPressSave = () => {
     updateSymptoms(selectedSymptoms)
-    navigation.goBack()
+    const currentHealthRecommendation = determineHealthRecommendation(
+      selectedSymptoms,
+    )
+    if (currentHealthRecommendation === HealthRecommendation.GetTested) {
+      navigation.navigate(SymptomCheckerStackScreens.AtRiskRecommendation)
+    } else {
+      navigation.goBack()
+    }
   }
 
   const determineSymptomButtonStyle = (symptom: string) => {

--- a/src/SymptomChecker/SymptomCheckerContext.tsx
+++ b/src/SymptomChecker/SymptomCheckerContext.tsx
@@ -16,13 +16,13 @@ type SymptomCheckerContextState = {
 export const SymptomCheckerContext = createContext<SymptomCheckerContextState>({
   symptoms: [],
   updateSymptoms: () => {},
-  healthAssessment: HealthAssessment.FollowHAGuidance,
+  healthAssessment: HealthAssessment.NotAtRisk,
 })
 
 const SymptomCheckerProvider: FunctionComponent = ({ children }) => {
   const [symptoms, setSymptoms] = useState<Symptom[]>([])
   const [healthAssessment, setHealthAssessment] = useState<HealthAssessment>(
-    HealthAssessment.FollowHAGuidance,
+    HealthAssessment.NotAtRisk,
   )
 
   const updateSymptoms = (newSymptoms: Symptom[]) => {

--- a/src/SymptomChecker/SymptomCheckerContext.tsx
+++ b/src/SymptomChecker/SymptomCheckerContext.tsx
@@ -2,40 +2,40 @@ import React, { FunctionComponent, useState, useEffect } from "react"
 import { createContext, useContext } from "react"
 
 import {
-  determineHealthRecommendation,
+  determineHealthAssessment,
   Symptom,
-  HealthRecommendation,
+  HealthAssessment,
 } from "./symptoms"
 
 type SymptomCheckerContextState = {
   symptoms: Symptom[]
   updateSymptoms: (newSymptoms: Symptom[]) => void
-  healthRecommendation: HealthRecommendation
+  healthAssessment: HealthAssessment
 }
 
 export const SymptomCheckerContext = createContext<SymptomCheckerContextState>({
   symptoms: [],
   updateSymptoms: () => {},
-  healthRecommendation: HealthRecommendation.FollowHAGuidance,
+  healthAssessment: HealthAssessment.FollowHAGuidance,
 })
 
 const SymptomCheckerProvider: FunctionComponent = ({ children }) => {
   const [symptoms, setSymptoms] = useState<Symptom[]>([])
-  const [healthRecommendation, setHealthRecommendation] = useState<
-    HealthRecommendation
-  >(HealthRecommendation.FollowHAGuidance)
+  const [healthAssessment, setHealthAssessment] = useState<HealthAssessment>(
+    HealthAssessment.FollowHAGuidance,
+  )
 
   const updateSymptoms = (newSymptoms: Symptom[]) => {
     setSymptoms(newSymptoms)
   }
 
   useEffect(() => {
-    setHealthRecommendation(determineHealthRecommendation(symptoms))
-  }, [setHealthRecommendation, symptoms])
+    setHealthAssessment(determineHealthAssessment(symptoms))
+  }, [setHealthAssessment, symptoms])
 
   return (
     <SymptomCheckerContext.Provider
-      value={{ symptoms, updateSymptoms, healthRecommendation }}
+      value={{ symptoms, updateSymptoms, healthAssessment }}
     >
       {children}
     </SymptomCheckerContext.Provider>

--- a/src/SymptomChecker/SymptomCheckerContext.tsx
+++ b/src/SymptomChecker/SymptomCheckerContext.tsx
@@ -1,0 +1,38 @@
+import React, { FunctionComponent, useState } from "react"
+import { createContext, useContext } from "react"
+
+type Symptom = string
+
+type SymptomCheckerContextState = {
+  symptoms: Symptom[]
+  updateSymptoms: (newSymptoms: Symptom[]) => void
+}
+
+export const SymptomCheckerContext = createContext<SymptomCheckerContextState>({
+  symptoms: [],
+  updateSymptoms: () => {},
+})
+
+const SymptomCheckerProvider: FunctionComponent = ({ children }) => {
+  const [symptoms, setSymptoms] = useState<Symptom[]>([])
+
+  const updateSymptoms = (newSymptoms: Symptom[]) => {
+    setSymptoms(newSymptoms)
+  }
+
+  return (
+    <SymptomCheckerContext.Provider value={{ symptoms, updateSymptoms }}>
+      {children}
+    </SymptomCheckerContext.Provider>
+  )
+}
+
+const useSymptomCheckerContext = (): SymptomCheckerContextState => {
+  const context = useContext(SymptomCheckerContext)
+  if (context === undefined) {
+    throw new Error("SymptomCheckerContext must be used with a provider")
+  }
+  return context
+}
+
+export { SymptomCheckerProvider, useSymptomCheckerContext }

--- a/src/SymptomChecker/SymptomCheckerContext.tsx
+++ b/src/SymptomChecker/SymptomCheckerContext.tsx
@@ -1,27 +1,42 @@
-import React, { FunctionComponent, useState } from "react"
+import React, { FunctionComponent, useState, useEffect } from "react"
 import { createContext, useContext } from "react"
 
-type Symptom = string
+import {
+  determineHealthRecommendation,
+  Symptom,
+  HealthRecommendation,
+} from "./symptoms"
 
 type SymptomCheckerContextState = {
   symptoms: Symptom[]
   updateSymptoms: (newSymptoms: Symptom[]) => void
+  healthRecommendation: HealthRecommendation
 }
 
 export const SymptomCheckerContext = createContext<SymptomCheckerContextState>({
   symptoms: [],
   updateSymptoms: () => {},
+  healthRecommendation: HealthRecommendation.FollowHAGuidance,
 })
 
 const SymptomCheckerProvider: FunctionComponent = ({ children }) => {
   const [symptoms, setSymptoms] = useState<Symptom[]>([])
+  const [healthRecommendation, setHealthRecommendation] = useState<
+    HealthRecommendation
+  >(HealthRecommendation.FollowHAGuidance)
 
   const updateSymptoms = (newSymptoms: Symptom[]) => {
     setSymptoms(newSymptoms)
   }
 
+  useEffect(() => {
+    setHealthRecommendation(determineHealthRecommendation(symptoms))
+  }, [setHealthRecommendation, symptoms])
+
   return (
-    <SymptomCheckerContext.Provider value={{ symptoms, updateSymptoms }}>
+    <SymptomCheckerContext.Provider
+      value={{ symptoms, updateSymptoms, healthRecommendation }}
+    >
       {children}
     </SymptomCheckerContext.Provider>
   )

--- a/src/SymptomChecker/symptoms.ts
+++ b/src/SymptomChecker/symptoms.ts
@@ -1,6 +1,6 @@
 export enum HealthAssessment {
-  GetTested,
-  FollowHAGuidance,
+  AtRisk,
+  NotAtRisk,
 }
 
 export type Symptom = string
@@ -9,7 +9,7 @@ export const determineHealthAssessment = (
   symptoms: Symptom[],
 ): HealthAssessment => {
   if (symptoms.length > 3) {
-    return HealthAssessment.GetTested
+    return HealthAssessment.AtRisk
   }
-  return HealthAssessment.FollowHAGuidance
+  return HealthAssessment.NotAtRisk
 }

--- a/src/SymptomChecker/symptoms.ts
+++ b/src/SymptomChecker/symptoms.ts
@@ -1,0 +1,15 @@
+export enum HealthRecommendation {
+  GetTested,
+  FollowHAGuidance,
+}
+
+export type Symptom = string
+
+export const determineHealthRecommendation = (
+  symptoms: Symptom[],
+): HealthRecommendation => {
+  if (symptoms.length > 3) {
+    return HealthRecommendation.GetTested
+  }
+  return HealthRecommendation.FollowHAGuidance
+}

--- a/src/SymptomChecker/symptoms.ts
+++ b/src/SymptomChecker/symptoms.ts
@@ -1,15 +1,15 @@
-export enum HealthRecommendation {
+export enum HealthAssessment {
   GetTested,
   FollowHAGuidance,
 }
 
 export type Symptom = string
 
-export const determineHealthRecommendation = (
+export const determineHealthAssessment = (
   symptoms: Symptom[],
-): HealthRecommendation => {
+): HealthAssessment => {
   if (symptoms.length > 3) {
-    return HealthRecommendation.GetTested
+    return HealthAssessment.GetTested
   }
-  return HealthRecommendation.FollowHAGuidance
+  return HealthAssessment.FollowHAGuidance
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,9 +2,9 @@
   "_display_name": "English",
   "about": {
     "description": "The {{applicationName}} app is made available by {{healthAuthorityName}}",
+    "emergency_contact": "Emergency Contact",
     "operating_system_abbr": "OS:",
-    "version": "Version:",
-    "emergency_contact": "Emergency Contact"
+    "version": "Version:"
   },
   "assessment": {
     "agree_question_description": "Stop and call emergency services if you are experiencing:\n• Severe, constant chest pain or pressure \n• Extreme difficulty breathing \n• Severe, constant lightheadedness \n• Serious disorientation or unresponsiveness",
@@ -34,23 +34,23 @@
     "isolate_title": "Isolate Yourself",
     "next": "Next",
     "share_cta": "I understand and consent",
-    "share_cta_skip": "No thanks, I don't want to share data",
     "share_description": "Your anonymous data helps the {{authority}} analyze, track, and contain the spread of COVID-19. Your data will be aggregated that from other PathCheck users who choose to share.\n\nYour data contains your survey responses and zip code, but no additional or personally-identifying information.\n\nThe {{authority}} will retain your anonymous data for a specific period of time.",
     "share_title": "Publish anonymized data",
     "start_cta": "Start",
     "start_description": "Your information is private, anonymized, and encrypted. No data leaves your device unless you give permission.",
-    "start_title": "Answer questions about your symptoms and medical history to learn what to do next about COVID-19"
+    "start_title": "Answer questions about your symptoms and medical history to learn what to do next about COVID-19",
+    "share_cta_skip": "No thanks, I don't want to share data"
   },
   "callback": {
     "fill_out_the_info": "Fill out the information below and a contact tracer from {{healthAuthorityName}} will get in touch.",
     "firstname": "First name",
     "lastname": "Last name",
     "phone_number_required": "Phone number (required)",
-    "well_get_in_touch": "We'll get in touch",
-    "success_header": "You're in the queue",
     "success_body": "Our contact tracers are working hard to keep you and your community safe. The {{healthAuthorityName}} has received your request for a call back. An expert will contact you within 24 hours.",
     "success_got_it": "Got it",
-    "success_requested": "Call Back Requested"
+    "success_header": "You're in the queue",
+    "success_requested": "Call Back Requested",
+    "well_get_in_touch": "We'll get in touch"
   },
   "common": {
     "alert": "Alert",
@@ -63,6 +63,7 @@
     "maybe_later": "Maybe later",
     "next": "Next",
     "no_thanks": "No thanks",
+    "save": "Save",
     "settings": "Open Settings",
     "skip": "Skip",
     "something_went_wrong": "Something went wrong",
@@ -116,17 +117,17 @@
   "exposure_history": {
     "exposure_detail": {
       "6ft_apart": "6ft apart",
+      "call_later": "Call later",
       "content": "Someone you were nearby has since tested positive for COVID-19.",
       "ha_guidance_header": "What should I do?",
       "ha_guidance_subheader": "See guidance from {{healthAuthorityName}}.",
       "header": "You may have crossed paths with the COVID-19 virus.",
       "isolate": "Isolate",
       "next_steps": "Next Steps",
-      "wash_your_hands": "Wash your hands",
-      "wear_a_mask": "Wear a mask",
       "schedule_callback": "Schedule a call to get support from a contact tracer from the {{healthAuthorityName}}.",
       "speak_with_contact_tracer": "Speak with a contact tracer",
-      "call_later": "Call later"
+      "wash_your_hands": "Wash your hands",
+      "wear_a_mask": "Wear a mask"
     },
     "exposure_window": {
       "four_to_six_days_ago": "4 to 6 days ago",
@@ -194,7 +195,6 @@
     "check": "Checkmark",
     "checked_checkbox": "Checked checkbox",
     "go_to_home_view": "Go to Home view",
-    "language_icon": "Outlined icon of a globe",
     "launch_enable_notif": "Enable Notifications",
     "launch_get_started": "Get Started",
     "launch_screen1_header": "Welcome to ",
@@ -202,25 +202,13 @@
     "question_icon": "Question mark icon",
     "unchecked_checkbox": "Unchecked checkbox"
   },
-  "more": {
-    "select_language": "Select language"
-  },
   "navigation": {
     "connect": "Connect",
     "exposure": "Exposure",
     "exposure_history": "Exposure History",
     "home": "Home",
-    "symptom_checker": "symptom_checker",
-    "more_info": "More Info"
-  },
-  "symptom_checker": {
-    "my_health": "My Health",
-    "check-in": "Check-in",
-    "how_are_you_feeling": "How are you feeling today?",
-    "good": "Good",
-    "not_well": "Not well",
-    "glad_to_hear_it": "Glad to hear it!",
-    "sorry_to_hear_it": "Sorry to hear you're not feeling well!"
+    "more_info": "More Info",
+    "symptom_checker": "symptom_checker"
   },
   "onboarding": {
     "activation_header_title": "App Setup",
@@ -295,13 +283,40 @@
     "success": "We received your request. Thank you!"
   },
   "screen_titles": {
-    "about": "About",
     "callback": "Request Call Back",
     "debug": "Debug",
     "exposure_history": "Exposure History",
     "exposures": "Exposures",
+    "how_the_app_works": "How the app works",
     "legal": "Legal",
-    "report_issue": "Report an Issue",
-    "how_the_app_works": "How the app works"
+    "report_issue": "Report an Issue"
+  },
+  "symptom_checker": {
+    "check-in": "Check-in",
+    "follow_ha_guidance": "Based on your symptoms, it does not seem like you have COVID-19.",
+    "get_tested": "Based on your symptoms, we recommend you get tested for COVID-19.",
+    "glad_to_hear_it": "Glad to hear it!",
+    "good": "Good",
+    "how_are_you_feeling": "How are you feeling today?",
+    "my_health": "My Health",
+    "not_well": "Not well",
+    "sorry_to_hear_it": "Sorry to hear you're not feeling well!",
+    "what_symptoms": "What symptoms are you experiencing?"
+  },
+  "symptoms": {
+    "body_aches": "Body aches",
+    "chest_pain_or_pressure": "Chest pain or pressure",
+    "chills": "Chills",
+    "cough": "Cough",
+    "diarrhea": "Diarrhea",
+    "difficulty_breathing": "Difficulty breathing",
+    "disorientation_or_unresponsiveness": "Disorientation or unresponsiveness",
+    "fever": "Fever",
+    "lightheadedness": "Lightheadedness",
+    "loss_of_appetite": "Loss of appetite",
+    "loss_of_smell": "Loss of smell",
+    "loss_of_taste": "Loss of taste",
+    "other": "Other",
+    "vomiting": "Vomiting"
   }
 }

--- a/src/navigation/SymptomCheckerStack.tsx
+++ b/src/navigation/SymptomCheckerStack.tsx
@@ -7,28 +7,31 @@ import {
 import { SymptomCheckerStackScreens } from "./index"
 import SymptomCheckerScreen from "../SymptomChecker/"
 import SelectSymptomsScreen from "../SymptomChecker/SelectSymptoms"
+import { SymptomCheckerProvider } from "../SymptomChecker/SymptomCheckerContext"
 
 const Stack = createStackNavigator()
 
 const SymptomCheckerStack: FunctionComponent = () => {
   return (
-    <Stack.Navigator>
-      <Stack.Screen
-        name={SymptomCheckerStackScreens.SymptomChecker}
-        component={SymptomCheckerScreen}
-        options={{ headerShown: false }}
-      />
-      <Stack.Screen
-        name={SymptomCheckerStackScreens.SelectSymptoms}
-        component={SelectSymptomsScreen}
-        options={{
-          headerShown: false,
-          ...TransitionPresets.ModalPresentationIOS,
-          cardOverlayEnabled: true,
-          gestureEnabled: false,
-        }}
-      />
-    </Stack.Navigator>
+    <SymptomCheckerProvider>
+      <Stack.Navigator>
+        <Stack.Screen
+          name={SymptomCheckerStackScreens.SymptomChecker}
+          component={SymptomCheckerScreen}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name={SymptomCheckerStackScreens.SelectSymptoms}
+          component={SelectSymptomsScreen}
+          options={{
+            headerShown: false,
+            ...TransitionPresets.ModalPresentationIOS,
+            cardOverlayEnabled: true,
+            gestureEnabled: false,
+          }}
+        />
+      </Stack.Navigator>
+    </SymptomCheckerProvider>
   )
 }
 

--- a/src/navigation/SymptomCheckerStack.tsx
+++ b/src/navigation/SymptomCheckerStack.tsx
@@ -4,10 +4,11 @@ import {
   TransitionPresets,
 } from "@react-navigation/stack"
 
-import { SymptomCheckerStackScreens } from "./index"
 import SymptomCheckerScreen from "../SymptomChecker/"
 import SelectSymptomsScreen from "../SymptomChecker/SelectSymptoms"
+import AtRiskRecommendationScreen from "../SymptomChecker/AtRiskRecommendation"
 import { SymptomCheckerProvider } from "../SymptomChecker/SymptomCheckerContext"
+import { SymptomCheckerStackScreens } from "./index"
 
 const Stack = createStackNavigator()
 
@@ -28,6 +29,13 @@ const SymptomCheckerStack: FunctionComponent = () => {
             ...TransitionPresets.ModalPresentationIOS,
             cardOverlayEnabled: true,
             gestureEnabled: false,
+          }}
+        />
+        <Stack.Screen
+          name={SymptomCheckerStackScreens.AtRiskRecommendation}
+          component={AtRiskRecommendationScreen}
+          options={{
+            headerShown: false,
           }}
         />
       </Stack.Navigator>

--- a/src/navigation/SymptomCheckerStack.tsx
+++ b/src/navigation/SymptomCheckerStack.tsx
@@ -1,8 +1,12 @@
 import React, { FunctionComponent } from "react"
-import { createStackNavigator } from "@react-navigation/stack"
+import {
+  createStackNavigator,
+  TransitionPresets,
+} from "@react-navigation/stack"
 
 import { SymptomCheckerStackScreens } from "./index"
 import SymptomCheckerScreen from "../SymptomChecker/"
+import SelectSymptomsScreen from "../SymptomChecker/SelectSymptoms"
 
 const Stack = createStackNavigator()
 
@@ -13,6 +17,16 @@ const SymptomCheckerStack: FunctionComponent = () => {
         name={SymptomCheckerStackScreens.SymptomChecker}
         component={SymptomCheckerScreen}
         options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={SymptomCheckerStackScreens.SelectSymptoms}
+        component={SelectSymptomsScreen}
+        options={{
+          headerShown: false,
+          ...TransitionPresets.ModalPresentationIOS,
+          cardOverlayEnabled: true,
+          gestureEnabled: false,
+        }}
       />
     </Stack.Navigator>
   )

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -176,12 +176,13 @@ export const ReportIssueScreens: {
   ReportIssue: "ReportIssue",
 }
 
-export type SymptomCheckerStackScreen = "SymptomChecker"
+export type SymptomCheckerStackScreen = "SymptomChecker" | "SelectSymptoms"
 
 export const SymptomCheckerStackScreens: {
   [key in SymptomCheckerStackScreen]: SymptomCheckerStackScreen
 } = {
   SymptomChecker: "SymptomChecker",
+  SelectSymptoms: "SelectSymptoms",
 }
 
 export type Stack =

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -176,13 +176,17 @@ export const ReportIssueScreens: {
   ReportIssue: "ReportIssue",
 }
 
-export type SymptomCheckerStackScreen = "SymptomChecker" | "SelectSymptoms"
+export type SymptomCheckerStackScreen =
+  | "SymptomChecker"
+  | "SelectSymptoms"
+  | "AtRiskRecommendation"
 
 export const SymptomCheckerStackScreens: {
   [key in SymptomCheckerStackScreen]: SymptomCheckerStackScreen
 } = {
   SymptomChecker: "SymptomChecker",
   SelectSymptoms: "SelectSymptoms",
+  AtRiskRecommendation: "AtRiskRecommendation",
 }
 
 export type Stack =

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -39,7 +39,7 @@ export const semiBoldFontFamily = "IBMPlexSans-SemiBold"
 export const boldFontFamily = "IBMPlexSans-Bold"
 export const monospaceFontFamily = "IBMPlexMono"
 
-const base: TextStyle = {
+export const base: TextStyle = {
   fontFamily: baseFontFamily,
   fontWeight: baseWeight,
   letterSpacing: baseLetterSpacing,


### PR DESCRIPTION
Why: as a user, I would like to be able to select some symptoms and be given a recommendation on how to proceed.

This commit:
- Adds the ability for a user to select symptoms from a list
- Gives the user a recommendation based on their symptoms. Right now, the scoring is just based on whether the user has selected more than 3 symptoms. Of course, this is a placeholder.
- Adds a screen that the user is navigated to if their symptoms indicate they may be at risk
- Adds a `SymptomCheckerContext`

Co-Authored-By: Alejandro Dustet <alejandro@thoughtbot.com>
Co-Authored-By: John Schoeman <johnschoeman1617@gmail.com>

![gif2](https://user-images.githubusercontent.com/39350030/93390481-c039e500-f83b-11ea-8e29-672235f8d4cb.gif)