### PR TITLE
Add custom gradient style for buttons

### DIFF
--- a/src/Activation/ActivationSummary.tsx
+++ b/src/Activation/ActivationSummary.tsx
@@ -50,6 +50,7 @@ const ActivationSummary: FunctionComponent = () => {
           label={t("common.settings")}
           onPress={handleOnPressOpenSettings}
           customButtonStyle={style.primaryButton}
+          customButtonInnerStyle={style.primaryButtonGradient}
         />
         <TouchableOpacity
           onPress={handleOnPressGoToHome}
@@ -69,6 +70,7 @@ const ActivationSummary: FunctionComponent = () => {
         label={t("label.go_to_home_view")}
         onPress={handleOnPressGoToHome}
         customButtonStyle={style.primaryButton}
+        customButtonInnerStyle={style.primaryButtonGradient}
       />
     )
   }
@@ -161,6 +163,9 @@ const style = StyleSheet.create({
   primaryButton: {
     width: "100%",
     marginBottom: Spacing.xxSmall,
+  },
+  primaryButtonGradient: {
+    width: "100%",
   },
   secondaryButton: {
     ...Buttons.secondary,

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -106,6 +106,7 @@ const RequestCallBackActions: FunctionComponent<RequestCallBackActionsProps> = (
       </GlobalText>
       <Button
         customButtonStyle={style.requestCallbackButton}
+        customButtonInnerStyle={style.requestCallbackButtonGradient}
         onPress={navigateToCallbackForm}
         label={t("exposure_history.exposure_detail.speak_with_contact_tracer")}
         hasRightArrow
@@ -184,6 +185,11 @@ const style = StyleSheet.create({
   },
   requestCallbackButton: {
     marginBottom: Spacing.small,
+    width: "100%",
+    alignSelf: "center",
+  },
+  requestCallbackButtonGradient: {
+    width: "100%",
     padding: Spacing.small,
   },
   callLaterButton: {

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -136,6 +136,7 @@ const Home: FunctionComponent = () => {
               onPress={handleOnPressReportTestResult}
               label={t("home.bluetooth.report_positive_result")}
               customButtonStyle={style.button}
+              customButtonInnerStyle={style.buttonGradient}
               hasRightArrow
             />
           </View>
@@ -206,6 +207,9 @@ const style = StyleSheet.create({
     marginHorizontal: Spacing.small,
   },
   button: {
+    width: "100%",
+  },
+  buttonGradient: {
     width: "100%",
     paddingTop: Spacing.xSmall,
     paddingBottom: Spacing.xSmall + 1,

--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -112,6 +112,7 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
           <>
             <Button
               customButtonStyle={style.nextButton}
+              customButtonInnerStyle={style.nextButtonGradient}
               label={howItWorksScreenContent.primaryButtonLabel}
               onPress={howItWorksScreenContent.primaryButtonOnPress}
               hasRightArrow
@@ -192,6 +193,11 @@ const createStyle = (insets: EdgeInsets) => {
       paddingHorizontal: Spacing.large,
     },
     nextButton: {
+      width: "95%",
+      alignSelf: "center",
+      marginBottom: Spacing.xxSmall,
+    },
+    nextButtonGradient: {
       paddingTop: Spacing.xSmall,
       paddingBottom: Spacing.xSmall + 1,
       width: "95%",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -21,6 +21,7 @@ interface ButtonProps {
   loading?: boolean
   disabled?: boolean
   customButtonStyle?: ViewStyle
+  customButtonInnerStyle?: ViewStyle
   customTextStyle?: TextStyle
   testID?: string
   hasRightArrow?: boolean
@@ -33,6 +34,7 @@ const Button: FunctionComponent<ButtonProps> = ({
   disabled,
   loading,
   customButtonStyle,
+  customButtonInnerStyle,
   customTextStyle,
   testID,
   hasRightArrow,
@@ -84,7 +86,7 @@ const Button: FunctionComponent<ButtonProps> = ({
 
   const buttonStyle = {
     ...style.button,
-    ...customButtonStyle,
+    ...customButtonInnerStyle,
   }
 
   return (


### PR DESCRIPTION
Why:
----

On some android devices, there is a background that shows on some of the buttons in the application. We need the buttons to be displayed consistently among all the platforms.

<img width="250" alt="Screen Shot 2020-09-17 at 2 45 23 PM" src="https://user-images.githubusercontent.com/2413802/93515418-90034c80-f8f6-11ea-98f1-6eaac32798a4.png">

How:
----

The custom styles that are being applied to the buttons are being added both for the button and for the inner gradient used to display the color pattern on the buttons. On android devices, this style gets added twice resulting on the white bottom lines we can see in some of the buttons. We need as a first fix to separate those customizations. Meaning that style overrides for our buttons will have to take into consideration both the button and the inner gradient on it.

This Commit:
----

- Add a new argument for the button component to receive custom gradient
styles
- Update buttons on the how it works, activation summary and home
screens to use the new API

Co-authored-by: John Schoeman <johnschoeman1617@gmail.com>
Co-authored-By: devinjameson <devin@thoughtbot.com>

<img width="350" alt="Screen Shot 2020-09-17 at 2 45 23 PM" src="https://user-images.githubusercontent.com/2413802/93515489-ac06ee00-f8f6-11ea-85ba-0ed3d267072d.png"> <img width="350"  alt="Screen Shot 2020-09-17 at 2 45 41 PM" src="https://user-images.githubusercontent.com/2413802/93515494-ad381b00-f8f6-11ea-9a76-f3f544ef78a4.png"> 
<img width="350"  alt="Screen Shot 2020-09-17 at 2 45 51 PM" src="https://user-images.githubusercontent.com/2413802/93515500-add0b180-f8f6-11ea-92e0-a5a9fe34bd54.png"> <img width="350"  alt="Screen Shot 2020-09-17 at 2 45 54 PM" src="https://user-images.githubusercontent.com/2413802/93515505-ae694800-f8f6-11ea-9139-d2d9b91d57cc.png">
