### PR TITLE
Handle failures when operating with symptom logs

### DIFF
--- a/src/MyHealth/SelectSymptoms.tsx
+++ b/src/MyHealth/SelectSymptoms.tsx
@@ -59,25 +59,63 @@ const SelectSymptomsScreen: FunctionComponent = () => {
     }
   }
 
-  const handleOnPressDelete = () => {
+  const handleOnPressDelete = async () => {
     if (isEditingLogEntry) {
-      deleteLogEntry(symptomLogEntryToEdit.id)
-      showMessage({
-        message: t("symptom_checker.entry_deleted"),
-        ...Affordances.successFlashMessageOptions,
-      })
+      const result = await deleteLogEntry(symptomLogEntryToEdit.id)
+      if (result.kind === "success") {
+        showMessage({
+          message: t("symptom_checker.entry_deleted"),
+          ...Affordances.successFlashMessageOptions,
+        })
 
-      navigation.goBack()
+        navigation.goBack()
+      } else {
+        showMessage({
+          message: t("symptom_checker.errors.deleting_symptom_log"),
+          ...Affordances.errorFlashMessageOptions,
+        })
+      }
     }
   }
 
-  const handleOnPressSave = () => {
+  const handleOnPressSave = async () => {
     if (isEditingLogEntry) {
-      updateLogEntry({ ...symptomLogEntryToEdit, symptoms: selectedSymptoms })
+      await updateSymptomLog()
     } else {
-      addLogEntry(selectedSymptoms)
+      await createNewSymptomLog()
     }
+  }
 
+  const createNewSymptomLog = async () => {
+    const result = await addLogEntry(selectedSymptoms)
+
+    if (result.kind === "success") {
+      completeOnPressSave()
+    } else {
+      showMessage({
+        message: t("symptom_checker.errors.adding_symptoms"),
+        ...Affordances.successFlashMessageOptions,
+      })
+    }
+  }
+
+  const updateSymptomLog = async () => {
+    const result = await updateLogEntry({
+      ...symptomLogEntryToEdit,
+      symptoms: selectedSymptoms,
+    })
+
+    if (result.kind === "success") {
+      completeOnPressSave()
+    } else {
+      showMessage({
+        message: t("symptom_checker.errors.updating_symptoms"),
+        ...Affordances.successFlashMessageOptions,
+      })
+    }
+  }
+
+  const completeOnPressSave = () => {
     const currentHealthAssessment = determineHealthAssessment(selectedSymptoms)
     if (currentHealthAssessment === HealthAssessment.AtRisk) {
       navigation.navigate(MyHealthStackScreens.AtRiskRecommendation)

--- a/src/MyHealth/SelectSymptoms.tsx
+++ b/src/MyHealth/SelectSymptoms.tsx
@@ -266,10 +266,11 @@ const style = StyleSheet.create({
   },
   saveButton: {
     width: "100%",
-    paddingHorizontal: Spacing.xHuge,
   },
   saveButtonInner: {
     width: "100%",
+    paddingTop: Spacing.xSmall,
+    paddingBottom: Spacing.xSmall + 1,
   },
   deleteButtonContainer: {
     ...Buttons.secondary,

--- a/src/MyHealth/Today.tsx
+++ b/src/MyHealth/Today.tsx
@@ -11,12 +11,20 @@ import {
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
+import { showMessage } from "react-native-flash-message"
 
 import { GlobalText, Button } from "../components"
 import { CheckInStatus } from "./symptoms"
 import { MyHealthStackScreens } from "../navigation"
 
-import { Outlines, Colors, Typography, Spacing, Iconography } from "../styles"
+import {
+  Outlines,
+  Colors,
+  Typography,
+  Spacing,
+  Iconography,
+  Affordances,
+} from "../styles"
 import { Icons, Images } from "../assets"
 import { useConfigurationContext } from "../ConfigurationContext"
 import { useSymptomLogContext } from "./SymptomLogContext"
@@ -29,13 +37,26 @@ const Today: FunctionComponent = () => {
     addTodaysCheckIn,
   } = useSymptomLogContext()
 
-  const handleOnPressGood = () => {
-    addTodaysCheckIn(CheckInStatus.FeelingGood)
+  const handleOnPressGood = async () => {
+    const result = await addTodaysCheckIn(CheckInStatus.FeelingGood)
+    if (result.kind === "failure") {
+      showMessage({
+        message: t("symptom_checker.errors.adding_check_in"),
+        ...Affordances.errorFlashMessageOptions,
+      })
+    }
   }
 
-  const handleOnPressNotWell = () => {
-    addTodaysCheckIn(CheckInStatus.FeelingNotWell)
-    navigation.navigate(MyHealthStackScreens.SelectSymptoms)
+  const handleOnPressNotWell = async () => {
+    const result = await addTodaysCheckIn(CheckInStatus.FeelingNotWell)
+    if (result.kind === "failure") {
+      showMessage({
+        message: t("symptom_checker.errors.adding_check_in"),
+        ...Affordances.errorFlashMessageOptions,
+      })
+    } else {
+      navigation.navigate(MyHealthStackScreens.SelectSymptoms)
+    }
   }
 
   const handleOnPressLogSymptoms = () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -329,7 +329,13 @@
     "delete_entry": "Delete entry",
     "entry_deleted": "Entry deleted",
     "log_symptoms": "Log symptoms",
-    "check_in_again": "Check in again tomorrow."
+    "check_in_again": "Check in again tomorrow.",
+    "errors": {
+      "adding_check_in": "Sorry, we could not add todays check in",
+      "adding_symptoms": "Sorry, we could not log your symptoms",
+      "updating_symptoms": "Sorry, we could not update your symptoms",
+      "deleting_symptom_log": "Sorry, we could not delete the symptoms log"
+    }
   },
   "my_health": {
     "today": "Today",


### PR DESCRIPTION
Why:
----

We need to be able to recover from errors operating on symptom logs or check ins.

This Commit:
----
- Handle failures on log context operations
- Show flash error message when adding symptoms fails
- Show flash error message when deleting log symptoms fails
- Show flash error message when updating log symptoms fails
