### PR TITLE
Refresh exposure history once it's focused

### DIFF
--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -80,8 +80,8 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
   }, [getLastDetectionDate])
 
   const refreshExposureInfo = async () => {
-    const exposureInfos = await getCurrentExposures()
-    setExposureInfo(exposureInfos)
+    const exposureInfo = await getCurrentExposures()
+    setExposureInfo(exposureInfo)
 
     const detectionDate = await getLastDetectionDate()
     setLastExposureDetectionDate(detectionDate)

--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -33,7 +33,7 @@ export interface ExposureState {
   getRevisionToken: () => Promise<string>
   lastExposureDetectionDate: Posix | null
   storeRevisionToken: (revisionToken: string) => Promise<void>
-  refreshExposureInfo: () => Promise<void>
+  refreshExposureInfo: () => void
   checkForNewExposures: () => Promise<OperationResponse>
 }
 
@@ -52,9 +52,7 @@ const initialState = {
   storeRevisionToken: () => {
     return Promise.resolve()
   },
-  refreshExposureInfo: () => {
-    return Promise.resolve()
-  },
+  refreshExposureInfo: () => {},
   checkForNewExposures: () => {
     return Promise.resolve(SUCCESS_RESPONSE)
   },
@@ -87,8 +85,6 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
 
     const detectionDate = await getLastDetectionDate()
     setLastExposureDetectionDate(detectionDate)
-
-    return Promise.resolve()
   }
 
   useEffect(() => {

--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -1,10 +1,10 @@
-import React, { FunctionComponent, useEffect } from "react"
+import React, { FunctionComponent, useCallback } from "react"
 
 import { useExposureContext } from "../ExposureContext"
 import History from "./History"
 
 import { ExposureInfo, ExposureDatum } from "../exposure"
-import { useNavigation } from "@react-navigation/native"
+import { useFocusEffect } from "@react-navigation/native"
 
 const toExposureList = (exposureInfo: ExposureInfo): ExposureDatum[] => {
   return exposureInfo
@@ -17,14 +17,11 @@ const ExposureHistoryScreen: FunctionComponent = () => {
     refreshExposureInfo,
   } = useExposureContext()
 
-  const navigation = useNavigation()
-
-  useEffect(() => {
-    // Refresh exposure info each time this screen gets focus
-    navigation.addListener("focus", () => {
+  useFocusEffect(
+    useCallback(() => {
       refreshExposureInfo()
-    })
-  }, [])
+    }, [refreshExposureInfo]),
+  )
 
   const exposures = toExposureList(exposureInfo)
 

--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -1,16 +1,30 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent, useEffect } from "react"
 
 import { useExposureContext } from "../ExposureContext"
 import History from "./History"
 
 import { ExposureInfo, ExposureDatum } from "../exposure"
+import { useNavigation } from "@react-navigation/native"
 
 const toExposureList = (exposureInfo: ExposureInfo): ExposureDatum[] => {
   return exposureInfo
 }
 
 const ExposureHistoryScreen: FunctionComponent = () => {
-  const { lastExposureDetectionDate, exposureInfo } = useExposureContext()
+  const {
+    lastExposureDetectionDate,
+    exposureInfo,
+    refreshExposureInfo,
+  } = useExposureContext()
+
+  const navigation = useNavigation()
+
+  useEffect(() => {
+    // Refresh exposure info each time this screen gets focus
+    navigation.addListener("focus", () => {
+      refreshExposureInfo()
+    })
+  }, [])
 
   const exposures = toExposureList(exposureInfo)
 

--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -1,10 +1,10 @@
 import React, { FunctionComponent, useCallback } from "react"
+import { useFocusEffect } from "@react-navigation/native"
 
 import { useExposureContext } from "../ExposureContext"
 import History from "./History"
 
 import { ExposureInfo, ExposureDatum } from "../exposure"
-import { useFocusEffect } from "@react-navigation/native"
 
 const toExposureList = (exposureInfo: ExposureInfo): ExposureDatum[] => {
   return exposureInfo
@@ -20,7 +20,7 @@ const ExposureHistoryScreen: FunctionComponent = () => {
   useFocusEffect(
     useCallback(() => {
       refreshExposureInfo()
-    }, [refreshExposureInfo]),
+    }, []),
   )
 
   const exposures = toExposureList(exposureInfo)

--- a/src/factories/exposureContext.tsx
+++ b/src/factories/exposureContext.tsx
@@ -9,5 +9,6 @@ export default Factory.define<ExposureState>(() => ({
   lastExposureDetectionDate: null,
   storeRevisionToken: (_revisionToken: string) => Promise.resolve(),
   getRevisionToken: () => Promise.resolve(""),
+  refreshExposureInfo: () => {},
   checkForNewExposures: () => Promise.resolve(SUCCESS_RESPONSE),
 }))


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
We were only refreshing the exposure history once the user minimized the app.
This PR updates the exposure history screen every time that tab gets focus.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/GAEN-252