### PR TITLE
Style MyHealth screens

### DIFF
--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -123,7 +123,7 @@ const style = StyleSheet.create({
   },
   headerText: {
     ...Typography.header1,
-    color: Colors.primaryText,
+    ...Typography.bold,
     marginRight: Spacing.medium,
   },
   moreInfoButton: {

--- a/src/MyHealth/OverTime.spec.tsx
+++ b/src/MyHealth/OverTime.spec.tsx
@@ -54,7 +54,7 @@ describe("OverTime", () => {
       const secondTimeString =
         posixToDayjs(secondLogEntryPosix)?.local()?.format("HH:mm A") ||
         "not a date"
-      const { debug, getByText, queryByText } = render(
+      const { getByText, queryByText } = render(
         <SymptomLogContext.Provider
           value={factories.symptomLogContext.build({
             dailyLogData: [
@@ -80,7 +80,6 @@ describe("OverTime", () => {
           <OverTime />
         </SymptomLogContext.Provider>,
       )
-      debug()
 
       expect(queryByText("You were not feeling well")).toBeNull()
       expect(getByText(dateString)).toBeDefined()

--- a/src/MyHealth/OverTime.spec.tsx
+++ b/src/MyHealth/OverTime.spec.tsx
@@ -15,7 +15,7 @@ jest.mock("@react-navigation/native")
 describe("OverTime", () => {
   describe("when the user has log entries with only a checkIn", () => {
     it("shows the correct message, and a date", () => {
-      const dateString = "2020-09-21"
+      const dateString = "September 21, 2020"
       const timeString = "10:00"
       const logEntryPosix = Date.parse(`${dateString} ${timeString}`)
       const { getByText, queryByText } = render(
@@ -45,18 +45,16 @@ describe("OverTime", () => {
 
   describe("when the user has log data with no checkIn entries", () => {
     it("shows the correct message, date and symptoms", () => {
-      const dateString = "2020-09-21"
+      const dateString = "September 21, 2020"
       const firstLogEntryPosix = Date.parse(`2020-09-21 10:00`)
       const firstTimeString =
-        posixToDayjs(firstLogEntryPosix)?.local()?.format("HH:mm") ||
+        posixToDayjs(firstLogEntryPosix)?.local()?.format("HH:mm A") ||
         "not a date"
       const secondLogEntryPosix = Date.parse(`${dateString} 12:00`)
       const secondTimeString =
-        posixToDayjs(secondLogEntryPosix)?.local()?.format("HH:mm") ||
+        posixToDayjs(secondLogEntryPosix)?.local()?.format("HH:mm A") ||
         "not a date"
-      const coughSymptom = "cough"
-      const lossOfSmellSymptom = "loss_of_smell"
-      const { getByText, queryByText } = render(
+      const { debug, getByText, queryByText } = render(
         <SymptomLogContext.Provider
           value={factories.symptomLogContext.build({
             dailyLogData: [
@@ -66,12 +64,12 @@ describe("OverTime", () => {
                 logEntries: [
                   {
                     id: "1",
-                    symptoms: [coughSymptom],
+                    symptoms: ["cough"],
                     date: firstLogEntryPosix,
                   },
                   {
                     id: "2",
-                    symptoms: [lossOfSmellSymptom],
+                    symptoms: ["loss_of_smell"],
                     date: secondLogEntryPosix,
                   },
                 ],
@@ -82,13 +80,14 @@ describe("OverTime", () => {
           <OverTime />
         </SymptomLogContext.Provider>,
       )
+      debug()
 
       expect(queryByText("You were not feeling well")).toBeNull()
       expect(getByText(dateString)).toBeDefined()
       expect(getByText(firstTimeString)).toBeDefined()
       expect(getByText(secondTimeString)).toBeDefined()
-      expect(getByText(coughSymptom)).toBeDefined()
-      expect(getByText(lossOfSmellSymptom)).toBeDefined()
+      expect(getByText("Cough")).toBeDefined()
+      expect(getByText("Loss of smell")).toBeDefined()
     })
   })
 

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -38,13 +38,13 @@ type LogEntryProps = {
 const LogEntry: FunctionComponent<LogEntryProps> = ({ logEntry }) => {
   const { t } = useTranslation()
   const navigation = useNavigation<StackNavigationProp<MyHealthStackParams>>()
-  const { symptoms, date: timestamp } = logEntry
+  const { symptoms, date } = logEntry
 
   if (symptoms.length === 0) {
     return null
   }
 
-  const dayJsDate = posixToDayjs(timestamp)
+  const dayJsDate = posixToDayjs(date)
 
   const handleOnPressEdit = () => {
     navigation.navigate(MyHealthStackScreens.SelectSymptoms, {

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -1,5 +1,11 @@
 import React, { FunctionComponent } from "react"
-import { ScrollView, StyleSheet, TouchableOpacity, View } from "react-native"
+import {
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { useTranslation } from "react-i18next"
@@ -18,15 +24,42 @@ type CheckInSummaryProps = {
 
 const CheckInSummary: FunctionComponent<CheckInSummaryProps> = ({ status }) => {
   const { t } = useTranslation()
-  const [statusDotText, statusDotStyle] =
-    status === CheckInStatus.FeelingNotWell
-      ? [t("my_health.symptom_log.feeling_not_well"), style.statusDotOrange]
-      : [t("my_health.symptom_log.feeling_well"), style.statusDotGreen]
+
+  type CheckInContent = {
+    text: string
+    colorStyle: ViewStyle
+  }
+
+  const determineCheckInStatusContent = (): CheckInContent => {
+    const didNotCheckInContent: CheckInContent = {
+      text: t("my_health.symptom_log.did_not_check_in"),
+      colorStyle: style.statusDotGray,
+    }
+    const feelingNotWellContent: CheckInContent = {
+      text: t("my_health.symptom_log.feeling_not_well"),
+      colorStyle: style.statusDotOrange,
+    }
+    const feelingGoodContent: CheckInContent = {
+      text: t("my_health.symptom_log.feeling_well"),
+      colorStyle: style.statusDotGreen,
+    }
+
+    switch (status) {
+      case CheckInStatus.NotCheckedIn:
+        return didNotCheckInContent
+      case CheckInStatus.FeelingNotWell:
+        return feelingNotWellContent
+      case CheckInStatus.FeelingGood:
+        return feelingGoodContent
+    }
+  }
+
+  const content = determineCheckInStatusContent()
 
   return (
     <View style={style.checkInStatusContainer}>
-      <View style={{ ...style.statusDot, ...statusDotStyle }} />
-      <GlobalText style={style.checkInStatusText}>{statusDotText}</GlobalText>
+      <View style={{ ...style.statusDot, ...content.colorStyle }} />
+      <GlobalText style={style.checkInStatusText}>{content.text}</GlobalText>
     </View>
   )
 }
@@ -145,6 +178,9 @@ const style = StyleSheet.create({
     width: Spacing.xxSmall,
     height: Spacing.xxSmall,
     borderRadius: Outlines.borderRadiusMax,
+  },
+  statusDotGray: {
+    backgroundColor: Colors.neutral75,
   },
   statusDotOrange: {
     backgroundColor: Colors.warning100,

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -1,39 +1,33 @@
 import React, { FunctionComponent } from "react"
-import { TouchableOpacity, View } from "react-native"
+import { ScrollView, StyleSheet, TouchableOpacity, View } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { useTranslation } from "react-i18next"
 
 import { useSymptomLogContext } from "./SymptomLogContext"
-import { SymptomLogEntry, Symptom, DayLogData, CheckInStatus } from "./symptoms"
+import { SymptomLogEntry, DayLogData, CheckInStatus } from "./symptoms"
 import { GlobalText } from "../components"
-import { Posix, posixToDayjs } from "../utils/dateTime"
+import { posixToDayjs } from "../utils/dateTime"
 import { MyHealthStackScreens } from "../navigation"
 import { MyHealthStackParams } from "../navigation/MyHealthStack"
+import { Typography, Colors, Outlines, Spacing } from "../styles"
 
-type SymptomsListProps = {
-  symptoms: Symptom[]
-  timestamp: Posix
+type CheckInSummaryProps = {
+  status: CheckInStatus
 }
 
-const SymptomsList: FunctionComponent<SymptomsListProps> = ({
-  symptoms,
-  timestamp,
-}) => {
-  if (symptoms.length === 0) {
-    return null
-  }
-  const dayJsDate = posixToDayjs(timestamp)
+const CheckInSummary: FunctionComponent<CheckInSummaryProps> = ({ status }) => {
+  const { t } = useTranslation()
+  const [statusDotText, statusDotStyle] =
+    status === CheckInStatus.FeelingNotWell
+      ? [t("my_health.symptom_log.feeling_not_well"), style.statusDotOrange]
+      : [t("my_health.symptom_log.feeling_well"), style.statusDotGreen]
 
   return (
-    <>
-      {dayJsDate && (
-        <GlobalText>{dayJsDate.local().format("HH:mm")}</GlobalText>
-      )}
-      {symptoms.map((symptom) => {
-        return <GlobalText key={symptom}>{symptom}</GlobalText>
-      })}
-    </>
+    <View style={style.checkInStatusContainer}>
+      <View style={{ ...style.statusDot, ...statusDotStyle }} />
+      <GlobalText style={style.checkInStatusText}>{statusDotText}</GlobalText>
+    </View>
   )
 }
 
@@ -44,7 +38,13 @@ type LogEntryProps = {
 const LogEntry: FunctionComponent<LogEntryProps> = ({ logEntry }) => {
   const { t } = useTranslation()
   const navigation = useNavigation<StackNavigationProp<MyHealthStackParams>>()
-  const { symptoms, date } = logEntry
+  const { symptoms, date: timestamp } = logEntry
+
+  if (symptoms.length === 0) {
+    return null
+  }
+
+  const dayJsDate = posixToDayjs(timestamp)
 
   const handleOnPressEdit = () => {
     navigation.navigate(MyHealthStackScreens.SelectSymptoms, {
@@ -53,29 +53,34 @@ const LogEntry: FunctionComponent<LogEntryProps> = ({ logEntry }) => {
   }
 
   return (
-    <>
-      <SymptomsList symptoms={symptoms} timestamp={date} />
-      <TouchableOpacity
-        onPress={handleOnPressEdit}
-        accessibilityLabel={t("common.edit")}
-      >
-        <GlobalText>{t("common.edit")}</GlobalText>
-      </TouchableOpacity>
-    </>
+    <View style={style.symptomLogContainer}>
+      <View style={style.timeAndEditContainer}>
+        {dayJsDate && (
+          <GlobalText style={style.timeText}>
+            {dayJsDate.local().format("HH:mm A")}
+          </GlobalText>
+        )}
+        <TouchableOpacity
+          onPress={handleOnPressEdit}
+          accessibilityLabel={t("common.edit")}
+        >
+          <GlobalText style={style.editText}>{t("common.edit")}</GlobalText>
+        </TouchableOpacity>
+      </View>
+      <View style={style.symptomsContainer}>
+        {symptoms.map((symptom) => {
+          const translatedSymptom = t(`symptoms.${symptom}`)
+          return (
+            <View style={style.symptomTextContainer} key={translatedSymptom}>
+              <GlobalText style={style.symptomText}>
+                {translatedSymptom}
+              </GlobalText>
+            </View>
+          )
+        })}
+      </View>
+    </View>
   )
-}
-
-type CheckInSummaryProps = {
-  status: CheckInStatus
-}
-
-const CheckInSummary: FunctionComponent<CheckInSummaryProps> = ({ status }) => {
-  const { t } = useTranslation()
-  const reportedStatusText =
-    status === CheckInStatus.FeelingNotWell
-      ? t("my_health.symptom_log.feeling_not_well")
-      : t("my_health.symptom_log.feeling_well")
-  return <GlobalText>{reportedStatusText}</GlobalText>
 }
 
 type DaySummaryProps = {
@@ -90,7 +95,9 @@ const DaySummary: FunctionComponent<DaySummaryProps> = ({
   return (
     <>
       {dayJsDate && (
-        <GlobalText>{dayJsDate.local().format("YYYY-MM-DD")}</GlobalText>
+        <GlobalText style={style.dateText}>
+          {dayJsDate.local().format("MMMM D, YYYY")}
+        </GlobalText>
       )}
       {checkIn && <CheckInSummary status={checkIn.status} />}
       {logEntries.map((logEntry) => {
@@ -104,12 +111,86 @@ const OverTime: FunctionComponent = () => {
   const { dailyLogData } = useSymptomLogContext()
 
   return (
-    <View>
+    <ScrollView
+      style={style.container}
+      contentContainerStyle={style.contentContainer}
+      alwaysBounceVertical={false}
+    >
       {dailyLogData.map((logData) => {
         return <DaySummary key={logData.date} dayLogData={logData} />
       })}
-    </View>
+    </ScrollView>
   )
 }
+
+const style = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: Spacing.large,
+    backgroundColor: Colors.primaryLightBackground,
+  },
+  contentContainer: {
+    paddingTop: Spacing.large,
+    paddingBottom: Spacing.large,
+  },
+  dateText: {
+    ...Typography.header4,
+    marginBottom: Spacing.xxxSmall,
+  },
+  checkInStatusContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: Spacing.small,
+  },
+  statusDot: {
+    width: Spacing.xxSmall,
+    height: Spacing.xxSmall,
+    borderRadius: Outlines.borderRadiusMax,
+  },
+  statusDotOrange: {
+    backgroundColor: Colors.warning100,
+  },
+  statusDotGreen: {
+    backgroundColor: Colors.success100,
+  },
+  checkInStatusText: {
+    ...Typography.body1,
+    marginLeft: Spacing.xxSmall,
+  },
+  symptomLogContainer: {
+    paddingBottom: Spacing.medium,
+    marginBottom: Spacing.medium,
+    borderBottomWidth: Outlines.hairline,
+    borderBottomColor: Colors.neutral10,
+  },
+  timeAndEditContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    marginBottom: Spacing.xSmall,
+  },
+  timeText: {
+    ...Typography.body2,
+    color: Colors.neutral100,
+  },
+  editText: {
+    ...Typography.body2,
+  },
+  symptomsContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+  symptomTextContainer: {
+    backgroundColor: Colors.neutral10,
+    marginBottom: Spacing.xxSmall,
+    marginRight: Spacing.xxSmall,
+    borderRadius: Outlines.borderRadiusMax,
+    paddingVertical: Spacing.xxxSmall,
+    paddingHorizontal: Spacing.xSmall,
+  },
+  symptomText: {
+    ...Typography.body2,
+  },
+})
 
 export default OverTime

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -126,12 +126,11 @@ const OverTime: FunctionComponent = () => {
 const style = StyleSheet.create({
   container: {
     flex: 1,
-    paddingHorizontal: Spacing.large,
     backgroundColor: Colors.primaryLightBackground,
   },
   contentContainer: {
-    paddingTop: Spacing.large,
-    paddingBottom: Spacing.large,
+    paddingVertical: Spacing.large,
+    paddingHorizontal: Spacing.large,
   },
   dateText: {
     ...Typography.header4,

--- a/src/MyHealth/SelectSymptoms.spec.tsx
+++ b/src/MyHealth/SelectSymptoms.spec.tsx
@@ -17,7 +17,6 @@ describe("SelectSymptomsScreen", () => {
       jest.resetAllMocks()
     })
     it("updates the symptom log", async () => {
-      const showMessageSpy = showMessage as jest.Mock
       const updateLogEntrySpy = jest.fn()
       updateLogEntrySpy.mockResolvedValueOnce({})
       const logEntry = {
@@ -49,11 +48,6 @@ describe("SelectSymptomsScreen", () => {
           ...logEntry,
           symptoms: ["cough", "fever"],
         })
-        expect(showMessageSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: "Symptoms updated!",
-          }),
-        )
         expect(navigateSpy).toHaveBeenCalledWith(
           MyHealthStackScreens.AtRiskRecommendation,
         )
@@ -116,7 +110,6 @@ describe("SelectSymptomsScreen", () => {
       expect(queryByLabelText("Delete entry")).toBeNull()
     })
     it("creates a new symptom log", async () => {
-      const showMessageSpy = showMessage as jest.Mock
       const addLogEntrySpy = jest.fn()
       addLogEntrySpy.mockResolvedValueOnce({})
       const navigateSpy = jest.fn()
@@ -139,11 +132,6 @@ describe("SelectSymptomsScreen", () => {
 
       await waitFor(() => {
         expect(addLogEntrySpy).toHaveBeenCalledWith([coughSymptom])
-        expect(showMessageSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: "Symptoms saved!",
-          }),
-        )
         expect(navigateSpy).toHaveBeenCalledWith(
           MyHealthStackScreens.AtRiskRecommendation,
         )

--- a/src/MyHealth/SelectSymptoms.tsx
+++ b/src/MyHealth/SelectSymptoms.tsx
@@ -32,7 +32,7 @@ import { Icons } from "../assets"
 import { MyHealthStackParams } from "../navigation/MyHealthStack"
 
 const SelectSymptomsScreen: FunctionComponent = () => {
-  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
+  useStatusBarEffect("dark-content", Colors.secondary10)
   const { t } = useTranslation()
   const navigation = useNavigation()
   const route = useRoute<RouteProp<MyHealthStackParams, "SelectSymptoms">>()
@@ -77,19 +77,18 @@ const SelectSymptomsScreen: FunctionComponent = () => {
       addLogEntry(selectedSymptoms)
     }
 
-    const flashMessage = isEditingLogEntry
-      ? t("symptom_checker.symptoms_updated")
-      : t("symptom_checker.symptoms_saved")
-
     const currentHealthAssessment = determineHealthAssessment(selectedSymptoms)
     if (currentHealthAssessment === HealthAssessment.AtRisk) {
+      navigation.navigate(MyHealthStackScreens.AtRiskRecommendation)
+    } else {
+      navigation.goBack()
+      const flashMessage = isEditingLogEntry
+        ? t("symptom_checker.symptoms_updated")
+        : t("symptom_checker.symptoms_saved")
       showMessage({
         message: flashMessage,
         ...Affordances.successFlashMessageOptions,
       })
-      navigation.navigate(MyHealthStackScreens.AtRiskRecommendation)
-    } else {
-      navigation.goBack()
     }
   }
 
@@ -107,7 +106,7 @@ const SelectSymptomsScreen: FunctionComponent = () => {
 
   return (
     <>
-      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+      <StatusBar backgroundColor={Colors.secondary10} />
       <View style={style.headerContainer}>
         <GlobalText style={style.headerText}>
           {t("symptom_checker.what_symptoms")}
@@ -174,7 +173,7 @@ const style = StyleSheet.create({
   contentContainer: {
     flexGrow: 1,
     backgroundColor: Colors.primaryLightBackground,
-    paddingTop: Spacing.xxxHuge,
+    paddingTop: Spacing.medium,
     paddingHorizontal: Spacing.large,
     paddingBottom: Spacing.xxHuge,
   },
@@ -190,7 +189,7 @@ const style = StyleSheet.create({
     flexDirection: "row",
     alignItems: "flex-end",
     justifyContent: "space-between",
-    backgroundColor: Colors.white,
+    backgroundColor: Colors.secondary10,
   },
   headerText: {
     ...Typography.header2,

--- a/src/MyHealth/SelectSymptoms.tsx
+++ b/src/MyHealth/SelectSymptoms.tsx
@@ -164,7 +164,7 @@ const SelectSymptomsScreen: FunctionComponent = () => {
   )
 }
 
-const headerHeight = 100
+const headerHeight = 130
 
 const style = StyleSheet.create({
   container: {
@@ -177,12 +177,6 @@ const style = StyleSheet.create({
     paddingHorizontal: Spacing.large,
     paddingBottom: Spacing.xxHuge,
   },
-  closeIconContainer: {
-    position: "absolute",
-    right: 0,
-    top: 0,
-    padding: Spacing.medium,
-  },
   headerContainer: {
     width: "100%",
     height: headerHeight,
@@ -190,11 +184,17 @@ const style = StyleSheet.create({
     alignItems: "flex-end",
     justifyContent: "space-between",
     backgroundColor: Colors.secondary10,
+    paddingHorizontal: Spacing.small,
+    paddingBottom: Spacing.medium,
   },
   headerText: {
     ...Typography.header2,
-    marginBottom: Spacing.large,
-    marginLeft: Spacing.small,
+  },
+  closeIconContainer: {
+    position: "absolute",
+    right: 0,
+    top: 0,
+    padding: Spacing.medium,
   },
   symptomButtonsContainer: {
     flexWrap: "wrap",

--- a/src/MyHealth/SelectSymptoms.tsx
+++ b/src/MyHealth/SelectSymptoms.tsx
@@ -26,6 +26,7 @@ import {
   Typography,
   Outlines,
   Iconography,
+  Buttons,
 } from "../styles"
 import { SvgXml } from "react-native-svg"
 import { Icons } from "../assets"
@@ -150,13 +151,18 @@ const SelectSymptomsScreen: FunctionComponent = () => {
           onPress={handleOnPressSave}
           label={t("common.save")}
           disabled={selectedSymptoms.length === 0}
+          customButtonStyle={style.saveButton}
+          customButtonInnerStyle={style.saveButtonInner}
         />
         {isEditingLogEntry && (
           <TouchableOpacity
             onPress={handleOnPressDelete}
             accessibilityLabel={t("symptom_checker.delete_entry")}
+            style={style.deleteButtonContainer}
           >
-            <GlobalText>{t("symptom_checker.delete_entry")}</GlobalText>
+            <GlobalText style={style.deleteButtonText}>
+              {t("symptom_checker.delete_entry")}
+            </GlobalText>
           </TouchableOpacity>
         )}
       </ScrollView>
@@ -211,14 +217,31 @@ const style = StyleSheet.create({
     marginRight: Spacing.small,
   },
   symptomButtonSelected: {
-    backgroundColor: Colors.primary100,
-    borderColor: Colors.primary100,
+    backgroundColor: Colors.neutral100,
+    borderColor: Colors.neutral100,
   },
   symptomButtonText: {
     ...Typography.body1,
   },
   symptomButtonTextSelected: {
     color: Colors.white,
+  },
+  saveButton: {
+    width: "100%",
+    paddingHorizontal: Spacing.xHuge,
+  },
+  saveButtonInner: {
+    width: "100%",
+  },
+  deleteButtonContainer: {
+    ...Buttons.secondary,
+    alignSelf: "center",
+    marginTop: Spacing.medium,
+  },
+  deleteButtonText: {
+    ...Typography.buttonSecondary,
+    fontSize: Typography.small,
+    color: Colors.danger100,
   },
 })
 

--- a/src/MyHealth/Today.tsx
+++ b/src/MyHealth/Today.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from "react"
 import {
   TouchableOpacity,
+  ScrollView,
   View,
   Image,
   StyleSheet,
@@ -63,7 +64,11 @@ const Today: FunctionComponent = () => {
       : Colors.primary100
 
   return (
-    <>
+    <ScrollView
+      style={style.container}
+      contentContainerStyle={style.contentContainer}
+      alwaysBounceVertical={false}
+    >
       <View style={style.floatingContainer}>
         <SvgXml
           xml={Icons.CheckInBrokenCircle}
@@ -86,7 +91,7 @@ const Today: FunctionComponent = () => {
           hasPlusIcon
         />
       </View>
-    </>
+    </ScrollView>
   )
 }
 
@@ -195,6 +200,15 @@ const FeelingButton: FunctionComponent<FeelingButtonProps> = ({
 
 const feelingButtonHeight = 120
 const style = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: Spacing.xLarge,
+    backgroundColor: Colors.primaryLightBackground,
+  },
+  contentContainer: {
+    paddingTop: Spacing.large,
+    paddingBottom: Spacing.large,
+  },
   floatingContainer: {
     ...Outlines.lightShadow,
     backgroundColor: Colors.primaryLightBackground,

--- a/src/MyHealth/Today.tsx
+++ b/src/MyHealth/Today.tsx
@@ -202,12 +202,11 @@ const feelingButtonHeight = 120
 const style = StyleSheet.create({
   container: {
     flex: 1,
-    paddingHorizontal: Spacing.xLarge,
     backgroundColor: Colors.primaryLightBackground,
   },
   contentContainer: {
-    paddingTop: Spacing.large,
-    paddingBottom: Spacing.large,
+    paddingVertical: Spacing.large,
+    paddingHorizontal: Spacing.xLarge,
   },
   floatingContainer: {
     ...Outlines.lightShadow,

--- a/src/MyHealth/index.tsx
+++ b/src/MyHealth/index.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useState } from "react"
-import { View, StyleSheet, ScrollView } from "react-native"
+import { View, StyleSheet } from "react-native"
 import SegmentedControl from "@react-native-community/segmented-control"
 import { useTranslation } from "react-i18next"
 
@@ -11,81 +11,72 @@ import OverTime from "./OverTime"
 import { Typography, Colors, Spacing } from "../styles"
 
 const MyHealthScreen: FunctionComponent = () => {
-  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
+  useStatusBarEffect("dark-content", Colors.secondary10)
   const { t } = useTranslation()
   const [selectedIndex, setSelectedIndex] = useState<number>(0)
 
-  const determineDisplayToday = () => {
-    if (selectedIndex === 0) {
-      return {}
-    }
-    return style.hidden
-  }
+  const todayStyle = selectedIndex === 0 ? style.innerContainer : style.hidden
 
-  const determineDisplayOverTime = () => {
-    if (selectedIndex === 1) {
-      return {}
-    }
-    return style.hidden
-  }
+  const overTimeStyle =
+    selectedIndex === 1 ? style.innerContainer : style.hidden
 
   return (
     <>
-      <StatusBar backgroundColor={Colors.primaryLightBackground} />
-      <ScrollView
-        style={style.container}
-        contentContainerStyle={style.contentContainer}
-        alwaysBounceVertical={false}
-      >
-        <GlobalText style={style.headerText}>
-          {t("symptom_checker.my_health")}
-        </GlobalText>
-        <View style={style.segmentedControlContainer}>
-          <SegmentedControl
-            values={[t("my_health.today"), t("my_health.over_time")]}
-            selectedIndex={selectedIndex}
-            onChange={(event) => {
-              setSelectedIndex(event.nativeEvent.selectedSegmentIndex)
-            }}
-            fontStyle={style.segmentedControlText}
-            activeFontStyle={style.activeSegmentedControlText}
-          />
+      <StatusBar backgroundColor={Colors.secondary10} />
+      <View style={style.container}>
+        <View style={style.headerContainer}>
+          <GlobalText style={style.headerText}>
+            {t("symptom_checker.my_health")}
+          </GlobalText>
+          <View style={style.segmentedControlContainer}>
+            <SegmentedControl
+              values={[t("my_health.today"), t("my_health.over_time")]}
+              selectedIndex={selectedIndex}
+              onChange={(event) => {
+                setSelectedIndex(event.nativeEvent.selectedSegmentIndex)
+              }}
+              fontStyle={style.segmentedControlText}
+              activeFontStyle={style.activeSegmentedControlText}
+            />
+          </View>
         </View>
-        <View style={determineDisplayToday()}>
+        <View style={todayStyle}>
           <Today />
         </View>
-        <View style={determineDisplayOverTime()}>
+        <View style={overTimeStyle}>
           <OverTime />
         </View>
-      </ScrollView>
+      </View>
     </>
   )
 }
 
 const style = StyleSheet.create({
   container: {
-    backgroundColor: Colors.primaryLightBackground,
-  },
-  contentContainer: {
     flexGrow: 1,
-    backgroundColor: Colors.primaryLightBackground,
+    backgroundColor: Colors.secondary10,
     paddingTop: Spacing.large,
+  },
+  headerContainer: {
     paddingHorizontal: Spacing.large,
-    paddingBottom: Spacing.xxxHuge,
+    backgroundColor: Colors.secondary10,
   },
   headerText: {
     ...Typography.header1,
     ...Typography.bold,
-    marginBottom: Spacing.xLarge,
+    marginBottom: Spacing.medium,
   },
   segmentedControlContainer: {
-    marginBottom: Spacing.xLarge,
+    marginBottom: Spacing.large,
   },
   segmentedControlText: {
     fontFamily: "IBMPlexSans",
   },
   activeSegmentedControlText: {
     fontFamily: "IBMPlexSans-Medium",
+  },
+  innerContainer: {
+    flexGrow: 1,
   },
   hidden: {
     display: "none",

--- a/src/configuration/copy.json
+++ b/src/configuration/copy.json
@@ -7,8 +7,5 @@
   },
   "legal": {
     "en": ""
-  },
-  "callback_success": {
-    "en": ""
   }
 }

--- a/src/configuration/copy.json
+++ b/src/configuration/copy.json
@@ -7,5 +7,8 @@
   },
   "legal": {
     "en": ""
+  },
+  "callback_success": {
+    "en": ""
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -332,7 +332,8 @@
     "over_time": "Over Time",
     "symptom_log": {
       "feeling_well": "You were feeling well",
-      "feeling_not_well": "You were not feeling well"
+      "feeling_not_well": "You were not feeling well",
+      "did_not_check_in": "You did not check in"
     }
   },
   "symptoms": {

--- a/src/styles/outlines.ts
+++ b/src/styles/outlines.ts
@@ -27,7 +27,7 @@ export const baseShadow: ViewStyle = {
     width: 0,
     height: 8,
   },
-  shadowOpacity: 0.3,
+  shadowOpacity: 0.15,
   shadowRadius: 13.16,
   elevation: 20,
 }


### PR DESCRIPTION
Why:
----
Prior to this commit, there were many elements of the MyHealth screens that were not styled.

This commit:
----
- Style the `OverTime`, `Today` and `SelectSymptoms` screens
- Update some specs

Co-Authored-By: Matt Buckley <matt@nicethings.io>

![gif](https://user-images.githubusercontent.com/39350030/94282649-108d0300-ff1e-11ea-9c64-569ce2c792bb.gif)