### PR TITLE
Parse dates in UTC

### DIFF
--- a/src/ExposureHistory/History/DateInfoHeader.tsx
+++ b/src/ExposureHistory/History/DateInfoHeader.tsx
@@ -1,9 +1,6 @@
 import React, { FunctionComponent } from "react"
 import { StyleSheet } from "react-native"
 import { useTranslation } from "react-i18next"
-import dayjs from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
-dayjs.extend(relativeTime)
 
 import { GlobalText } from "../../components"
 import { DateTimeUtils } from "../../utils"

--- a/src/gaen/dataConverters.ts
+++ b/src/gaen/dataConverters.ts
@@ -1,6 +1,5 @@
-import dayjs from "dayjs"
-
 import { ExposureDatum } from "../exposure"
+import { DateTimeUtils } from "../utils"
 
 type UUID = string
 type Posix = number
@@ -18,9 +17,8 @@ export const toExposureInfo = (
 }
 
 const toExposureDatum = (r: RawExposure): ExposureDatum => {
-  const beginningOfDay = (date: Posix) => dayjs(date).startOf("day")
   return {
     id: r.id,
-    date: beginningOfDay(r.date).valueOf(),
+    date: DateTimeUtils.beginningOfDay(r.date),
   }
 }

--- a/src/utils/dateTime.spec.ts
+++ b/src/utils/dateTime.spec.ts
@@ -1,4 +1,5 @@
-import { isToday, posixToDayjs } from "./dateTime"
+import dayjs from "dayjs"
+import { isToday, posixToDayjs, beginningOfDay } from "./dateTime"
 
 describe("isToday", () => {
   describe("when provided a posix that is today", () => {
@@ -42,5 +43,14 @@ describe("posixToDayjs", () => {
 
   it("returns null for an invalid posix timestamp", () => {
     expect(posixToDayjs(parseInt("not a valid int"))).toBeNull()
+  })
+})
+
+describe("begginingOfDay", () => {
+  it("returns UTC date", () => {
+    const date = beginningOfDay(1600387200000)
+    expect(dayjs.utc(date).format("YYYY-MM-DD HH:mm Z")).toEqual(
+      "2020-09-18 00:00 +00:00",
+    )
   })
 })

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -2,7 +2,9 @@ import dayjs, { Dayjs } from "dayjs"
 import duration from "dayjs/plugin/duration"
 import localizedFormat from "dayjs/plugin/localizedFormat"
 import relativeTime from "dayjs/plugin/relativeTime"
+import utc from "dayjs/plugin/utc"
 
+dayjs.extend(utc)
 dayjs.extend(relativeTime)
 dayjs.extend(duration)
 dayjs.extend(localizedFormat)
@@ -18,16 +20,16 @@ export const durationToString = (duration: DurationMinutes): string => {
 export const isToday = (date: Posix): boolean => {
   const now = Date.now()
   const beginningOfToday = beginningOfDay(now)
-  const endOfToday = dayjs(now).endOf("day").valueOf()
+  const endOfToday = dayjs.utc(now).endOf("day").valueOf()
   return beginningOfToday <= date && endOfToday >= date
 }
 
 export const daysAgo = (days: number): Posix => {
-  return dayjs(Date.now()).subtract(days, "day").valueOf()
+  return dayjs.utc(Date.now()).subtract(days, "day").valueOf()
 }
 
 export const beginningOfDay = (date: Posix): Posix => {
-  return dayjs(date).startOf("day").valueOf()
+  return dayjs.utc(date).startOf("day").valueOf()
 }
 
 export const isInFuture = (date: Posix): boolean => {
@@ -35,7 +37,7 @@ export const isInFuture = (date: Posix): boolean => {
 }
 
 export const posixToDayjs = (posixDate: Posix): Dayjs | null => {
-  const dayJsDate = dayjs(posixDate)
+  const dayJsDate = dayjs.utc(posixDate)
   return dayJsDate.isValid() ? dayJsDate : null
 }
 


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
We were converting posix dates to the local timezone and then trying to calculate the start of day.
That resulted in exposures from **Friday 18 Sep** being shown as if they happened on **Thursday 17 Sep**.
That only happened on timezones with values less than UTC (I'm at GMT-3).

This PR fixes that and now displays the correct dates in Exposure History and Debug Menu

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/GAEN-309

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->
Before:

![device-2020-09-21-103258](https://user-images.githubusercontent.com/9491378/93804814-37e18880-fc1d-11ea-8be8-668da62034fc.png)

After:

![device-2020-09-21-150813](https://user-images.githubusercontent.com/9491378/93804174-4d09e780-fc1c-11ea-9a4e-dcdd368d5070.png)