### PR TITLE
Remove redundant exposure detection check.

### DIFF
--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -325,9 +325,8 @@ final class ExposureManager: NSObject {
       let downloadedKeyArchives = try await(self.downloadKeyArchives(targetUrls: targetUrls))
       unpackedArchiveURLs = try await(self.unpackKeyArchives(packages: downloadedKeyArchives))
       let exposureConfiguraton = try await(self.getExposureConfigurationV2())
-      var exposureSummary = try await(self.callDetectExposures(configuration: exposureConfiguraton.asENExposureConfiguration,
+      let exposureSummary = try await(self.callDetectExposures(configuration: exposureConfiguraton.asENExposureConfiguration,
                                                                diagnosisKeyURLs: unpackedArchiveURLs))
-      exposureSummary = try await(self.getCachedExposures(configuration: exposureConfiguraton.asENExposureConfiguration))
       var newExposures: [Exposure] = []
       if let summary = exposureSummary {
         summary.daySummaries.forEach { (daySummary) in


### PR DESCRIPTION
Remove redundant call to `detectExposures` so as to not count against the daily API call limit of 6 per 24 hour period 
<img width="772" alt="Screen Shot 2020-09-18 at 12 56 47 PM" src="https://user-images.githubusercontent.com/2637355/93624505-732a5000-f9ae-11ea-808c-8554114eea22.png">

![IMG_2103](https://user-images.githubusercontent.com/2637355/93624217-044cf700-f9ae-11ea-8202-3a1ad8a13575.PNG)
