### PR TITLE
Add node-fetch to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "dayjs": "^1.8.24",
     "i18next": "^19.3.3",
     "lodash.isequal": "^4.5.0",
+    "node-fetch": "^2.6.1",
     "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-i18next": "^11.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6502,6 +6502,11 @@ node-fetch@^2.2.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
Why:
Currently we have low severity vulnerability warning related to our
version of node-fetch, will this doesn't affect us as we are not using
the feature in the library with the vulnerability, we would still like
to update the package to stay up to date with latest security patches.