### PR TITLE
Only log crashes on staging builds

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -5,7 +5,8 @@ type Loggable = Record<string, unknown>
 
 class Logger {
   static start(): void {
-    if (env.STAGING === "true") {
+    const isStagingEnv = !__DEV__ && env.STAGING === "true"
+    if (isStagingEnv) {
       Bugsnag.start()
     }
   }


### PR DESCRIPTION
Why:
Currently we are logging crashes and unexpected errors on both staging
and some development builds because we are only checking if the
env.STAGING = true to determine if we initialize bugsnag or not. We
would like to only log these errors on release builds with env.STAGING =
true.

This commit:
Updates the logic in the logger.ts file to only init bugsnag in the
correct environment of staging.

Note that a future commit might want to revisit how we determine what a
staging environment is. as its possible to have a dev build be set to
staging even though we dont want this as a possibility.

Co-Authored-By: alejandro dustet <alejandro@thoughtbot.com>
Co-Authored-By: devin jameson <devin@thoughtbot.com>