### PR TITLE
Fix bug on fix proximity tracing event

### DIFF
--- a/src/Home/ProximityTracingActivationStatus.tsx
+++ b/src/Home/ProximityTracingActivationStatus.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react"
-import { Alert } from "react-native"
+import { Alert, Platform } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
@@ -20,12 +20,19 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
 
   const { status } = exposureNotifications
 
-  const isNotAuthorized = status === ENPermissionStatus.NOT_AUTHORIZED
-
   const showNotAuthorizedAlert = () => {
+    const errorMessage = Platform.select({
+      ios: t("home.proximity_tracing.unauthorized_error_message_ios", {
+        applicationName,
+      }),
+      android: t("home.proximity_tracing.unauthorized_error_message_android", {
+        applicationName,
+      }),
+    })
+
     Alert.alert(
-      t("home.bluetooth.unauthorized_error_title"),
-      t("home.bluetooth.unauthorized_error_message", { applicationName }),
+      t("home.proximity_tracing.unauthorized_error_title"),
+      errorMessage,
       [
         {
           text: t("common.back"),
@@ -39,9 +46,14 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
     )
   }
 
-  const handleOnPressFix = () => {
-    exposureNotifications.request()
-    if (isNotAuthorized) {
+  const handleOnPressFix = async () => {
+    try {
+      await exposureNotifications.request()
+
+      if (status !== ENPermissionStatus.ENABLED) {
+        showNotAuthorizedAlert()
+      }
+    } catch {
       showNotAuthorizedAlert()
     }
   }

--- a/src/PermissionsContext.tsx
+++ b/src/PermissionsContext.tsx
@@ -140,11 +140,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
   }
 
   const requestENPermission = async () => {
-    permissionStrategy.request().catch((error) => {
-      if (error.message !== "Error enabling notifications") {
-        throw Error(error)
-      }
-    })
+    return permissionStrategy.request()
   }
 
   const requestNotificationPermission = async () => {

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -62,7 +62,14 @@ const toStatus = (data: string[]): RawENPermissionStatus => {
 const permissionsModule = NativeModules.ENPermissionsModule
 
 export const requestAuthorization = async (): Promise<void> => {
-  return permissionsModule.requestExposureNotificationAuthorization()
+  return permissionsModule
+    .requestExposureNotificationAuthorization()
+    .catch((error: string) => {
+      Logger.error("Failed to request ExposureNotification API Authorization", {
+        error,
+      })
+      throw new Error(error)
+    })
 }
 
 export const getCurrentENPermissionsStatus = async (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -173,9 +173,7 @@
       "tracing_off_header": "Inactive",
       "tracing_off_subheader": "Enable Bluetooth and Proximity Tracing to get info about possible exposures",
       "tracing_off_subheader_location": "Enable Bluetooth, Proximity Tracing, and Location to get info about possible exposures",
-      "tracing_on_header": "Active",
-      "unauthorized_error_message": "To activate Proximity Tracing, ensure \"Share Exposure Information\" is enabled in Settings > {{applicationName}} > Exposure Notifications",
-      "unauthorized_error_title": "Share Exposure Information"
+      "tracing_on_header": "Active"
     },
     "fix": "Fix issues with {{technology}}",
     "get_more_info": "Get more info on {{technology}}",
@@ -183,6 +181,11 @@
     "location_info_header": "Location",
     "location_info_subheader_1": "Why do I need my location turned on?",
     "open_settings": "Open Settings",
+    "proximity_tracing": {
+      "unauthorized_error_message_android": "To enable Proximity Tracing and Exposure Notifications, please go to the COVID-19 Exposure Notifications of your Settings App and enable 'Use Exposure Notifications'",
+      "unauthorized_error_message_ios": "To enable Proximity Tracing and Exposure Notifications, please go to the Exposure Notificaiton section in Settings and Share Exposure Information and set the Active Region to {{applicationName}}",
+      "unauthorized_error_title": "Enable Proximity Tracing"
+    },
     "proximity_tracing_info_body_1": "If smartphones with the app installed are turned on, have Bluetooth enabled, and are near each other for a period of time, an encounter is registered on your device.",
     "proximity_tracing_info_body_2": "In the event of an encounter, your data, and information remain anonymous. The app doesn’t store any personal data. Only random IDs are exchanged. These are deleted within 14 days.",
     "proximity_tracing_info_header": "Proximity Tracing",


### PR DESCRIPTION
Why:
Currently there is a bug in iOS 13.7 when a user tries to tap the 'Fix
Proximity Tracing' link on the home screen, where nothing will happen.
This was caused by the NatvieModule.requestAuthorization function
throwing and not being handled.

We would like to try to update the authorization immediately via the
gaen api, and if this fails, we would like to indicate to the user that
the need to update permissions manually via their settings app and link
them to the settings app.

This commit:
Wraps the call to request authorization in a try catch in the component
and shows the Alert dialog with settings link if the request throws.
Additionally we added a logger to the native module function to capture
any failure events in the future. We did not fix the underlying issue of
the `manager.setExposureNotificationEnabled` throwing in the iOS layer.


