### PR TITLE
Log publish request body on staging

### DIFF
--- a/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
@@ -7,6 +7,7 @@ import { ExposureKey } from "../exposureKey"
 import { fetchWithTimeout, TIMEOUT_ERROR } from "./fetchWithTimeout"
 
 jest.mock("./fetchWithTimeout")
+jest.mock("../logger")
 
 describe("postDiagnosisKeys", () => {
   afterEach(() => {

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -3,6 +3,7 @@ import env from "react-native-config"
 
 import { ExposureKey } from "../exposureKey"
 import { fetchWithTimeout, TIMEOUT_ERROR } from "./fetchWithTimeout"
+import Logger from "../logger"
 
 const exposureUrl = env.POST_DIAGNOSIS_KEYS_URL
 
@@ -92,7 +93,7 @@ class PostDiagnosisKeysRequest {
         {
           method: "POST",
           headers: defaultHeaders,
-          body: JSON.stringify(this.requestData),
+          body: this.requestBody(),
         },
         PostDiagnosisKeysRequest.TIMEOUT,
       )) as Response
@@ -172,6 +173,12 @@ class PostDiagnosisKeysRequest {
     return new Promise((resolve) =>
       setTimeout(resolve, PostDiagnosisKeysRequest.DEFAULT_RETRY_DELAY_MS),
     )
+  }
+
+  private requestBody = () => {
+    const encodedBody = JSON.stringify(this.requestData)
+    Logger.addMetadata("publishKeys", { requestBody: encodedBody })
+    return encodedBody
   }
 }
 


### PR DESCRIPTION
Why:
----

When new servers are added, often the troubleshooting comes on the staging environment and one item often requested is the body of the request that was sent. We need a way to retrieve it for diagnosis purposes on the staging environment.

This Commit:
----

- Log body from the publish keys request
