### PR TITLE
Serialize daily check ins and symptom logs

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,515 @@
+PODS:
+  - Alamofire (4.9.1)
+  - boost-for-react-native (1.63.0)
+  - BugsnagReactNative (7.3.5):
+    - React
+  - BVLinearGradient (2.5.6):
+    - React
+  - DoubleConversion (1.1.6)
+  - FBLazyVector (0.63.2)
+  - FBReactNativeSpec (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - RCTRequired (= 0.63.2)
+    - RCTTypeSafety (= 0.63.2)
+    - React-Core (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - ReactCommon/turbomodule/core (= 0.63.2)
+  - Folly (2020.01.13.00):
+    - boost-for-react-native
+    - DoubleConversion
+    - Folly/Default (= 2020.01.13.00)
+    - glog
+  - Folly/Default (2020.01.13.00):
+    - boost-for-react-native
+    - DoubleConversion
+    - glog
+  - glog (0.3.5)
+  - KeychainAccess (4.2.0)
+  - Permission-Notifications (2.1.4):
+    - RNPermissions
+  - PromisesObjC (1.2.10)
+  - PromisesSwift (1.2.10):
+    - PromisesObjC (= 1.2.10)
+  - RCTRequired (0.63.2)
+  - RCTTypeSafety (0.63.2):
+    - FBLazyVector (= 0.63.2)
+    - Folly (= 2020.01.13.00)
+    - RCTRequired (= 0.63.2)
+    - React-Core (= 0.63.2)
+  - React (0.63.2):
+    - React-Core (= 0.63.2)
+    - React-Core/DevSupport (= 0.63.2)
+    - React-Core/RCTWebSocket (= 0.63.2)
+    - React-RCTActionSheet (= 0.63.2)
+    - React-RCTAnimation (= 0.63.2)
+    - React-RCTBlob (= 0.63.2)
+    - React-RCTImage (= 0.63.2)
+    - React-RCTLinking (= 0.63.2)
+    - React-RCTNetwork (= 0.63.2)
+    - React-RCTSettings (= 0.63.2)
+    - React-RCTText (= 0.63.2)
+    - React-RCTVibration (= 0.63.2)
+  - React-callinvoker (0.63.2)
+  - React-Core (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default (= 0.63.2)
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/CoreModulesHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/Default (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/DevSupport (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default (= 0.63.2)
+    - React-Core/RCTWebSocket (= 0.63.2)
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - React-jsinspector (= 0.63.2)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/RCTAnimationHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/RCTBlobHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/RCTImageHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/RCTLinkingHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/RCTNetworkHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/RCTSettingsHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/RCTTextHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/RCTVibrationHeaders (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-Core/RCTWebSocket (0.63.2):
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-Core/Default (= 0.63.2)
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-jsiexecutor (= 0.63.2)
+    - Yoga
+  - React-CoreModules (0.63.2):
+    - FBReactNativeSpec (= 0.63.2)
+    - Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.2)
+    - React-Core/CoreModulesHeaders (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-RCTImage (= 0.63.2)
+    - ReactCommon/turbomodule/core (= 0.63.2)
+  - React-cxxreact (0.63.2):
+    - boost-for-react-native (= 1.63.0)
+    - DoubleConversion
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-callinvoker (= 0.63.2)
+    - React-jsinspector (= 0.63.2)
+  - React-jsi (0.63.2):
+    - boost-for-react-native (= 1.63.0)
+    - DoubleConversion
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-jsi/Default (= 0.63.2)
+  - React-jsi/Default (0.63.2):
+    - boost-for-react-native (= 1.63.0)
+    - DoubleConversion
+    - Folly (= 2020.01.13.00)
+    - glog
+  - React-jsiexecutor (0.63.2):
+    - DoubleConversion
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+  - React-jsinspector (0.63.2)
+  - react-native-config (1.2.1):
+    - React
+  - react-native-netinfo (5.9.7):
+    - React-Core
+  - react-native-safe-area-context (3.0.5):
+    - React
+  - react-native-segmented-control (2.1.2):
+    - React
+  - react-native-simple-crypto (0.2.12):
+    - React
+  - react-native-splash-screen (3.2.0):
+    - React
+  - react-native-webview (8.2.1):
+    - React
+  - React-RCTActionSheet (0.63.2):
+    - React-Core/RCTActionSheetHeaders (= 0.63.2)
+  - React-RCTAnimation (0.63.2):
+    - FBReactNativeSpec (= 0.63.2)
+    - Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.2)
+    - React-Core/RCTAnimationHeaders (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - ReactCommon/turbomodule/core (= 0.63.2)
+  - React-RCTBlob (0.63.2):
+    - FBReactNativeSpec (= 0.63.2)
+    - Folly (= 2020.01.13.00)
+    - React-Core/RCTBlobHeaders (= 0.63.2)
+    - React-Core/RCTWebSocket (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-RCTNetwork (= 0.63.2)
+    - ReactCommon/turbomodule/core (= 0.63.2)
+  - React-RCTImage (0.63.2):
+    - FBReactNativeSpec (= 0.63.2)
+    - Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.2)
+    - React-Core/RCTImageHeaders (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - React-RCTNetwork (= 0.63.2)
+    - ReactCommon/turbomodule/core (= 0.63.2)
+  - React-RCTLinking (0.63.2):
+    - FBReactNativeSpec (= 0.63.2)
+    - React-Core/RCTLinkingHeaders (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - ReactCommon/turbomodule/core (= 0.63.2)
+  - React-RCTNetwork (0.63.2):
+    - FBReactNativeSpec (= 0.63.2)
+    - Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.2)
+    - React-Core/RCTNetworkHeaders (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - ReactCommon/turbomodule/core (= 0.63.2)
+  - React-RCTSettings (0.63.2):
+    - FBReactNativeSpec (= 0.63.2)
+    - Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.63.2)
+    - React-Core/RCTSettingsHeaders (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - ReactCommon/turbomodule/core (= 0.63.2)
+  - React-RCTText (0.63.2):
+    - React-Core/RCTTextHeaders (= 0.63.2)
+  - React-RCTVibration (0.63.2):
+    - FBReactNativeSpec (= 0.63.2)
+    - Folly (= 2020.01.13.00)
+    - React-Core/RCTVibrationHeaders (= 0.63.2)
+    - React-jsi (= 0.63.2)
+    - ReactCommon/turbomodule/core (= 0.63.2)
+  - ReactCommon/turbomodule/core (0.63.2):
+    - DoubleConversion
+    - Folly (= 2020.01.13.00)
+    - glog
+    - React-callinvoker (= 0.63.2)
+    - React-Core (= 0.63.2)
+    - React-cxxreact (= 0.63.2)
+    - React-jsi (= 0.63.2)
+  - Realm (5.4.2):
+    - Realm/Headers (= 5.4.2)
+  - Realm/Headers (5.4.2)
+  - RealmSwift (5.4.2):
+    - Realm (= 5.4.2)
+  - RNCAsyncStorage (1.10.0):
+    - React
+  - RNCMaskedView (0.1.10):
+    - React
+  - RNCPushNotificationIOS (1.4.0):
+    - React
+  - RNDateTimePicker (2.3.2):
+    - React
+  - RNGestureHandler (1.6.1):
+    - React
+  - RNPermissions (2.1.4):
+    - React
+  - RNReanimated (1.8.0):
+    - React
+  - RNScreens (2.8.0):
+    - React
+  - RNSVG (12.1.0):
+    - React
+  - Yoga (1.14.0)
+  - ZIPFoundation (0.9.11)
+
+DEPENDENCIES:
+  - Alamofire (~> 4.9.1)
+  - "BugsnagReactNative (from `../node_modules/@bugsnag/react-native`)"
+  - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
+  - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
+  - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
+  - FBReactNativeSpec (from `../node_modules/react-native/Libraries/FBReactNativeSpec`)
+  - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
+  - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - KeychainAccess (~> 4.2.0)
+  - Permission-Notifications (from `../node_modules/react-native-permissions/ios/Notifications.podspec`)
+  - PromisesObjC
+  - PromisesSwift
+  - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
+  - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
+  - React (from `../node_modules/react-native/`)
+  - React-callinvoker (from `../node_modules/react-native/ReactCommon/callinvoker`)
+  - React-Core (from `../node_modules/react-native/`)
+  - React-Core/DevSupport (from `../node_modules/react-native/`)
+  - React-Core/RCTWebSocket (from `../node_modules/react-native/`)
+  - React-CoreModules (from `../node_modules/react-native/React/CoreModules`)
+  - React-cxxreact (from `../node_modules/react-native/ReactCommon/cxxreact`)
+  - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
+  - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
+  - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
+  - react-native-config (from `../node_modules/react-native-config`)
+  - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
+  - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - "react-native-segmented-control (from `../node_modules/@react-native-community/segmented-control`)"
+  - react-native-simple-crypto (from `../node_modules/react-native-simple-crypto`)
+  - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
+  - react-native-webview (from `../node_modules/react-native-webview`)
+  - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
+  - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
+  - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
+  - React-RCTImage (from `../node_modules/react-native/Libraries/Image`)
+  - React-RCTLinking (from `../node_modules/react-native/Libraries/LinkingIOS`)
+  - React-RCTNetwork (from `../node_modules/react-native/Libraries/Network`)
+  - React-RCTSettings (from `../node_modules/react-native/Libraries/Settings`)
+  - React-RCTText (from `../node_modules/react-native/Libraries/Text`)
+  - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
+  - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - Realm
+  - RealmSwift
+  - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
+  - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
+  - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
+  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNPermissions (from `../node_modules/react-native-permissions`)
+  - RNReanimated (from `../node_modules/react-native-reanimated`)
+  - RNScreens (from `../node_modules/react-native-screens`)
+  - RNSVG (from `../node_modules/react-native-svg`)
+  - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
+  - ZIPFoundation (~> 0.9.11)
+
+SPEC REPOS:
+  trunk:
+    - Alamofire
+    - boost-for-react-native
+    - KeychainAccess
+    - PromisesObjC
+    - PromisesSwift
+    - Realm
+    - RealmSwift
+    - ZIPFoundation
+
+EXTERNAL SOURCES:
+  BugsnagReactNative:
+    :path: "../node_modules/@bugsnag/react-native"
+  BVLinearGradient:
+    :path: "../node_modules/react-native-linear-gradient"
+  DoubleConversion:
+    :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
+  FBLazyVector:
+    :path: "../node_modules/react-native/Libraries/FBLazyVector"
+  FBReactNativeSpec:
+    :path: "../node_modules/react-native/Libraries/FBReactNativeSpec"
+  Folly:
+    :podspec: "../node_modules/react-native/third-party-podspecs/Folly.podspec"
+  glog:
+    :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
+  Permission-Notifications:
+    :path: "../node_modules/react-native-permissions/ios/Notifications.podspec"
+  RCTRequired:
+    :path: "../node_modules/react-native/Libraries/RCTRequired"
+  RCTTypeSafety:
+    :path: "../node_modules/react-native/Libraries/TypeSafety"
+  React:
+    :path: "../node_modules/react-native/"
+  React-callinvoker:
+    :path: "../node_modules/react-native/ReactCommon/callinvoker"
+  React-Core:
+    :path: "../node_modules/react-native/"
+  React-CoreModules:
+    :path: "../node_modules/react-native/React/CoreModules"
+  React-cxxreact:
+    :path: "../node_modules/react-native/ReactCommon/cxxreact"
+  React-jsi:
+    :path: "../node_modules/react-native/ReactCommon/jsi"
+  React-jsiexecutor:
+    :path: "../node_modules/react-native/ReactCommon/jsiexecutor"
+  React-jsinspector:
+    :path: "../node_modules/react-native/ReactCommon/jsinspector"
+  react-native-config:
+    :path: "../node_modules/react-native-config"
+  react-native-netinfo:
+    :path: "../node_modules/@react-native-community/netinfo"
+  react-native-safe-area-context:
+    :path: "../node_modules/react-native-safe-area-context"
+  react-native-segmented-control:
+    :path: "../node_modules/@react-native-community/segmented-control"
+  react-native-simple-crypto:
+    :path: "../node_modules/react-native-simple-crypto"
+  react-native-splash-screen:
+    :path: "../node_modules/react-native-splash-screen"
+  react-native-webview:
+    :path: "../node_modules/react-native-webview"
+  React-RCTActionSheet:
+    :path: "../node_modules/react-native/Libraries/ActionSheetIOS"
+  React-RCTAnimation:
+    :path: "../node_modules/react-native/Libraries/NativeAnimation"
+  React-RCTBlob:
+    :path: "../node_modules/react-native/Libraries/Blob"
+  React-RCTImage:
+    :path: "../node_modules/react-native/Libraries/Image"
+  React-RCTLinking:
+    :path: "../node_modules/react-native/Libraries/LinkingIOS"
+  React-RCTNetwork:
+    :path: "../node_modules/react-native/Libraries/Network"
+  React-RCTSettings:
+    :path: "../node_modules/react-native/Libraries/Settings"
+  React-RCTText:
+    :path: "../node_modules/react-native/Libraries/Text"
+  React-RCTVibration:
+    :path: "../node_modules/react-native/Libraries/Vibration"
+  ReactCommon:
+    :path: "../node_modules/react-native/ReactCommon"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-community/async-storage"
+  RNCMaskedView:
+    :path: "../node_modules/@react-native-community/masked-view"
+  RNCPushNotificationIOS:
+    :path: "../node_modules/@react-native-community/push-notification-ios"
+  RNDateTimePicker:
+    :path: "../node_modules/@react-native-community/datetimepicker"
+  RNGestureHandler:
+    :path: "../node_modules/react-native-gesture-handler"
+  RNPermissions:
+    :path: "../node_modules/react-native-permissions"
+  RNReanimated:
+    :path: "../node_modules/react-native-reanimated"
+  RNScreens:
+    :path: "../node_modules/react-native-screens"
+  RNSVG:
+    :path: "../node_modules/react-native-svg"
+  Yoga:
+    :path: "../node_modules/react-native/ReactCommon/yoga"
+
+SPEC CHECKSUMS:
+  Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
+  boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
+  BugsnagReactNative: fc7d6fb2127e53a8bfc79130b58263da363bb94b
+  BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  FBLazyVector: 3ef4a7f62e7db01092f9d517d2ebc0d0677c4a37
+  FBReactNativeSpec: dc7fa9088f0f2a998503a352b0554d69a4391c5a
+  Folly: b73c3869541e86821df3c387eb0af5f65addfab4
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  KeychainAccess: 3f760109aa99b05d0f231e28b22642da7153e38a
+  Permission-Notifications: d437cafc026900006d35981d35a2d694f883f44e
+  PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
+  PromisesSwift: ce4c7602f91a6bfc8732039f1bc1a3fcded1a302
+  RCTRequired: f13f25e7b12f925f1f6a6a8c69d929a03c0129fe
+  RCTTypeSafety: 44982c5c8e43ff4141eb519a8ddc88059acd1f3a
+  React: e1c65dd41cb9db13b99f24608e47dd595f28ca9a
+  React-callinvoker: 552a6a6bc8b3bb794cf108ad59e5a9e2e3b4fc98
+  React-Core: 9d341e725dc9cd2f49e4c49ad1fc4e8776aa2639
+  React-CoreModules: 5335e168165da7f7083ce7147768d36d3e292318
+  React-cxxreact: d3261ec5f7d11743fbf21e263a34ea51d1f13ebc
+  React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
+  React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
+  React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
+  react-native-config: ae9ef3bdbf539f2d14ebaf4ebeba508f766e066a
+  react-native-netinfo: 250dc0ca126512f618a8a2ca6a936577e1f66586
+  react-native-safe-area-context: e768fca90207ee68924b3d0877633f2ce9cc9d68
+  react-native-segmented-control: e257b39e80733b848d7d040e07c29eee99396aff
+  react-native-simple-crypto: f37bae3fba012c1b389f1c68a3e4f68fe4d9b523
+  react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
+  react-native-webview: 160ac8d6bb974e2933f2de6bb7464a8e934ff31d
+  React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
+  React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
+  React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13
+  React-RCTImage: de355d738727b09ad3692f2a979affbd54b5f378
+  React-RCTLinking: 8122f221d395a63364b2c0078ce284214bd04575
+  React-RCTNetwork: 8f96c7b49ea6a0f28f98258f347b6ad218bc0830
+  React-RCTSettings: 8a49622aff9c1925f5455fa340b6fe4853d64ab6
+  React-RCTText: 1b6773e776e4b33f90468c20fe3b16ca3e224bb8
+  React-RCTVibration: 4d2e726957f4087449739b595f107c0d4b6c2d2d
+  ReactCommon: a0a1edbebcac5e91338371b72ffc66aa822792ce
+  Realm: ced868eb0254f8d33a21c06981355e5aa33bc005
+  RealmSwift: aedc4363150f3c61f91ae0537ed116d2d080a4dd
+  RNCAsyncStorage: 6d99641f8e6f15d169d695d8ef184bf187903f11
+  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
+  RNCPushNotificationIOS: dc1c0c6aa18a128df123598149f42e848d26a4ac
+  RNDateTimePicker: 4bd49e09f91ca73d69119a9e1173b0d43b82f5e5
+  RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
+  RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8
+  RNReanimated: 955cf4068714003d2f1a6e2bae3fb1118f359aff
+  RNScreens: 62211832af51e0aebcf6e8c36bcf7dd65592f244
+  RNSVG: ce9d996113475209013317e48b05c21ee988d42e
+  Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
+  ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
+
+PODFILE CHECKSUM: 3aac7b477d538c6ccf463f1a7912f5708ba6016d
+
+COCOAPODS: 1.9.3

--- a/src/MyHealth/SymptomLogContext.tsx
+++ b/src/MyHealth/SymptomLogContext.tsx
@@ -6,28 +6,56 @@ import React, {
   useState,
 } from "react"
 
-import { SymptomLogEntry, HealthAssessment } from "./symptoms"
+import {
+  SymptomLogEntry,
+  DailyCheckIn,
+  CheckInStatus,
+  DayLogData,
+  serializeDailyLogData,
+} from "./symptoms"
 
 const fetchLogEntries = (): Promise<SymptomLogEntry[]> => {
   return Promise.resolve([
     {
-      id: 1,
-      symptoms: [],
-      healthAssessment: HealthAssessment.NotAtRisk,
-      date: new Date().getTime() / 1000,
+      id: "1",
+      symptoms: ["Loss of Breath"],
+      date: 1600614626042,
+    },
+    {
+      id: "2",
+      symptoms: ["Cough", "Fever"],
+      date: 1600610400000,
+    },
+    {
+      id: "3",
+      symptoms: ["Fever"],
+      date: 1599919200000,
+    },
+  ])
+}
+
+const fetchDailyCheckIns = (): Promise<DailyCheckIn[]> => {
+  return Promise.resolve([
+    {
+      date: 1600804626042,
+      status: CheckInStatus.FeelingGood,
+    },
+    {
+      date: 1599919200000,
+      status: CheckInStatus.FeelingNotWell,
     },
   ])
 }
 
 export type SymptomLogState = {
-  logEntries: SymptomLogEntry[]
+  dailyLogData: DayLogData[]
   addLogEntry: (entry: SymptomLogEntry) => Promise<void>
   updateLogEntry: (entry: SymptomLogEntry) => Promise<void>
   deleteLogEntry: (entry: SymptomLogEntry) => Promise<void>
 }
 
 const initialState = {
-  logEntries: [],
+  dailyLogData: [],
   addLogEntry: (_entry: SymptomLogEntry) => {
     return Promise.resolve()
   },
@@ -42,12 +70,21 @@ const initialState = {
 export const SymptomLogContext = createContext<SymptomLogState>(initialState)
 
 export const SymptomLogProvider: FunctionComponent = ({ children }) => {
+  const [dailyLogData, setDailyLogData] = useState<DayLogData[]>([])
   const [logEntries, setLogEntries] = useState<SymptomLogEntry[]>([])
+  const [dailyCheckIns, setDailyCheckIns] = useState<DailyCheckIn[]>([])
   useEffect(() => {
     fetchLogEntries().then((entries) => {
       setLogEntries(entries)
     })
+    fetchDailyCheckIns().then((checkIns) => {
+      setDailyCheckIns(checkIns)
+    })
   }, [])
+
+  useEffect(() => {
+    setDailyLogData(serializeDailyLogData(logEntries, dailyCheckIns))
+  }, [dailyCheckIns, logEntries])
 
   const addLogEntry = async (newEntry: SymptomLogEntry) => {
     const newLogEntries = [...logEntries, newEntry]
@@ -71,7 +108,7 @@ export const SymptomLogProvider: FunctionComponent = ({ children }) => {
   return (
     <SymptomLogContext.Provider
       value={{
-        logEntries,
+        dailyLogData,
         addLogEntry,
         updateLogEntry,
         deleteLogEntry,

--- a/src/MyHealth/symptoms.spec.ts
+++ b/src/MyHealth/symptoms.spec.ts
@@ -1,0 +1,137 @@
+import { serializeDailyLogData, CheckInStatus } from "./symptoms"
+import { beginningOfDay } from "../utils/dateTime"
+
+describe("serializeDailyLogData", () => {
+  it("returns a set of log entries grouped by day with entries sorted", () => {
+    const earlierDayDateString = "2020-09-21"
+    const earlierDayLogEntryOnePosix = Date.parse(
+      `${earlierDayDateString} 10:00`,
+    )
+    const earlierDayDatePosix = beginningOfDay(earlierDayLogEntryOnePosix)
+    const earlierDayLogEntryOne = {
+      id: "1",
+      symptoms: ["symptom1", "symptom2"],
+      date: earlierDayLogEntryOnePosix,
+    }
+    const earlierDayLogEntryTwoPosix = Date.parse(
+      `${earlierDayDateString} 12:00`,
+    )
+    const earlierDayLogEntryTwo = {
+      id: "2",
+      symptoms: ["symptom1"],
+      date: earlierDayLogEntryTwoPosix,
+    }
+    const middleDayDateString = "2020-09-22"
+    const middleDayLogEntryOnePosix = Date.parse(`${middleDayDateString} 10:00`)
+    const middleDayDatePosix = beginningOfDay(middleDayLogEntryOnePosix)
+    const middleDayLogEntryOne = {
+      id: "3",
+      symptoms: ["symptom1"],
+      date: middleDayLogEntryOnePosix,
+    }
+    const middleDayLogEntryTwoPosix = Date.parse(`${middleDayDateString} 12:00`)
+    const middleDayLogEntryTwo = {
+      id: "4",
+      symptoms: ["symptom2"],
+      date: middleDayLogEntryTwoPosix,
+    }
+
+    const recentDayEntryDateString = "2020-09-23"
+    const recentDayLogEntryPosix = Date.parse(
+      `${recentDayEntryDateString} 12:00`,
+    )
+    const recentDayEntryDatePosix = beginningOfDay(recentDayLogEntryPosix)
+    const recentDayEntry = {
+      id: "5",
+      symptoms: ["symptom2"],
+      date: recentDayLogEntryPosix,
+    }
+    expect(
+      serializeDailyLogData(
+        [
+          middleDayLogEntryTwo,
+          recentDayEntry,
+          earlierDayLogEntryOne,
+          middleDayLogEntryOne,
+          earlierDayLogEntryTwo,
+        ],
+        [],
+      ),
+    ).toEqual([
+      {
+        date: recentDayEntryDatePosix,
+        logEntries: [recentDayEntry],
+        checkIn: null,
+      },
+      {
+        date: middleDayDatePosix,
+        logEntries: [middleDayLogEntryOne, middleDayLogEntryTwo],
+        checkIn: null,
+      },
+      {
+        date: earlierDayDatePosix,
+        logEntries: [earlierDayLogEntryOne, earlierDayLogEntryTwo],
+        checkIn: null,
+      },
+    ])
+  })
+
+  it("sort and combine daily log entries with daily check ins", () => {
+    const logEntryDateString = "2020-09-21"
+    const logEntryDatePosix = Date.parse(`${logEntryDateString} 10:00`)
+    const logEntryKeyDate = beginningOfDay(logEntryDatePosix)
+    const logEntry = {
+      id: "1",
+      symptoms: ["symptom1", "symptom2"],
+      date: logEntryDatePosix,
+    }
+    const symptomLogEntries = [logEntry]
+    const sameDateCheckInPosix = Date.parse(`${logEntryDateString} 12:00`)
+    const sameDateCheckIn = {
+      date: sameDateCheckInPosix,
+      status: CheckInStatus.FeelingGood,
+    }
+    const earlierDateCheckInString = "2020-09-20"
+    const earlierDateCheckInPosix = Date.parse(
+      `${earlierDateCheckInString} 12:00`,
+    )
+    const earlierDateCheckInBeginningOfDay = beginningOfDay(
+      earlierDateCheckInPosix,
+    )
+    const earlierDateCheckIn = {
+      date: earlierDateCheckInPosix,
+      status: CheckInStatus.NotCheckedIn,
+    }
+    const laterDateCheckInString = "2020-09-22"
+    const laterDateCheckInPosix = Date.parse(`${laterDateCheckInString} 12:00`)
+    const laterDateCheckInBeginningOfDay = beginningOfDay(laterDateCheckInPosix)
+    const laterDateCheckIn = {
+      date: laterDateCheckInPosix,
+      status: CheckInStatus.FeelingNotWell,
+    }
+
+    expect(
+      serializeDailyLogData(symptomLogEntries, [
+        sameDateCheckIn,
+        laterDateCheckIn,
+        earlierDateCheckIn,
+      ]),
+    ).toEqual([
+      {
+        date: laterDateCheckInBeginningOfDay,
+        checkIn: laterDateCheckIn,
+        logEntries: [],
+      },
+      {
+        date: logEntryKeyDate,
+        checkIn: sameDateCheckIn,
+        logEntries: [logEntry],
+      },
+      {
+        date: earlierDateCheckInBeginningOfDay,
+        checkIn: earlierDateCheckIn,
+        logEntries: [],
+      },
+    ])
+  })
+})

--- a/src/MyHealth/symptoms.ts
+++ b/src/MyHealth/symptoms.ts
@@ -1,4 +1,4 @@
-import { Posix } from "../utils/dateTime"
+import { Posix, beginningOfDay } from "../utils/dateTime"
 
 export enum HealthAssessment {
   AtRisk,
@@ -7,10 +7,33 @@ export enum HealthAssessment {
 
 export type Symptom = string
 
+export enum CheckInStatus {
+  NotCheckedIn,
+  FeelingGood,
+  FeelingNotWell,
+}
+
+// Raw Daily Checkin
+export type DailyCheckIn = {
+  date: Posix
+  status: CheckInStatus
+}
+
+// Raw Log Entry
 export type SymptomLogEntry = {
-  id: number
+  id: string
+  date: Posix
   symptoms: Symptom[]
-  healthAssessment: HealthAssessment
+}
+
+type LogData = {
+  checkIn: DailyCheckIn | null
+  logEntries: SymptomLogEntry[]
+}
+
+type LogDataByDay = Record<Posix, LogData>
+
+export type DayLogData = LogData & {
   date: Posix
 }
 
@@ -21,4 +44,82 @@ export const determineHealthAssessment = (
     return HealthAssessment.AtRisk
   }
   return HealthAssessment.NotAtRisk
+}
+
+type WithADate = { date: Posix }
+const compareDatesAscending = (
+  { date: dateLeft }: WithADate,
+  { date: dateRight }: WithADate,
+) => {
+  return dateLeft < dateRight ? -1 : 1
+}
+const compareDatesDescending = (
+  { date: dateLeft }: WithADate,
+  { date: dateRight }: WithADate,
+) => {
+  return dateLeft < dateRight ? 1 : -1
+}
+
+const groupLogEntriesDaily = (allEntries: SymptomLogEntry[]): LogDataByDay => {
+  const groupedEntries: LogDataByDay = {}
+
+  allEntries.forEach((entry) => {
+    const { date } = entry
+    const entryDateBeginningOfDay = beginningOfDay(date)
+
+    if (groupedEntries[entryDateBeginningOfDay]) {
+      const newLogEntries = groupedEntries[entryDateBeginningOfDay].logEntries
+      newLogEntries.push(entry)
+      newLogEntries.sort(compareDatesAscending)
+      groupedEntries[entryDateBeginningOfDay].logEntries = newLogEntries
+    } else {
+      groupedEntries[entryDateBeginningOfDay] = {
+        logEntries: [entry],
+        checkIn: null,
+      }
+    }
+  })
+
+  return groupedEntries
+}
+
+const joinLogDataAndDailyCheckIns = (
+  logData: LogDataByDay,
+  dailyCheckIns: DailyCheckIn[],
+): LogDataByDay => {
+  dailyCheckIns.forEach((checkIn) => {
+    const { date } = checkIn
+    const checkInBeginningOfDay = beginningOfDay(date)
+
+    if (logData[checkInBeginningOfDay]) {
+      logData[checkInBeginningOfDay].checkIn = checkIn
+    } else {
+      logData[checkInBeginningOfDay] = {
+        logEntries: [],
+        checkIn,
+      }
+    }
+  })
+  return logData
+}
+
+export const serializeDailyLogData = (
+  symptomLogEntries: SymptomLogEntry[],
+  dailyCheckIns: DailyCheckIn[],
+): DayLogData[] => {
+  const symptomEntriesLogData = groupLogEntriesDaily(symptomLogEntries)
+  const dailyLogData = joinLogDataAndDailyCheckIns(
+    symptomEntriesLogData,
+    dailyCheckIns,
+  )
+
+  return Object.keys(dailyLogData)
+    .map((date: string) => {
+      const posixDate = Number(date)
+      return {
+        date: posixDate,
+        ...dailyLogData[posixDate],
+      }
+    })
+    .sort(compareDatesDescending)
 }

--- a/src/factories/symptomLogContext.ts
+++ b/src/factories/symptomLogContext.ts
@@ -2,7 +2,7 @@ import { Factory } from "fishery"
 import { SymptomLogState } from "../MyHealth/SymptomLogContext"
 
 export default Factory.define<SymptomLogState>(() => ({
-  logEntries: [],
+  dailyLogData: [],
   addLogEntry: jest.fn(),
   updateLogEntry: jest.fn(),
   deleteLogEntry: jest.fn(),


### PR DESCRIPTION
Why:
----

There are going to be two sets of data captured as part of the My Health initiative. The first aspect will be a daily check-in. Shown on the  `Today` portion of the My Health screen. The other portion is multiple entries per day of logging symptoms. These two separate sets of data should compose what is presented to the users on the `Over Time` tab of the my health screen.

How:
----

We learned that the data captured on this screen should not be treated as one. There are two distinct sets of data:

- the check in: daily, and it only captures the status, feeling well or not
- the symptoms: multiple times a day. It captures a set of symptoms logged by the user at any given time

The two data sets need to be presented to the user in a way that:
- if any of the two is missing. The entry for the day should still appear
- if both are present, a single entry for the day should be added, with multiple instances for each entry of symptoms
- if none are present for the day, this day should not appear on the UI

This Commit:
----

- Add a grouping logic for symptom log entries
- Change data structure to be displayed top respond to needs of merging two different sets of data
- Hooked the log context to the new flow of data serialization
- Update the Over Time screen to display the transformed and joined daily check in and symptom log entries

Co-authored-by: Devin Jameson <devin@thoughtbot.com>
Co-authored-by: Matt Buckley <matt.buckley@rocketinsights.com>

<img width="584" alt="Screen Shot 2020-09-22 at 5 16 34 PM" src="https://user-images.githubusercontent.com/2413802/93938528-6764c380-fcf7-11ea-816a-a7afa2d20f9b.png">
