### PR TITLE
Update tsconfig for ts 4.0

### DIFF
--- a/src/AnalyticsContext.tsx
+++ b/src/AnalyticsContext.tsx
@@ -60,10 +60,12 @@ const AnalyticsProvider: FunctionComponent = ({ children }) => {
       healthAuthoritySupportsAnalytics && userConsentedToAnalytics
 
     const initializeAnalyticsTracking = () => {
-      Matomo.initialize(
-        healthAuthorityAnalyticsUrl,
-        healthAuthorityAnalyticsSiteId,
-      )
+      if (healthAuthorityAnalyticsUrl && healthAuthorityAnalyticsSiteId) {
+        Matomo.initialize(
+          healthAuthorityAnalyticsUrl,
+          healthAuthorityAnalyticsSiteId,
+        )
+      }
     }
     const trackEvent = async (event: string) => {
       return actions.trackEvent(event)

--- a/src/Callback/Success.tsx
+++ b/src/Callback/Success.tsx
@@ -43,7 +43,7 @@ const Success: FunctionComponent = () => {
   return (
     <ScrollView contentContainerStyle={style.contentContainer}>
       <Image
-        source={Images.PersonAndHealthExpert}
+        source={Images.HowItWorksValueProposition}
         style={style.image}
         accessible
         accessibilityLabel={t("onboarding.welcome_image_label")}

--- a/src/MyHealth/OverTime.spec.tsx
+++ b/src/MyHealth/OverTime.spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from "@testing-library/react-native"
 import { useNavigation } from "@react-navigation/native"
 
 import { SymptomLogContext } from "./SymptomLogContext"
-import { CheckInStatus } from "./symptoms"
+import { SymptomLogEntry, CheckInStatus } from "./symptoms"
 
 import OverTime from "./OverTime"
 import { factories } from "../factories"
@@ -114,9 +114,9 @@ describe("OverTime", () => {
       })
 
       const logEntryPosix = Date.parse(`2020-09-21 10:00`)
-      const logEntry = {
+      const logEntry: SymptomLogEntry = {
         id: "1",
-        symptoms: ["Cough"],
+        symptoms: ["cough"],
         date: logEntryPosix,
       }
       const { getByLabelText } = render(

--- a/src/MyHealth/SelectSymptoms.tsx
+++ b/src/MyHealth/SelectSymptoms.tsx
@@ -164,6 +164,10 @@ const SelectSymptomsScreen: FunctionComponent = () => {
       : style.symptomButtonText
   }
 
+  const symptomsWithTranslationsList = Object.entries(
+    symptomsWithTranslations,
+  ) as [Symptom, string][]
+
   return (
     <>
       <StatusBar backgroundColor={Colors.secondary10} />
@@ -189,7 +193,7 @@ const SelectSymptomsScreen: FunctionComponent = () => {
         alwaysBounceVertical={false}
       >
         <View style={style.symptomButtonsContainer}>
-          {Object.entries(symptomsWithTranslations).map(
+          {symptomsWithTranslationsList.map(
             ([symptom, translation]: [Symptom, string]) => {
               return (
                 <TouchableHighlight

--- a/src/MyHealth/SymptomLogContext.spec.tsx
+++ b/src/MyHealth/SymptomLogContext.spec.tsx
@@ -9,7 +9,11 @@ import {
   addCheckIn,
   createLogEntry,
 } from "../gaen/nativeModule"
-import { CheckInStatus, combineSymptomAndCheckInLogs } from "./symptoms"
+import {
+  Symptom,
+  CheckInStatus,
+  combineSymptomAndCheckInLogs,
+} from "./symptoms"
 import Logger from "../logger"
 
 jest.mock("../gaen/nativeModule.ts")
@@ -67,7 +71,7 @@ describe("SymptomLogProvider", () => {
       createLogEntrySpy.mockResolvedValueOnce({})
       const mockedDate = Date.parse("2020-09-22 10:00")
       jest.spyOn(Date, "now").mockReturnValue(mockedDate)
-      const symptoms = ["newSymptom"]
+      const symptoms: Symptom[] = ["cough"]
       const newLogEntry = {
         date: mockedDate,
         symptoms,

--- a/src/MyHealth/symptoms.spec.ts
+++ b/src/MyHealth/symptoms.spec.ts
@@ -1,4 +1,8 @@
-import { combineSymptomAndCheckInLogs, CheckInStatus } from "./symptoms"
+import {
+  SymptomLogEntry,
+  combineSymptomAndCheckInLogs,
+  CheckInStatus,
+} from "./symptoms"
 import { beginningOfDay } from "../utils/dateTime"
 
 describe("combineSymptomAndCheckInLogs", () => {
@@ -8,31 +12,31 @@ describe("combineSymptomAndCheckInLogs", () => {
       `${earlierDayDateString} 10:00`,
     )
     const earlierDayDatePosix = beginningOfDay(earlierDayLogEntryOnePosix)
-    const earlierDayLogEntryOne = {
+    const earlierDayLogEntryOne: SymptomLogEntry = {
       id: "1",
-      symptoms: ["symptom1", "symptom2"],
+      symptoms: ["fever", "cough"],
       date: earlierDayLogEntryOnePosix,
     }
     const earlierDayLogEntryTwoPosix = Date.parse(
       `${earlierDayDateString} 12:00`,
     )
-    const earlierDayLogEntryTwo = {
+    const earlierDayLogEntryTwo: SymptomLogEntry = {
       id: "2",
-      symptoms: ["symptom1"],
+      symptoms: ["fever"],
       date: earlierDayLogEntryTwoPosix,
     }
     const middleDayDateString = "2020-09-22"
     const middleDayLogEntryOnePosix = Date.parse(`${middleDayDateString} 10:00`)
     const middleDayDatePosix = beginningOfDay(middleDayLogEntryOnePosix)
-    const middleDayLogEntryOne = {
+    const middleDayLogEntryOne: SymptomLogEntry = {
       id: "3",
-      symptoms: ["symptom1"],
+      symptoms: ["fever"],
       date: middleDayLogEntryOnePosix,
     }
     const middleDayLogEntryTwoPosix = Date.parse(`${middleDayDateString} 12:00`)
-    const middleDayLogEntryTwo = {
+    const middleDayLogEntryTwo: SymptomLogEntry = {
       id: "4",
-      symptoms: ["symptom2"],
+      symptoms: ["cough"],
       date: middleDayLogEntryTwoPosix,
     }
 
@@ -41,9 +45,9 @@ describe("combineSymptomAndCheckInLogs", () => {
       `${recentDayEntryDateString} 12:00`,
     )
     const recentDayEntryDatePosix = beginningOfDay(recentDayLogEntryPosix)
-    const recentDayEntry = {
+    const recentDayEntry: SymptomLogEntry = {
       id: "5",
-      symptoms: ["symptom2"],
+      symptoms: ["cough"],
       date: recentDayLogEntryPosix,
     }
     expect(
@@ -80,12 +84,12 @@ describe("combineSymptomAndCheckInLogs", () => {
     const logEntryDateString = "2020-09-21"
     const logEntryDatePosix = Date.parse(`${logEntryDateString} 10:00`)
     const logEntryKeyDate = beginningOfDay(logEntryDatePosix)
-    const logEntry = {
+    const logEntry: SymptomLogEntry = {
       id: "1",
-      symptoms: ["symptom1", "symptom2"],
+      symptoms: ["fever", "cough"],
       date: logEntryDatePosix,
     }
-    const symptomLogEntries = [logEntry]
+    const symptomLogEntries: SymptomLogEntry[] = [logEntry]
     const sameDateCheckInPosix = Date.parse(`${logEntryDateString} 12:00`)
     const sameDateCheckIn = {
       date: sameDateCheckInPosix,

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,10 +1,2 @@
-import React from "react"
-
-declare module "*.svg" {
-  import { SvgProps } from "react-native-svg"
-
-  const content: React.StatelessComponent<SvgProps>
-  export default content
-}
-
+declare module "*.svg" {}
 declare module "*.png" {}

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -5,6 +5,7 @@ import {
 } from "@react-navigation/stack"
 import { Platform } from "react-native"
 import {
+  LinkingOptions,
   NavigationContainer,
   NavigationContainerRef,
 } from "@react-navigation/native"
@@ -31,10 +32,12 @@ const settingsStackTransitionPreset = Platform.select({
   android: TransitionPresets.DefaultTransition,
 })
 
-const linking = {
+const linking: LinkingOptions = {
   prefixes: ["pathcheck://"],
   config: {
-    ExposureHistoryFlow: "exposureHistory",
+    screens: {
+      ExposureHistoryFlow: "exposureHistory",
+    },
   },
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,75 +1,33 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "React Native",
   "compilerOptions": {
-    "skipLibCheck": true,
-    /* Basic Options */
-    // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": [
-      "es2019"
-    ] /* Specify library files to be included in the compilation. */,
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react-native" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    "noEmit": true /* Do not emit outputs. */,
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["es6", "es2016.array.include", "es2017.object"],
+    "allowJs": true,
+    "jsx": "react-native",
+    "noEmit": true,
+    "isolatedModules": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "noImplicitAny": true ,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
 
-    /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
-    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
-    "strictNullChecks": true /* Enable strict null checks. */,
-    "strictFunctionTypes": true /* Enable strict checking of function types. */,
-    "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
-    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
-    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
-    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
-
-    /* Additional Checks */
-    "noUnusedLocals": true /* Report errors on unused locals. */,
-    "noUnusedParameters": true /* Report errors on unused parameters. */,
-    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
-    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
-    "resolveJsonModule": true,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "include": ["*.d.ts"],
-  "exclude": [
-    "node_modules",
-    "babel.config.js",
-    "metro.config.js",
-    "jest/*",
-    "**/*.svg"
-  ]
+  "include": ["**/*.ts", "**/*.tsx", "**/*.d.ts"],
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js", "jest/*", "**/*.svg"]
 }


### PR DESCRIPTION
Why:
Currently our tsconfig is set to only run the ts compiler on files that
end with `.d.ts` which means that the complier is not running on any of
our source files. This was caused by an update to the behaviour of the
includes tsconfig option from being inclusive to exclusive.

This commit:
updates the tsconfig file to fix the issue as well as removes no no
longer necessary config options. We updated some type errors that made
their way into the codebase during the few days of not type checking the
entire codebase

Co-Authored-By: devin jameson <devin@thoughtbot.com>