### PR TITLE
Use flexWrap for recommended actions list to mitigate text overlap on small screen sizes

### DIFF
--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -11,6 +11,7 @@ import { useConnectionStatus } from "../../hooks/useConnectionStatus"
 import { Colors, Iconography, Spacing, Typography, Buttons } from "../../styles"
 import { Icons } from "../../assets"
 import { useConfigurationContext } from "../../ConfigurationContext"
+import { screenWidth } from "../../styles/layout"
 
 const ExposureActions: FunctionComponent = () => {
   const { t } = useTranslation()
@@ -41,7 +42,13 @@ const ExposureActions: FunctionComponent = () => {
               healthAuthorityName,
             })}
           </GlobalText>
-          <View style={style.recommendations}>
+          <View
+            style={
+              screenWidth > 350
+                ? [style.row, style.recommendations]
+                : [style.column, style.recommendations]
+            }
+          >
             <RecommendationBubble
               icon={Icons.IsolateBubbles}
               text={t("exposure_history.exposure_detail.isolate")}
@@ -158,9 +165,14 @@ const style = StyleSheet.create({
   },
   recommendations: {
     display: "flex",
-    flexDirection: "row",
     justifyContent: "space-between",
     marginBottom: Spacing.xxxLarge,
+  },
+  column: {
+    flexDirection: "column",
+  },
+  row: {
+    flexDirection: "row",
   },
   recommendation: {
     display: "flex",

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -11,7 +11,6 @@ import { useConnectionStatus } from "../../hooks/useConnectionStatus"
 import { Colors, Iconography, Spacing, Typography, Buttons } from "../../styles"
 import { Icons } from "../../assets"
 import { useConfigurationContext } from "../../ConfigurationContext"
-import { Layout } from "../../styles"
 
 const ExposureActions: FunctionComponent = () => {
   const { t } = useTranslation()
@@ -42,13 +41,7 @@ const ExposureActions: FunctionComponent = () => {
               healthAuthorityName,
             })}
           </GlobalText>
-          <View
-            style={
-              Layout.screenWidth > 350
-                ? [style.row, style.recommendations]
-                : [style.column, style.recommendations]
-            }
-          >
+          <View style={style.recommendations}>
             <RecommendationBubble
               icon={Icons.IsolateBubbles}
               text={t("exposure_history.exposure_detail.isolate")}
@@ -164,15 +157,11 @@ const style = StyleSheet.create({
     marginBottom: Spacing.medium,
   },
   recommendations: {
+    flexDirection: "row",
+    flexWrap: "wrap",
     display: "flex",
     justifyContent: "space-between",
     marginBottom: Spacing.xxxLarge,
-  },
-  column: {
-    flexDirection: "column",
-  },
-  row: {
-    flexDirection: "row",
   },
   recommendation: {
     display: "flex",

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -44,7 +44,7 @@ const ExposureActions: FunctionComponent = () => {
           </GlobalText>
           <View
             style={
-              screenWidth > 350
+              Layout.screenWidth > 350
                 ? [style.row, style.recommendations]
                 : [style.column, style.recommendations]
             }

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -11,7 +11,7 @@ import { useConnectionStatus } from "../../hooks/useConnectionStatus"
 import { Colors, Iconography, Spacing, Typography, Buttons } from "../../styles"
 import { Icons } from "../../assets"
 import { useConfigurationContext } from "../../ConfigurationContext"
-import { screenWidth } from "../../styles/layout"
+import { Layout } from "../../styles"
 
 const ExposureActions: FunctionComponent = () => {
   const { t } = useTranslation()


### PR DESCRIPTION
JIRA issue: https://pathcheck.atlassian.net/jira/software/projects/GAEN/boards/33?selectedIssue=GAEN-300

BEFORE:
<img width="314" alt="Screen Shot 2020-09-18 at 11 14 35 AM" src="https://user-images.githubusercontent.com/2637355/93630741-775b6b00-f9b8-11ea-8beb-45c02574015f.png">


AFTER:
![Screenshot_1600464619](https://user-images.githubusercontent.com/2637355/93646670-a67fd580-f9d4-11ea-8904-32312277ade5.png)

