### PR TITLE
Overtime "List" vs "Calendar" Header

### DIFF
--- a/src/MyHealth/OverTime.spec.tsx
+++ b/src/MyHealth/OverTime.spec.tsx
@@ -59,6 +59,21 @@ describe("OverTime", () => {
     })
   })
 
+  describe("when the user views their last 14 days", () => {
+    it('shows the "Last 14 Days" header title', () => {
+      const { getByText } = render(<OverTime />)
+      expect(getByText("LAST 14 DAYS")).toBeDefined()
+    })
+  })
+
+  describe("when the user views their log history", () => {
+    it('shows the "History" header title', () => {
+      const { getByText, getByTestId } = render(<OverTime />)
+      fireEvent.press(getByTestId("calendar-button"))
+      expect(getByText("HISTORY")).toBeDefined()
+    })
+  })
+
   describe("when the user has log data with no checkIn entries", () => {
     it("shows the correct message, date and symptoms", () => {
       const dateString = "September 21, 2020"

--- a/src/MyHealth/OverTime.spec.tsx
+++ b/src/MyHealth/OverTime.spec.tsx
@@ -68,8 +68,8 @@ describe("OverTime", () => {
 
   describe("when the user views their log history", () => {
     it('shows the "History" header title', () => {
-      const { getByText, getByTestId } = render(<OverTime />)
-      fireEvent.press(getByTestId("calendar-button"))
+      const { getByText, getByLabelText } = render(<OverTime />)
+      fireEvent.press(getByLabelText("Toggle symptom log view"))
       expect(getByText("HISTORY")).toBeDefined()
     })
   })

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -151,47 +151,40 @@ const OverTime: FunctionComponent = () => {
     CALENDAR,
   }
 
-  const [viewSelection, setViewSelection] = useState<ViewSelection>(ViewSelection.LIST)
+  const [viewSelection, setViewSelection] = useState<ViewSelection>(
+    ViewSelection.LIST,
+  )
 
   const noSymptomHistory = dailyLogData.length === 0
 
-  const last14DaysStyle =
-    viewSelection === ViewSelection.LIST ? null : style.hidden
+  const headerTitle =
+    viewSelection === ViewSelection.LIST
+      ? t("symptom_checker.last_14_days")
+      : t("symptom_checker.history")
 
-  const historyStyle =
-    viewSelection === ViewSelection.CALENDAR ? {} : style.hidden
+  const headerIcon =
+    viewSelection === ViewSelection.LIST ? Icons.Calendar : Icons.Hamburger
+
+  const handleOnPressToggleView = () => {
+    if (viewSelection === ViewSelection.LIST) {
+      setViewSelection(ViewSelection.CALENDAR)
+    } else {
+      setViewSelection(ViewSelection.LIST)
+    }
+  }
 
   return (
     <>
-      <View style={[style.headerContainer, last14DaysStyle]}>
-        <GlobalText style={style.headerText}>
-          {t("symptom_checker.last_14_days")}
-        </GlobalText>
+      <View style={style.headerContainer}>
+        <GlobalText style={style.headerText}>{headerTitle}</GlobalText>
         <TouchableOpacity>
           <SvgXml
-            xml={Icons.Calendar}
+            xml={headerIcon}
             width={Iconography.xSmall}
             height={Iconography.xSmall}
-            testID="calendar-button"
-            onPress={() => {
-              setViewSelection(ViewSelection.CALENDAR)
-            }}
-          />
-        </TouchableOpacity>
-      </View>
-      <View style={[style.headerContainer, historyStyle]}>
-        <GlobalText style={style.headerText}>
-          {t("symptom_checker.history")}
-        </GlobalText>
-        <TouchableOpacity>
-          <SvgXml
-            xml={Icons.Hamburger}
-            width={Iconography.xSmall}
-            height={Iconography.xSmall}
-            testID="list-view-button"
+            accessibilityLabel="Toggle symptom log view"
             onPress={handleOnPressToggleView}
-              setViewSelection(ViewSelection.LIST)
-            }}
+            fill={Colors.primary100}
           />
         </TouchableOpacity>
       </View>
@@ -213,8 +206,6 @@ const OverTime: FunctionComponent = () => {
     </>
   )
 }
-
-const headerHeight = 50
 
 const style = StyleSheet.create({
   container: {
@@ -292,7 +283,7 @@ const style = StyleSheet.create({
   },
   headerContainer: {
     width: "100%",
-    height: headerHeight,
+    height: Spacing.xxHuge,
     flexDirection: "row",
     alignItems: "flex-end",
     justifyContent: "space-between",
@@ -303,7 +294,7 @@ const style = StyleSheet.create({
   headerText: {
     ...Typography.header3,
     paddingRight: Spacing.xxLarge,
-    paddingTop: 8,
+    paddingTop: Spacing.xxSmall,
   },
   hidden: {
     display: "none",

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -159,7 +159,7 @@ const OverTime: FunctionComponent = () => {
     viewSelection === ViewSelection.LIST ? null : style.hidden
 
   const historyStyle =
-    viewSelection === ViewSelection.CALENDAR ? null : style.hidden
+    viewSelection === ViewSelection.CALENDAR ? {} : style.hidden
 
   return (
     <>

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -146,30 +146,24 @@ const OverTime: FunctionComponent = () => {
   const { t } = useTranslation()
   const { dailyLogData } = useSymptomLogContext()
 
-  enum ViewSelection {
-    LIST,
-    CALENDAR,
-  }
+  type ViewSelection = "List" | "Calendar"
 
-  const [viewSelection, setViewSelection] = useState<ViewSelection>(
-    ViewSelection.LIST,
-  )
+  const [viewSelection, setViewSelection] = useState<ViewSelection>("List")
 
   const noSymptomHistory = dailyLogData.length === 0
 
   const headerTitle =
-    viewSelection === ViewSelection.LIST
+    viewSelection === "List"
       ? t("symptom_checker.last_14_days")
       : t("symptom_checker.history")
 
-  const headerIcon =
-    viewSelection === ViewSelection.LIST ? Icons.Calendar : Icons.Hamburger
+  const headerIcon = viewSelection === "List" ? Icons.Calendar : Icons.Hamburger
 
   const handleOnPressToggleView = () => {
-    if (viewSelection === ViewSelection.LIST) {
-      setViewSelection(ViewSelection.CALENDAR)
+    if (viewSelection === "List") {
+      setViewSelection("Calendar")
     } else {
-      setViewSelection(ViewSelection.LIST)
+      setViewSelection("List")
     }
   }
 

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -189,7 +189,7 @@ const OverTime: FunctionComponent = () => {
             width={Iconography.xSmall}
             height={Iconography.xSmall}
             testID="list-view-button"
-            onPress={() => {
+            onPress={handleOnPressToggleView}
               setViewSelection(ViewSelection.LIST)
             }}
           />

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -296,7 +296,7 @@ const style = StyleSheet.create({
     flexDirection: "row",
     alignItems: "flex-end",
     justifyContent: "space-between",
-    backgroundColor: Colors.white,
+    backgroundColor: Colors.primaryLightBackground,
     paddingHorizontal: Spacing.small,
     paddingBottom: Spacing.small,
   },

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -151,7 +151,7 @@ const OverTime: FunctionComponent = () => {
     CALENDAR,
   }
 
-  const [viewSelection, setViewSelection] = useState(ViewSelection.LIST)
+  const [viewSelection, setViewSelection] = useState<ViewSelection>(ViewSelection.LIST)
 
   const noSymptomHistory = dailyLogData.length === 0
 

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent, useState } from "react"
 import {
   ScrollView,
   StyleSheet,
@@ -16,7 +16,9 @@ import { GlobalText } from "../components"
 import { posixToDayjs } from "../utils/dateTime"
 import { MyHealthStackScreens } from "../navigation"
 import { MyHealthStackParams } from "../navigation/MyHealthStack"
-import { Typography, Colors, Outlines, Spacing } from "../styles"
+import { Typography, Colors, Outlines, Spacing, Iconography } from "../styles"
+import { SvgXml } from "react-native-svg"
+import { Icons } from "../assets"
 
 type CheckInSummaryProps = {
   status: CheckInStatus
@@ -144,26 +146,75 @@ const OverTime: FunctionComponent = () => {
   const { t } = useTranslation()
   const { dailyLogData } = useSymptomLogContext()
 
+  enum ViewSelection {
+    LIST,
+    CALENDAR,
+  }
+
+  const [viewSelection, setViewSelection] = useState(ViewSelection.LIST)
+
   const noSymptomHistory = dailyLogData.length === 0
 
+  const last14DaysStyle =
+    viewSelection === ViewSelection.LIST ? null : style.hidden
+
+  const historyStyle =
+    viewSelection === ViewSelection.CALENDAR ? null : style.hidden
+
   return (
-    <ScrollView
-      style={style.container}
-      contentContainerStyle={style.contentContainer}
-      alwaysBounceVertical={false}
-    >
-      {noSymptomHistory ? (
-        <GlobalText style={style.noSymptomHistoryText}>
-          {t("symptom_checker.no_symptom_history")}
+    <>
+      <View style={[style.headerContainer, last14DaysStyle]}>
+        <GlobalText style={style.headerText}>
+          {t("symptom_checker.last_14_days")}
         </GlobalText>
-      ) : (
-        dailyLogData.map((logData) => {
-          return <DaySummary key={logData.date} dayLogData={logData} />
-        })
-      )}
-    </ScrollView>
+        <TouchableOpacity>
+          <SvgXml
+            xml={Icons.Calendar}
+            width={Iconography.xSmall}
+            height={Iconography.xSmall}
+            testID="calendar-button"
+            onPress={() => {
+              setViewSelection(ViewSelection.CALENDAR)
+            }}
+          />
+        </TouchableOpacity>
+      </View>
+      <View style={[style.headerContainer, historyStyle]}>
+        <GlobalText style={style.headerText}>
+          {t("symptom_checker.history")}
+        </GlobalText>
+        <TouchableOpacity>
+          <SvgXml
+            xml={Icons.Hamburger}
+            width={Iconography.xSmall}
+            height={Iconography.xSmall}
+            testID="list-view-button"
+            onPress={() => {
+              setViewSelection(ViewSelection.LIST)
+            }}
+          />
+        </TouchableOpacity>
+      </View>
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
+      >
+        {noSymptomHistory ? (
+          <GlobalText style={style.noSymptomHistoryText}>
+            {t("symptom_checker.no_symptom_history")}
+          </GlobalText>
+        ) : (
+          dailyLogData.map((logData) => {
+            return <DaySummary key={logData.date} dayLogData={logData} />
+          })
+        )}
+      </ScrollView>
+    </>
   )
 }
+
+const headerHeight = 50
 
 const style = StyleSheet.create({
   container: {
@@ -238,6 +289,24 @@ const style = StyleSheet.create({
   noSymptomHistoryText: {
     alignSelf: "center",
     ...Typography.body1,
+  },
+  headerContainer: {
+    width: "100%",
+    height: headerHeight,
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+    backgroundColor: Colors.white,
+    paddingHorizontal: Spacing.small,
+    paddingBottom: Spacing.small,
+  },
+  headerText: {
+    ...Typography.header3,
+    paddingRight: Spacing.xxLarge,
+    paddingTop: 8,
+  },
+  hidden: {
+    display: "none",
   },
 })
 

--- a/src/MyHealth/index.tsx
+++ b/src/MyHealth/index.tsx
@@ -22,7 +22,7 @@ const MyHealthScreen: FunctionComponent = () => {
 
   return (
     <>
-      <StatusBar backgroundColor={Colors.secondary10} />
+      <StatusBar backgroundColor={Colors.white} />
       <View style={style.container}>
         <View style={style.headerContainer}>
           <GlobalText style={style.headerText}>
@@ -54,12 +54,12 @@ const MyHealthScreen: FunctionComponent = () => {
 const style = StyleSheet.create({
   container: {
     flexGrow: 1,
-    backgroundColor: Colors.secondary10,
+    backgroundColor: Colors.white,
     paddingTop: Spacing.large,
   },
   headerContainer: {
     paddingHorizontal: Spacing.large,
-    backgroundColor: Colors.secondary10,
+    backgroundColor: Colors.white,
   },
   headerText: {
     ...Typography.header1,

--- a/src/MyHealth/index.tsx
+++ b/src/MyHealth/index.tsx
@@ -59,7 +59,7 @@ const style = StyleSheet.create({
   },
   headerContainer: {
     paddingHorizontal: Spacing.large,
-    backgroundColor: Colors.white,
+    backgroundColor: Colors.primaryLightBackground,
   },
   headerText: {
     ...Typography.header1,

--- a/src/MyHealth/index.tsx
+++ b/src/MyHealth/index.tsx
@@ -22,7 +22,7 @@ const MyHealthScreen: FunctionComponent = () => {
 
   return (
     <>
-      <StatusBar backgroundColor={Colors.white} />
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
       <View style={style.container}>
         <View style={style.headerContainer}>
           <GlobalText style={style.headerText}>

--- a/src/MyHealth/index.tsx
+++ b/src/MyHealth/index.tsx
@@ -54,7 +54,7 @@ const MyHealthScreen: FunctionComponent = () => {
 const style = StyleSheet.create({
   container: {
     flexGrow: 1,
-    backgroundColor: Colors.white,
+    backgroundColor: Colors.primaryLightBackground,
     paddingTop: Spacing.large,
   },
   headerContainer: {

--- a/src/assets/svgs/calendar.ts
+++ b/src/assets/svgs/calendar.ts
@@ -1,0 +1,14 @@
+export default `
+<svg width="18" height="17" viewBox="0 0 18 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.5 2C0.5 1.17157 1.17157 0.5 2 0.5H15.8947C16.7232 0.5 17.3947 1.17157 17.3947 2V3.07895H0.5V2Z" fill="#252F42" stroke="#252F42"/>
+<mask id="path-2-inside-1" fill="white">
+<rect width="17.8947" height="17" rx="1"/>
+</mask>
+<rect width="17.8947" height="17" rx="1" stroke="#252F42" stroke-width="3" mask="url(#path-2-inside-1)"/>
+<rect x="7.6582" y="5.86719" width="1.68421" height="1.68421" fill="#252F42" stroke="#252F42"/>
+<rect x="7.6582" y="11.2383" width="1.68421" height="1.68421" fill="#252F42" stroke="#252F42"/>
+<rect x="3.18457" y="11.2383" width="1.68421" height="1.68421" fill="#252F42" stroke="#252F42"/>
+<rect x="12.1318" y="5.86719" width="1.68421" height="1.68421" fill="#252F42" stroke="#252F42"/>
+<rect x="12.1318" y="11.2383" width="1.68421" height="1.68421" fill="#252F42" stroke="#252F42"/>
+</svg>
+`

--- a/src/assets/svgs/hamburger.ts
+++ b/src/assets/svgs/hamburger.ts
@@ -1,0 +1,7 @@
+export default `
+<svg width="17" height="14" viewBox="0 0 17 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect y="11.0742" width="16.8" height="2.92485" fill="#252F42"/>
+<rect y="5.53906" width="16.8" height="2.92485" fill="#252F42"/>
+<rect width="16.8" height="2.92485" fill="#252F42"/>
+</svg>
+`

--- a/src/assets/svgs/index.ts
+++ b/src/assets/svgs/index.ts
@@ -7,6 +7,7 @@ import BackArrow from "./backArrow"
 import BarGraph from "./barGraph"
 import Bell from "./bell"
 import BellYellow from "./bellYellow"
+import Calendar from "./calendar"
 import ChatBubble from "./chatBubble"
 import CheckInCircle from "./checkInCircle"
 import CheckInBrokenCircle from "./checkInBrokenCircle"
@@ -22,6 +23,7 @@ import Export from "./export"
 import ExposureIcon from "./exposureIcon"
 import Gear from "./gear"
 import GoogleMapsLogo from "./google-maps-logo"
+import Hamburger from "./hamburger"
 import Headset from "./headset"
 import Heart from "./heart"
 import HomeInfo from "./homeInfo"
@@ -58,6 +60,7 @@ export const Icons = {
   BarGraph,
   Bell,
   BellYellow,
+  Calendar,
   ChatBubble,
   CheckInCircle,
   CheckInBrokenCircle,
@@ -73,6 +76,7 @@ export const Icons = {
   ExposureIcon,
   Gear,
   GoogleMapsLogo,
+  Hamburger,
   Headset,
   Heart,
   HomeInfo,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -331,6 +331,8 @@
     "log_symptoms": "Log symptoms",
     "check_in_again": "Check in again tomorrow.",
     "no_symptom_history": "No symptom history",
+    "last_14_days": "LAST 14 DAYS",
+    "history": "HISTORY",
     "errors": {
       "adding_check_in": "Sorry, we could not add todays check in",
       "adding_symptoms": "Sorry, we could not log your symptoms",


### PR DESCRIPTION
### Why 
We'd like the user to be able to toggle back and forth between list and calendar views on the `Overtime` screen

### This Commit
This commit implements toggling back and forth between list and calendar views on the `Overtime` screen

![Sep-28-2020 10-36-05](https://user-images.githubusercontent.com/2637355/94446305-74116d80-0176-11eb-8f07-e0be648191b6.gif)
