### PR TITLE
(Android) Manually refresh exposures

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
@@ -1,7 +1,5 @@
 package org.pathcheck.covidsafepaths.exposurenotifications.reactmodules;
 
-import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
@@ -19,9 +17,7 @@ import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationCl
 import org.pathcheck.covidsafepaths.exposurenotifications.common.AppExecutors;
 import org.pathcheck.covidsafepaths.exposurenotifications.common.NotificationHelper;
 import org.pathcheck.covidsafepaths.exposurenotifications.dto.RNDiagnosisKey;
-import org.pathcheck.covidsafepaths.exposurenotifications.nearby.ProvideDiagnosisKeysWorker;
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.RealmSecureStorageBte;
-import org.pathcheck.covidsafepaths.exposurenotifications.utils.CallbackMessages;
 import org.pathcheck.covidsafepaths.exposurenotifications.utils.Util;
 
 @SuppressWarnings("unused")
@@ -89,22 +85,6 @@ public class DebugMenuModule extends ReactContextBaseJavaModule {
   public void resetExposures(Promise promise) {
     RealmSecureStorageBte.INSTANCE.resetExposures();
     promise.resolve(null);
-  }
-
-  @ReactMethod
-  public void detectExposuresNow(Promise promise) {
-    ExposureNotificationClientWrapper.get(getReactApplicationContext())
-        .isEnabled()
-        .addOnSuccessListener(enabled -> {
-          if (enabled) {
-            WorkManager workManager = WorkManager.getInstance(getReactApplicationContext());
-            workManager.enqueue(new OneTimeWorkRequest.Builder(ProvideDiagnosisKeysWorker.class).build());
-            promise.resolve(CallbackMessages.DEBUG_DETECT_EXPOSURES_SUCCESS);
-          } else {
-            promise.reject(new Exception(CallbackMessages.DEBUG_DETECT_EXPOSURES_ERROR_EN_NOT_ENABLED));
-          }
-        })
-        .addOnFailureListener(promise::reject);
   }
 
   @ReactMethod

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
@@ -1,6 +1,8 @@
 package org.pathcheck.covidsafepaths.exposurenotifications.reactmodules;
 
 import androidx.annotation.NonNull;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -17,7 +19,9 @@ import org.jetbrains.annotations.NotNull;
 import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
 import org.pathcheck.covidsafepaths.exposurenotifications.common.AppExecutors;
 import org.pathcheck.covidsafepaths.exposurenotifications.dto.RNExposureInformation;
+import org.pathcheck.covidsafepaths.exposurenotifications.nearby.ProvideDiagnosisKeysWorker;
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.ExposureNotificationSharedPreferences;
+import org.pathcheck.covidsafepaths.exposurenotifications.utils.CallbackMessages;
 import org.threeten.bp.Duration;
 
 @SuppressWarnings("unused")
@@ -84,5 +88,21 @@ public class ExposureHistoryModule extends ReactContextBaseJavaModule {
     Long lastDetectionDate = prefs.getLastDetectionProcessDate();
     // Convert to double, we cannot send longs through the RN bridge
     promise.resolve(lastDetectionDate != null ? lastDetectionDate.doubleValue() : null);
+  }
+
+  @ReactMethod
+  public void detectExposures(Promise promise) {
+    ExposureNotificationClientWrapper.get(getReactApplicationContext())
+        .isEnabled()
+        .addOnSuccessListener(enabled -> {
+          if (enabled) {
+            WorkManager workManager = WorkManager.getInstance(getReactApplicationContext());
+            workManager.enqueue(new OneTimeWorkRequest.Builder(ProvideDiagnosisKeysWorker.class).build());
+            promise.resolve(CallbackMessages.DEBUG_DETECT_EXPOSURES_SUCCESS);
+          } else {
+            promise.reject(new Exception(CallbackMessages.DEBUG_DETECT_EXPOSURES_ERROR_EN_NOT_ENABLED));
+          }
+        })
+        .addOnFailureListener(promise::reject);
   }
 }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
@@ -98,6 +98,8 @@ public class ExposureHistoryModule extends ReactContextBaseJavaModule {
           if (enabled) {
             WorkManager workManager = WorkManager.getInstance(getReactApplicationContext());
             workManager.enqueue(new OneTimeWorkRequest.Builder(ProvideDiagnosisKeysWorker.class).build());
+            // We are not waiting until the job is completed.
+            // Is there any way to pass the promise through all the workers?
             promise.resolve(CallbackMessages.DEBUG_DETECT_EXPOSURES_SUCCESS);
           } else {
             promise.reject(new Exception(CallbackMessages.DEBUG_DETECT_EXPOSURES_ERROR_EN_NOT_ENABLED));

--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -103,7 +103,7 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
   const checkForNewExposures = async (): Promise<OperationResponse> => {
     try {
       await detectExposures()
-      getLastExposureDetectionDate()
+      await refreshExposureInfo()
       return SUCCESS_RESPONSE
     } catch (e) {
       return failureResponse(e.message)

--- a/src/Settings/ENDebugMenu.tsx
+++ b/src/Settings/ENDebugMenu.tsx
@@ -165,12 +165,6 @@ const ENDebugMenu: FunctionComponent<ENDebugMenuProps> = ({ navigation }) => {
               )}
             />
             <DebugMenuListItem
-              label="Detect Exposures Now"
-              onPress={handleOnPressSimulationButton(
-                NativeModule.detectExposuresNow,
-              )}
-            />
-            <DebugMenuListItem
               label="Reset Exposures"
               itemStyle={style.lastListItem}
               onPress={handleOnPressSimulationButton(

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -210,10 +210,6 @@ export const fetchDiagnosisKeys = async (): Promise<ENDiagnosisKey[]> => {
 export type ENModuleErrorMessage = string | null
 export type ENModuleSuccessMessage = string | null
 
-export const detectExposuresNow = async (): Promise<string> => {
-  return debugModule.detectExposuresNow()
-}
-
 export const simulateExposure = async (): Promise<"success"> => {
   return debugModule.simulateExposure()
 }


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
Expose native method to manually refresh exposures. 
It has already been added on iOS here https://github.com/Path-Check/gaen-mobile/pull/458/files.

It also removes the "Detect exposures now" button from the debug menu

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/GAEN-327