### PR TITLE
Add CTA to Self Screener from Exposure Detail

### DIFF
--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -9,6 +9,7 @@ export interface Configuration {
   displayCallbackForm: boolean
   displayReportAnIssue: boolean
   displayMyHealth: boolean
+  displaySelfScreener: boolean
   findATestCenterUrl: string | null
   healthAuthorityAdviceUrl: string
   healthAuthorityLearnMoreUrl: string
@@ -29,6 +30,7 @@ const initialState = {
   displayCallbackForm: false,
   displayReportAnIssue: false,
   displayMyHealth: false,
+  displaySelfScreener: false,
   findATestCenterUrl: null,
   healthAuthorityAdviceUrl: "",
   healthAuthorityLearnMoreUrl: "",
@@ -59,6 +61,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
   const displayCallbackForm = env.DISPLAY_CALLBACK_FORM === "true"
   const displayReportAnIssue = env.DISPLAY_REPORT_AN_ISSUE === "true"
   const displayMyHealth = env.DISPLAY_SYMPTOM_CHECKER === "true"
+  const displaySelfScreener = env.DISPLAY_SELF_SCREENER === "true"
   const healthAuthoritySupportsAnalytics = Boolean(env.MATOMO_URL)
   const healthAuthorityAnalyticsUrl = env.MATOMO_URL || null
   const healthAuthorityAnalyticsSiteId = parseInt(env.MATOMO_SITE_ID) || null
@@ -78,6 +81,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         displayCallbackForm,
         displayReportAnIssue,
         displayMyHealth,
+        displaySelfScreener,
         findATestCenterUrl,
         healthAuthorityAdviceUrl,
         healthAuthorityLearnMoreUrl,

--- a/src/ExposureHistory/ExposureDetail.spec.tsx
+++ b/src/ExposureHistory/ExposureDetail.spec.tsx
@@ -108,14 +108,12 @@ describe("ExposureDetail", () => {
       )
 
       expect(queryByLabelText("Speak with a contact tracer")).toBeNull()
-      expect(
-        getByText(`See guidance from ${healthAuthorityName}.`),
-      ).toBeDefined()
+      expect(getByText("General Guidance")).toBeDefined()
     })
   })
 
   describe("when the health authority has a callback form", () => {
-    it("shows info about what to do next and no general guidance", () => {
+    it("shows info about what to do next and general guidance", () => {
       const healthAuthorityName = "healthAuthorityName"
       const { getByText, queryByText } = render(
         <ConfigurationContext.Provider
@@ -133,32 +131,29 @@ describe("ExposureDetail", () => {
           `Schedule a call to get support from a contact tracer from the ${healthAuthorityName}.`,
         ),
       ).toBeDefined()
-      expect(
-        queryByText(`See guidance from ${healthAuthorityName}.`),
-      ).toBeNull()
+      expect(queryByText("General Guidance")).not.toBeNull()
     })
+  })
 
-    it("allow user to navigate to the form or the connect screen", () => {
+  describe("when the health authority supports the self screener", () => {
+    it("prompts the user to get personalized guidance", () => {
       const navigateSpy = jest.fn()
       ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
       const { getByLabelText } = render(
         <ConfigurationContext.Provider
           value={factories.configurationContext.build({
-            displayCallbackForm: true,
+            displaySelfScreener: true,
           })}
         >
           <ExposureDetail />
         </ConfigurationContext.Provider>,
       )
 
-      const showCallbackFormAction = getByLabelText(
-        "Speak with a contact tracer",
-      )
-      fireEvent.press(showCallbackFormAction)
-      expect(navigateSpy).toHaveBeenCalledWith(Stacks.Callback)
-      const callLaterAction = getByLabelText("Call later")
-      fireEvent.press(callLaterAction)
-      expect(navigateSpy).toHaveBeenCalledWith(Stacks.Connect)
+      const selfScreenerButton = getByLabelText("Personalize my guidance")
+
+      expect(selfScreenerButton).not.toBeNull()
+      fireEvent.press(selfScreenerButton)
+      expect(navigateSpy).toHaveBeenCalledWith(Stacks.SelfScreener)
     })
   })
 })

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -17,7 +17,7 @@ const ExposureDetail: FunctionComponent = () => {
   const route = useRoute<
     RouteProp<ExposureHistoryStackParamList, "ExposureDetail">
   >()
-  useStatusBarEffect("light-content", Colors.headerBackground)
+  useStatusBarEffect("dark-content", Colors.secondary10)
   const { t } = useTranslation()
 
   const { exposureDatum } = route.params
@@ -42,6 +42,9 @@ const ExposureDetail: FunctionComponent = () => {
   return (
     <ScrollView style={style.container}>
       <View style={style.headerContainer}>
+        <GlobalText style={style.headerText}>
+          {t("exposure_history.exposure_detail.header")}
+        </GlobalText>
         <View style={style.exposureWindowContainer}>
           <SvgXml
             xml={Icons.ExposureIcon}
@@ -55,12 +58,6 @@ const ExposureDetail: FunctionComponent = () => {
             {exposureWindowBucketInWords(exposureDatum)}
           </GlobalText>
         </View>
-        <GlobalText style={style.headerText}>
-          {t("exposure_history.exposure_detail.header")}
-        </GlobalText>
-        <GlobalText style={style.contentText}>
-          {t("exposure_history.exposure_detail.content")}
-        </GlobalText>
       </View>
       <View style={style.bottomContainer}>
         <ExposureActions />
@@ -71,11 +68,12 @@ const ExposureDetail: FunctionComponent = () => {
 const style = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.secondary10,
+    backgroundColor: Colors.primaryLightBackground,
   },
   headerContainer: {
-    backgroundColor: Colors.primaryLightBackground,
-    paddingHorizontal: Spacing.medium,
+    backgroundColor: Colors.secondary10,
+    paddingLeft: Spacing.medium,
+    paddingRight: Spacing.massive,
     paddingVertical: Spacing.large,
   },
   exposureWindowContainer: {
@@ -90,11 +88,9 @@ const style = StyleSheet.create({
     marginLeft: Spacing.xSmall,
   },
   headerText: {
-    ...Typography.header3,
-    marginBottom: Spacing.xxSmall,
-  },
-  contentText: {
-    ...Typography.body2,
+    ...Typography.header2,
+    color: Colors.primary125,
+    marginBottom: Spacing.medium,
   },
   bottomContainer: {
     backgroundColor: Colors.primaryLightBackground,

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react"
-import { View, StyleSheet, Linking, TouchableOpacity } from "react-native"
+import { View, StyleSheet, Linking } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
@@ -8,15 +8,17 @@ import { Stacks } from "../../navigation"
 import { GlobalText, Button } from "../../components"
 import { useConnectionStatus } from "../../hooks/useConnectionStatus"
 
-import { Colors, Iconography, Spacing, Typography, Buttons } from "../../styles"
+import { Colors, Iconography, Spacing, Typography } from "../../styles"
 import { Icons } from "../../assets"
 import { useConfigurationContext } from "../../ConfigurationContext"
 
 const ExposureActions: FunctionComponent = () => {
   const { t } = useTranslation()
   const isInternetReachable = useConnectionStatus()
+  const navigation = useNavigation()
   const {
     displayCallbackForm,
+    displaySelfScreener,
     healthAuthorityName,
     healthAuthorityAdviceUrl,
   } = useConfigurationContext()
@@ -25,57 +27,70 @@ const ExposureActions: FunctionComponent = () => {
     Linking.openURL(healthAuthorityAdviceUrl)
   }
 
-  const displayNextStepsLink = healthAuthorityAdviceUrl !== ""
+  const displayNextStepsLink =
+    !displaySelfScreener && healthAuthorityAdviceUrl !== ""
 
   return (
     <>
       <GlobalText style={style.bottomHeaderText}>
         {t("exposure_history.exposure_detail.ha_guidance_header")}
       </GlobalText>
-      {displayCallbackForm ? (
-        <RequestCallBackActions healthAuthorityName={healthAuthorityName} />
-      ) : (
-        <>
-          <GlobalText style={style.bottomSubheaderText}>
-            {t("exposure_history.exposure_detail.ha_guidance_subheader", {
-              healthAuthorityName,
-            })}
-          </GlobalText>
-          <View style={style.recommendations}>
-            <RecommendationBubble
-              icon={Icons.IsolateBubbles}
-              text={t("exposure_history.exposure_detail.isolate")}
-            />
-            <RecommendationBubble
-              icon={Icons.Mask}
-              text={t("exposure_history.exposure_detail.wear_a_mask")}
-            />
-            <RecommendationBubble
-              icon={Icons.SixFeet}
-              text={t("exposure_history.exposure_detail.6ft_apart")}
-            />
-            <RecommendationBubble
-              icon={Icons.WashHands}
-              text={t("exposure_history.exposure_detail.wash_your_hands")}
+      <>
+        {displayCallbackForm && (
+          <RequestCallBackActions healthAuthorityName={healthAuthorityName} />
+        )}
+        <GlobalText style={style.bottomHeaderText}>
+          {t("exposure_history.exposure_detail.general_guidance", {
+            healthAuthorityName,
+          })}
+        </GlobalText>
+        <View style={style.recommendations}>
+          <RecommendationBubble
+            icon={Icons.IsolateBubbles}
+            text={t("exposure_history.exposure_detail.isolate")}
+          />
+          <RecommendationBubble
+            icon={Icons.Mask}
+            text={t("exposure_history.exposure_detail.wear_a_mask")}
+          />
+          <RecommendationBubble
+            icon={Icons.SixFeet}
+            text={t("exposure_history.exposure_detail.6ft_apart")}
+          />
+          <RecommendationBubble
+            icon={Icons.WashHands}
+            text={t("exposure_history.exposure_detail.wash_your_hands")}
+          />
+        </View>
+        {displaySelfScreener && (
+          <Button
+            onPress={() => navigation.navigate(Stacks.SelfScreener)}
+            label={t(
+              "exposure_history.exposure_detail.personalize_my_guidance",
+            )}
+            customButtonStyle={style.personalizeGuidanceButton}
+            customButtonInnerStyle={style.personalizeGuidanceButtonGradient}
+            customTextStyle={style.personalizeGuidanceButtonText}
+            hasRightArrow
+            outlined
+          />
+        )}
+        {displayNextStepsLink && (
+          <View style={style.buttonContainer}>
+            <Button
+              onPress={handleOnPressNextStep}
+              label={t("exposure_history.exposure_detail.next_steps")}
+              disabled={!isInternetReachable}
+              hasRightArrow
             />
           </View>
-          {displayNextStepsLink && (
-            <View style={style.buttonContainer}>
-              <Button
-                onPress={handleOnPressNextStep}
-                label={t("exposure_history.exposure_detail.next_steps")}
-                disabled={!isInternetReachable}
-                hasRightArrow
-              />
-            </View>
-          )}
-          {!isInternetReachable && (
-            <GlobalText style={style.connectivityWarningText}>
-              {t("exposure_history.no_connectivity_message")}
-            </GlobalText>
-          )}
-        </>
-      )}
+        )}
+        {!isInternetReachable && (
+          <GlobalText style={style.connectivityWarningText}>
+            {t("exposure_history.no_connectivity_message")}
+          </GlobalText>
+        )}
+      </>
     </>
   )
 }
@@ -94,9 +109,6 @@ const RequestCallBackActions: FunctionComponent<RequestCallBackActionsProps> = (
     navigation.navigate(Stacks.Callback)
   }
 
-  const navigateToConnectStack = () => {
-    navigation.navigate(Stacks.Connect)
-  }
   return (
     <>
       <GlobalText style={style.bottomSubheaderText}>
@@ -111,15 +123,6 @@ const RequestCallBackActions: FunctionComponent<RequestCallBackActionsProps> = (
         label={t("exposure_history.exposure_detail.speak_with_contact_tracer")}
         hasRightArrow
       />
-      <TouchableOpacity
-        onPress={navigateToConnectStack}
-        accessibilityLabel={t("exposure_history.exposure_detail.call_later")}
-        style={style.callLaterButton}
-      >
-        <GlobalText style={style.callLaterButtonText}>
-          {t("exposure_history.exposure_detail.call_later")}
-        </GlobalText>
-      </TouchableOpacity>
     </>
   )
 }
@@ -148,11 +151,11 @@ const RecommendationBubble: FunctionComponent<RecommendationBubbleProps> = ({
 
 const style = StyleSheet.create({
   bottomHeaderText: {
-    ...Typography.header5,
+    ...Typography.header4,
     marginBottom: Spacing.xxSmall,
   },
   bottomSubheaderText: {
-    ...Typography.body2,
+    ...Typography.body1,
     color: Colors.neutral100,
     marginBottom: Spacing.medium,
   },
@@ -170,7 +173,7 @@ const style = StyleSheet.create({
   recommendationBubbleCircle: {
     ...Iconography.smallIcon,
     borderRadius: 50,
-    backgroundColor: Colors.primaryLightBackground,
+    backgroundColor: Colors.secondary10,
     padding: Spacing.xLarge,
     marginBottom: Spacing.xSmall,
   },
@@ -188,20 +191,24 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
     width: "100%",
     alignSelf: "center",
+    paddingVertical: Spacing.small,
   },
   requestCallbackButtonGradient: {
     width: "100%",
-    padding: Spacing.small,
   },
-  callLaterButton: {
-    ...Buttons.primary,
-    backgroundColor: Colors.secondary50,
-    minWidth: "100%",
+  personalizeGuidanceButton: {
+    marginBottom: Spacing.small,
+    width: "100%",
+    alignSelf: "center",
+    borderColor: Colors.secondary100,
   },
-  callLaterButtonText: {
-    ...Typography.body1,
-    ...Typography.bold,
-    color: Colors.primary100,
+  personalizeGuidanceButtonText: {
+    ...Typography.buttonPrimary,
+    color: Colors.primary110,
+  },
+  personalizeGuidanceButtonGradient: {
+    width: "100%",
+    justifyContent: "space-between",
   },
 })
 

--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -20,7 +20,7 @@ const ExposureHistoryScreen: FunctionComponent = () => {
   useFocusEffect(
     useCallback(() => {
       refreshExposureInfo()
-    }, []),
+    }, [refreshExposureInfo]),
   )
 
   const exposures = toExposureList(exposureInfo)

--- a/src/SelfScreener/SelfScreenerIntro.tsx
+++ b/src/SelfScreener/SelfScreenerIntro.tsx
@@ -1,0 +1,16 @@
+import React, { FunctionComponent } from "react"
+import { useTranslation } from "react-i18next"
+import { SafeAreaView } from "react-native"
+
+import { GlobalText } from "../components"
+
+const SelfScreenerIntro: FunctionComponent = () => {
+  const { t } = useTranslation()
+  return (
+    <SafeAreaView>
+      <GlobalText>{t("self_screener.intro.header")}</GlobalText>
+    </SafeAreaView>
+  )
+}
+
+export default SelfScreenerIntro

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -51,6 +51,16 @@ const Button: FunctionComponent<ButtonProps> = ({
     }
   }
 
+  const determineRightArrowColor = (): string => {
+    if (disabled) {
+      return Colors.black
+    } else if (outlined) {
+      return Colors.primary110
+    } else {
+      return Colors.white
+    }
+  }
+
   const determineTextStyle = (): TextStyle => {
     if (outlined) {
       return style.outlinedButtonText
@@ -120,7 +130,7 @@ const Button: FunctionComponent<ButtonProps> = ({
             {hasRightArrow && (
               <SvgXml
                 xml={Icons.Arrow}
-                fill={disabled ? Colors.black : Colors.white}
+                fill={determineRightArrowColor()}
                 style={style.rightArrow}
               />
             )}

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -8,6 +8,7 @@ export default Factory.define<Configuration>(() => ({
   displayReportAnIssue: false,
   displayCallbackForm: false,
   displayMyHealth: false,
+  displaySelfScreener: false,
   findATestCenterUrl: "findATestCenterUrl",
   healthAuthorityAdviceUrl: "authorityAdviceUrl",
   healthAuthorityLearnMoreUrl: "authorityLearnMoreUrl",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -122,8 +122,10 @@
       "content": "Someone you were nearby has since tested positive for COVID-19.",
       "ha_guidance_header": "What should I do?",
       "ha_guidance_subheader": "See guidance from {{healthAuthorityName}}.",
-      "header": "You may have crossed paths with the COVID-19 virus.",
+      "general_guidance": "General Guidance",
+      "header": "Someone you were nearby has since tested positive for COVID-19.",
       "isolate": "Isolate",
+      "personalize_my_guidance": "Personalize my guidance",
       "next_steps": "Next Steps",
       "schedule_callback": "Schedule a call to get support from a contact tracer from the {{healthAuthorityName}}.",
       "speak_with_contact_tracer": "Speak with a contact tracer",
@@ -155,6 +157,11 @@
     "updated": "Updated",
     "why_did_i_get_an_en": "Why did I get an exposure notification?",
     "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you have been in close proximity with later receives a positive test for COVID-19 and chooses to notify others."
+  },
+  "self-screener": {
+    "intro": {
+      "header": "COVID-19 Self Screener"
+    }
   },
   "home": {
     "bluetooth_info_body": "Your phone detects other phones you spend time in close proximity with using Bluetooth Low Energy. This allows the app to log your log daily encounters anonymously, even when you don’t have the app open on your device.",

--- a/src/navigation/ExposureHistoryStack.tsx
+++ b/src/navigation/ExposureHistoryStack.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react"
-import { createStackNavigator } from "@react-navigation/stack"
+import { useNavigation } from "@react-navigation/native"
+import { createStackNavigator, HeaderBackButton } from "@react-navigation/stack"
 import { useTranslation } from "react-i18next"
 
 import ExposureHistoryScreen from "../ExposureHistory/index"
@@ -10,7 +11,7 @@ import {
   ExposureHistoryScreen as Screen,
 } from "./index"
 
-import { Headers } from "../styles"
+import { Headers, Colors } from "../styles"
 
 type ExposureHistoryStackParams = {
   [key in Screen]: undefined
@@ -39,11 +40,25 @@ const ExposureHistoryStack: FunctionComponent = () => {
         name={ExposureHistoryScreens.ExposureDetail}
         component={ExposureDetail}
         options={{
-          ...Headers.headerScreenOptions,
+          ...Headers.headerLightOptions,
           title: t("navigation.exposure"),
+          headerLeft: function headerLeft() {
+            return <BackButton />
+          },
         }}
       />
     </Stack.Navigator>
+  )
+}
+
+const BackButton: FunctionComponent = () => {
+  const navigation = useNavigation()
+  return (
+    <HeaderBackButton
+      labelVisible={false}
+      tintColor={Colors.primary125}
+      onPress={navigation.goBack}
+    />
   )
 }
 

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -18,6 +18,7 @@ import SettingsStack from "./SettingsStack"
 import ModalStack from "./ModalStack"
 import Welcome from "../Welcome"
 import CallbackStack from "./CallbackStack"
+import SelfScreenerStack from "./SelfScreenerStack"
 import { useAnalyticsContext } from "../AnalyticsContext"
 
 const Stack = createStackNavigator()
@@ -125,6 +126,10 @@ const MainNavigator: FunctionComponent = () => {
             ...TransitionPresets.ModalTransition,
             headerShown: false,
           }}
+        />
+        <Stack.Screen
+          name={Stacks.SelfScreener}
+          component={SelfScreenerStack}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/src/navigation/SelfScreenerStack.tsx
+++ b/src/navigation/SelfScreenerStack.tsx
@@ -1,0 +1,19 @@
+import React, { FunctionComponent } from "react"
+import { createStackNavigator } from "@react-navigation/stack"
+import { SelfScreenerScreens } from "."
+import SelfScreenerIntro from "../SelfScreener/SelfScreenerIntro"
+
+const Stack = createStackNavigator()
+const SelfAssessmentStack: FunctionComponent = () => {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name={SelfScreenerScreens.SelfScreenerIntro}
+        component={SelfScreenerIntro}
+        options={{ headerShown: false }}
+      />
+    </Stack.Navigator>
+  )
+}
+
+export default SelfAssessmentStack

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -182,6 +182,13 @@ export const MyHealthStackScreens: {
   SelectSymptoms: "SelectSymptoms",
 }
 
+export type SelfScreenerScreen = "SelfScreenerIntro"
+
+export const SelfScreenerScreens: {
+  [key in SelfScreenerScreen]: SelfScreenerScreen
+} = {
+  SelfScreenerIntro: "SelfScreenerIntro",
+}
 export type Stack =
   | "Activation"
   | "AffectedUserStack"
@@ -195,6 +202,7 @@ export type Stack =
   | "Settings"
   | "Home"
   | "MyHealth"
+  | "SelfScreener"
 
 export const Stacks: { [key in Stack]: Stack } = {
   Activation: "Activation",
@@ -209,6 +217,7 @@ export const Stacks: { [key in Stack]: Stack } = {
   Settings: "Settings",
   Home: "Home",
   MyHealth: "MyHealth",
+  SelfScreener: "SelfScreener",
 }
 
 export const useStatusBarEffect = (

--- a/src/styles/headers.ts
+++ b/src/styles/headers.ts
@@ -26,3 +26,19 @@ export const headerScreenOptions: StackNavigationOptions = {
   headerTintColor: Colors.headerText,
   headerTitleAlign: "center",
 }
+
+export const headerLightOptions: StackNavigationOptions = {
+  headerStyle: {
+    backgroundColor: Colors.secondary10,
+    shadowColor: "transparent",
+    elevation: 0,
+  },
+  headerTitleStyle: {
+    ...Typography.mediumBold,
+    color: Colors.primaryText,
+    letterSpacing: Typography.largeLetterSpacing,
+    textTransform: "uppercase",
+  },
+  headerBackTitleVisible: false,
+  headerTitleAlign: "center",
+}


### PR DESCRIPTION
Why:
As an LA user who has received an EN, I want to be able to enter the
self screener flow so that I can get personalized information about what
I should do next.

This commit:
-Adds a SelfScreener stack with placeholder text
- Displays a button to navigate to the SelfScreener if it is enabled for
  the HA
- Updates the styling of the ExposureDetail page to match the updated
  styles for this flow.

![self screener](https://user-images.githubusercontent.com/21161427/94488779-43025e80-01b1-11eb-9696-4101f345c7a3.gif)
