### PR TITLE
Symptom Log Calendar

### DIFF
--- a/src/MyHealth/Calendar.spec.tsx
+++ b/src/MyHealth/Calendar.spec.tsx
@@ -6,16 +6,22 @@ import { factories } from "../factories"
 
 import Calendar from "./Calendar"
 import { DayLogData } from "./symptoms"
+import dayjs from "dayjs"
 
 afterEach(cleanup)
+const buildLogDataHistory = () => {
+  const logData = factories.dayLogData.build()
+  const totalDays = 30
+  return toLogDataHistory([logData], totalDays)
+}
 
 describe("Calendar", () => {
-  it("renders", () => {
-    const logDataHistory = buildLogDataHistory()
-    const onSelectDate = (_logData: DayLogData) => {}
-    const selectedDay = logDataHistory[0]
+  const logDataHistory = buildLogDataHistory()
+  const onSelectDate = (_logData: DayLogData) => {}
+  const selectedDay = logDataHistory[0]
 
-    const { getByTestId } = render(
+  it("displays 4 weeks of data", () => {
+    const { getByText } = render(
       <Calendar
         logDataHistory={logDataHistory}
         onSelectDate={onSelectDate}
@@ -23,12 +29,28 @@ describe("Calendar", () => {
       />,
     )
 
-    expect(getByTestId("myhealth-history-calendar")).not.toBeNull()
+    const dayNumber = parseInt(dayjs(logDataHistory[0].date).format("D"))
+
+    Array(30)
+      .fill(0)
+      .forEach((_, i) => {
+        if (Math.abs(dayNumber - i) > 3) {
+          expect(getByText(`${i + 1}`)).toBeDefined()
+        }
+      })
+  })
+
+  it("displays the days of the week", () => {
+    const labels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    const { getByText } = render(
+      <Calendar
+        logDataHistory={logDataHistory}
+        onSelectDate={onSelectDate}
+        selectedDay={selectedDay}
+      />,
+    )
+    labels.forEach((label) => {
+      expect(getByText(label)).toBeDefined()
+    })
   })
 })
-
-const buildLogDataHistory = () => {
-  const logData = factories.dayLogData.build()
-  const totalDays = 30
-  return toLogDataHistory([logData], totalDays)
-}

--- a/src/MyHealth/Calendar.spec.tsx
+++ b/src/MyHealth/Calendar.spec.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+import { cleanup, render } from "@testing-library/react-native"
+
+import { toLogDataHistory } from "./logDataHistory"
+import { factories } from "../factories"
+
+import Calendar from "./Calendar"
+import { DayLogData } from "./symptoms"
+
+afterEach(cleanup)
+
+describe("Calendar", () => {
+  it("renders", () => {
+    const logDataHistory = buildLogDataHistory()
+    const onSelectDate = (_logData: DayLogData) => {}
+    const selectedDay = logDataHistory[0]
+
+    const { getByTestId } = render(
+      <Calendar
+        logDataHistory={logDataHistory}
+        onSelectDate={onSelectDate}
+        selectedDay={selectedDay}
+      />,
+    )
+
+    expect(getByTestId("myhealth-history-calendar")).not.toBeNull()
+  })
+})
+
+const buildLogDataHistory = () => {
+  const logData = factories.dayLogData.build()
+  const totalDays = 30
+  return toLogDataHistory([logData], totalDays)
+}

--- a/src/MyHealth/Calendar.tsx
+++ b/src/MyHealth/Calendar.tsx
@@ -1,0 +1,120 @@
+import React, { FunctionComponent } from "react"
+import { Text, TouchableOpacity, View, StyleSheet } from "react-native"
+import dayjs from "dayjs"
+
+import { Spacing, Typography } from "../styles"
+import { GlobalText } from "../components"
+import { DayLogData } from "./symptoms"
+import DayIndicator from "./DayIndicator."
+
+interface CalendarProps {
+  logDataHistory: DayLogData[]
+  onSelectDate: (logData: DayLogData) => void
+  selectedDay: DayLogData | null
+}
+
+const Calendar: FunctionComponent<CalendarProps> = ({
+  logDataHistory,
+  onSelectDate,
+  selectedDay,
+}: CalendarProps) => {
+  const lastMonth = dayjs().subtract(1, "month")
+  const title = `${lastMonth.format("MMMM")} | ${dayjs().format(
+    "MMMM",
+  )}`.toUpperCase()
+
+  const week1 = logDataHistory.slice(0, 7)
+  const week2 = logDataHistory.slice(7, 14)
+  const week3 = logDataHistory.slice(14, 21)
+  const week4 = logDataHistory.slice(21, 28)
+
+  interface CalendarRowProps {
+    week: DayLogData[]
+  }
+
+  const CalendarRow = ({ week }: CalendarRowProps) => {
+    return (
+      <View style={styles.calendarRow}>
+        {week
+          .filter((logData: DayLogData | null) => logData.checkIn)
+          .map((logData: DayLogData) => {
+            const isSelected =
+              logData.checkIn.date === selectedDay?.checkIn.date
+
+            return (
+              <TouchableOpacity
+                key={`calendar-day-${logData.checkIn.date}`}
+                testID={`calendar-day-${logData.checkIn.date}`}
+                onPress={() => onSelectDate(logData)}
+              >
+                <DayIndicator isSelected={isSelected} logData={logData} />
+              </TouchableOpacity>
+            )
+          })}
+      </View>
+    )
+  }
+
+  const DayLabels = () => {
+    const labels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    return (
+      <View style={styles.calendarRow}>
+        {labels.map((label: string, idx: number) => {
+          return (
+            <View style={styles.labelStyle} key={`calendar-label-${idx}`}>
+              <Text style={styles.labelTextStyle}>{label}</Text>
+            </View>
+          )
+        })}
+      </View>
+    )
+  }
+
+  return (
+    <View testID={"myhealth-history-calendar"} style={styles.container}>
+      <View style={styles.header}>
+        <GlobalText style={styles.monthText}>{title}</GlobalText>
+      </View>
+      <View style={styles.calendarContainer}>
+        <DayLabels />
+        <CalendarRow week={week1} />
+        <CalendarRow week={week2} />
+        <CalendarRow week={week3} />
+        <CalendarRow week={week4} />
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  monthText: {
+    ...Typography.bold,
+  },
+  calendarContainer: {
+    flex: 1,
+    paddingVertical: Spacing.small,
+  },
+  calendarRow: {
+    flex: 1,
+    paddingVertical: Spacing.xxSmall,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  labelStyle: {
+    justifyContent: "center",
+    alignItems: "center",
+    width: Spacing.xHuge,
+  },
+  labelTextStyle: {},
+})
+
+export default Calendar

--- a/src/MyHealth/Calendar.tsx
+++ b/src/MyHealth/Calendar.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent, useEffect } from "react"
 import { Text, TouchableOpacity, View, StyleSheet } from "react-native"
 import dayjs from "dayjs"
 
@@ -6,6 +6,7 @@ import { Spacing, Typography } from "../styles"
 import { GlobalText } from "../components"
 import { DayLogData } from "./symptoms"
 import DayIndicator from "./DayIndicator"
+import { DateTimeUtils } from "../utils"
 
 interface CalendarProps {
   logDataHistory: DayLogData[]
@@ -22,6 +23,17 @@ const Calendar: FunctionComponent<CalendarProps> = ({
   const title = `${lastMonth.format("MMMM")} | ${dayjs().format(
     "MMMM",
   )}`.toUpperCase()
+
+  useEffect(() => {
+    if (!selectedDay) {
+      logDataHistory.forEach((logData: DayLogData) => {
+        if (DateTimeUtils.isToday(logData.date)) {
+          selectedDay = logData
+          onSelectDate(logData)
+        }
+      })
+    }
+  }, [])
 
   const week1 = logDataHistory.slice(0, 7)
   const week2 = logDataHistory.slice(7, 14)

--- a/src/MyHealth/Calendar.tsx
+++ b/src/MyHealth/Calendar.tsx
@@ -5,7 +5,7 @@ import dayjs from "dayjs"
 import { Spacing, Typography } from "../styles"
 import { GlobalText } from "../components"
 import { DayLogData } from "./symptoms"
-import DayIndicator from "./DayIndicator."
+import DayIndicator from "./DayIndicator"
 
 interface CalendarProps {
   logDataHistory: DayLogData[]

--- a/src/MyHealth/DayIndicator..tsx
+++ b/src/MyHealth/DayIndicator..tsx
@@ -1,0 +1,138 @@
+import React, { FunctionComponent } from "react"
+import { View, Text, ViewStyle, TextStyle, StyleSheet } from "react-native"
+import dayjs from "dayjs"
+
+import { DateTimeUtils } from "../utils"
+import { Outlines, Colors, Typography, Spacing } from "../styles"
+import { CheckInStatus, DayLogData } from "./symptoms"
+
+interface DayIndicatorProps {
+  logData: DayLogData
+  isSelected: boolean
+}
+
+type IndicatorStyle = [ViewStyle, TextStyle]
+
+const DayIndicator: FunctionComponent<DayIndicatorProps> = ({
+  logData,
+  isSelected,
+}: DayIndicatorProps) => {
+  const isToday = DateTimeUtils.isToday(logData.date)
+
+  const applyRiskStyle = ([
+    circleStyle,
+    textStyle,
+  ]: IndicatorStyle): IndicatorStyle => {
+    switch (logData.checkIn.status) {
+      case CheckInStatus.NotCheckedIn: {
+        return [{ ...circleStyle }, { ...textStyle, color: Colors.primaryText }]
+      }
+      case CheckInStatus.FeelingGood: {
+        return [
+          { ...circleStyle, borderColor: Colors.success100 },
+          { ...textStyle, color: Colors.success100 },
+        ]
+      }
+      case CheckInStatus.FeelingNotWell: {
+        return [
+          { ...circleStyle, borderColor: Colors.warning100 },
+          { ...textStyle, color: Colors.warning100 },
+        ]
+      }
+    }
+  }
+
+  const applyIsTodayStyle = ([
+    circleStyle,
+    textStyle,
+  ]: IndicatorStyle): IndicatorStyle => {
+    if (isToday) {
+      return [
+        {
+          ...circleStyle,
+        },
+        {
+          ...textStyle,
+          fontWeight: Typography.boldWeight,
+        },
+      ]
+    } else {
+      return [circleStyle, textStyle]
+    }
+  }
+
+  const applyIsSelectedStyle = ([
+    circleStyle,
+    textStyle,
+  ]: IndicatorStyle): IndicatorStyle => {
+    if (isSelected) {
+      switch (logData.checkIn.status) {
+        case CheckInStatus.NotCheckedIn: {
+          return [
+            {
+              ...circleStyle,
+              borderColor: Colors.primaryText,
+            },
+            { ...textStyle, color: Colors.primaryText },
+          ]
+        }
+        case CheckInStatus.FeelingGood: {
+          return [
+            {
+              ...circleStyle,
+              borderColor: Colors.success100,
+              backgroundColor: Colors.success100,
+            },
+            { ...textStyle, color: Colors.primaryText },
+          ]
+        }
+        case CheckInStatus.FeelingNotWell: {
+          return [
+            {
+              ...circleStyle,
+              borderColor: Colors.warning100,
+              backgroundColor: Colors.warning100,
+            },
+            { ...textStyle, color: Colors.primaryText },
+          ]
+        }
+      }
+    } else {
+      return [circleStyle, textStyle]
+    }
+  }
+
+  const baseStyles: IndicatorStyle = [styles.circleBase, styles.textBase]
+
+  const [circleStyle, textStyle] = [baseStyles]
+    .map(applyIsTodayStyle)
+    .map(applyRiskStyle)
+    .flatMap(applyIsSelectedStyle)
+
+  const dayNumber = dayjs(logData.date).format("D")
+  console.log(dayNumber)
+
+  const indicator = <Text style={textStyle}>{dayNumber}</Text>
+
+  return <View style={circleStyle}>{indicator}</View>
+}
+
+const styles = StyleSheet.create({
+  circleBase: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    width: Spacing.xHuge,
+    height: Spacing.xHuge,
+    borderRadius: Outlines.borderRadiusMax,
+    borderColor: Colors.transparent,
+    borderWidth: Outlines.hairline,
+  },
+  textBase: {
+    ...Typography.smallFont,
+    ...Typography.monospace,
+    color: Colors.primaryText,
+  },
+})
+
+export default DayIndicator

--- a/src/MyHealth/DayIndicator.tsx
+++ b/src/MyHealth/DayIndicator.tsx
@@ -27,6 +27,12 @@ const DayIndicator: FunctionComponent<DayIndicatorProps> = ({
       case CheckInStatus.NotCheckedIn: {
         return [{ ...circleStyle }, { ...textStyle, color: Colors.primaryText }]
       }
+      case CheckInStatus.TooOld: {
+        return [
+          { ...circleStyle },
+          { ...textStyle, color: Colors.transparentPrimaryText },
+        ]
+      }
       case CheckInStatus.FeelingGood: {
         return [
           { ...circleStyle, borderColor: Colors.success100 },
@@ -96,6 +102,8 @@ const DayIndicator: FunctionComponent<DayIndicatorProps> = ({
             { ...textStyle, color: Colors.primaryText },
           ]
         }
+        default:
+          return [circleStyle, textStyle]
       }
     } else {
       return [circleStyle, textStyle]
@@ -104,7 +112,7 @@ const DayIndicator: FunctionComponent<DayIndicatorProps> = ({
 
   const baseStyles: IndicatorStyle = [styles.circleBase, styles.textBase]
 
-  const [circleStyle, textStyle] = [baseStyles]
+  const [[circleStyle, textStyle]] = [baseStyles]
     .map(applyIsTodayStyle)
     .map(applyRiskStyle)
     .map(applyIsSelectedStyle)

--- a/src/MyHealth/DayIndicator.tsx
+++ b/src/MyHealth/DayIndicator.tsx
@@ -107,10 +107,9 @@ const DayIndicator: FunctionComponent<DayIndicatorProps> = ({
   const [circleStyle, textStyle] = [baseStyles]
     .map(applyIsTodayStyle)
     .map(applyRiskStyle)
-    .flatMap(applyIsSelectedStyle)
+    .map(applyIsSelectedStyle)
 
   const dayNumber = dayjs(logData.date).format("D")
-  console.log(dayNumber)
 
   const indicator = <Text style={textStyle}>{dayNumber}</Text>
 

--- a/src/MyHealth/DaySummary.tsx
+++ b/src/MyHealth/DaySummary.tsx
@@ -28,6 +28,10 @@ const CheckInSummary: FunctionComponent<CheckInSummaryProps> = ({ status }) => {
       text: t("my_health.symptom_log.did_not_check_in"),
       colorStyle: style.statusDotGray,
     }
+    const tooOldContent: CheckInContent = {
+      text: t("my_health.symptom_log.too_old"),
+      colorStyle: style.statusDotGray,
+    }
     const feelingNotWellContent: CheckInContent = {
       text: t("my_health.symptom_log.feeling_not_well"),
       colorStyle: style.statusDotOrange,
@@ -40,6 +44,8 @@ const CheckInSummary: FunctionComponent<CheckInSummaryProps> = ({ status }) => {
     switch (status) {
       case CheckInStatus.NotCheckedIn:
         return didNotCheckInContent
+      case CheckInStatus.TooOld:
+        return tooOldContent
       case CheckInStatus.FeelingNotWell:
         return feelingNotWellContent
       case CheckInStatus.FeelingGood:

--- a/src/MyHealth/DaySummary.tsx
+++ b/src/MyHealth/DaySummary.tsx
@@ -1,0 +1,200 @@
+import React, { FunctionComponent } from "react"
+import { StyleSheet, TouchableOpacity, View, ViewStyle } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { StackNavigationProp } from "@react-navigation/stack"
+import { useTranslation } from "react-i18next"
+
+import { SymptomLogEntry, DayLogData, CheckInStatus } from "./symptoms"
+import { GlobalText } from "../components"
+import { posixToDayjs } from "../utils/dateTime"
+import { MyHealthStackScreens } from "../navigation"
+import { MyHealthStackParams } from "../navigation/MyHealthStack"
+import { Typography, Colors, Outlines, Spacing } from "../styles"
+
+type CheckInSummaryProps = {
+  status: CheckInStatus
+}
+
+const CheckInSummary: FunctionComponent<CheckInSummaryProps> = ({ status }) => {
+  const { t } = useTranslation()
+
+  type CheckInContent = {
+    text: string
+    colorStyle: ViewStyle
+  }
+
+  const determineCheckInStatusContent = (): CheckInContent => {
+    const didNotCheckInContent: CheckInContent = {
+      text: t("my_health.symptom_log.did_not_check_in"),
+      colorStyle: style.statusDotGray,
+    }
+    const feelingNotWellContent: CheckInContent = {
+      text: t("my_health.symptom_log.feeling_not_well"),
+      colorStyle: style.statusDotOrange,
+    }
+    const feelingGoodContent: CheckInContent = {
+      text: t("my_health.symptom_log.feeling_well"),
+      colorStyle: style.statusDotGreen,
+    }
+
+    switch (status) {
+      case CheckInStatus.NotCheckedIn:
+        return didNotCheckInContent
+      case CheckInStatus.FeelingNotWell:
+        return feelingNotWellContent
+      case CheckInStatus.FeelingGood:
+        return feelingGoodContent
+    }
+  }
+
+  const content = determineCheckInStatusContent()
+
+  return (
+    <View style={style.checkInStatusContainer}>
+      <View style={{ ...style.statusDot, ...content.colorStyle }} />
+      <GlobalText style={style.checkInStatusText}>{content.text}</GlobalText>
+    </View>
+  )
+}
+
+type LogEntryProps = {
+  logEntry: SymptomLogEntry
+}
+
+const LogEntry: FunctionComponent<LogEntryProps> = ({ logEntry }) => {
+  const { t } = useTranslation()
+  const navigation = useNavigation<StackNavigationProp<MyHealthStackParams>>()
+  const { symptoms, date } = logEntry
+
+  if (symptoms.length === 0) {
+    return null
+  }
+
+  const dayJsDate = posixToDayjs(date)
+
+  const handleOnPressEdit = () => {
+    navigation.navigate(MyHealthStackScreens.SelectSymptoms, {
+      logEntry: JSON.stringify(logEntry),
+    })
+  }
+
+  return (
+    <View style={style.symptomLogContainer}>
+      <View style={style.timeAndEditContainer}>
+        {dayJsDate && (
+          <GlobalText style={style.timeText}>
+            {dayJsDate.local().format("HH:mm A")}
+          </GlobalText>
+        )}
+        <TouchableOpacity
+          onPress={handleOnPressEdit}
+          accessibilityLabel={t("common.edit")}
+        >
+          <GlobalText style={style.editText}>{t("common.edit")}</GlobalText>
+        </TouchableOpacity>
+      </View>
+      <View style={style.symptomsContainer}>
+        {symptoms.map((symptom) => {
+          const translatedSymptom = t(`symptoms.${symptom}`)
+          return (
+            <View style={style.symptomTextContainer} key={translatedSymptom}>
+              <GlobalText style={style.symptomText}>
+                {translatedSymptom}
+              </GlobalText>
+            </View>
+          )
+        })}
+      </View>
+    </View>
+  )
+}
+
+type DaySummaryProps = {
+  dayLogData: DayLogData
+}
+
+const DaySummary: FunctionComponent<DaySummaryProps> = ({
+  dayLogData: { date, checkIn, logEntries },
+}) => {
+  const dayJsDate = posixToDayjs(date)
+
+  return (
+    <>
+      {dayJsDate && (
+        <GlobalText style={style.dateText}>
+          {dayJsDate.local().format("MMMM D, YYYY")}
+        </GlobalText>
+      )}
+      {checkIn && <CheckInSummary status={checkIn.status} />}
+      {logEntries.map((logEntry) => {
+        return <LogEntry key={logEntry.id} logEntry={logEntry} />
+      })}
+    </>
+  )
+}
+
+const style = StyleSheet.create({
+  dateText: {
+    ...Typography.header4,
+    marginBottom: Spacing.xxxSmall,
+  },
+  checkInStatusContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: Spacing.small,
+  },
+  statusDot: {
+    width: Spacing.xxSmall,
+    height: Spacing.xxSmall,
+    borderRadius: Outlines.borderRadiusMax,
+  },
+  statusDotGray: {
+    backgroundColor: Colors.neutral75,
+  },
+  statusDotOrange: {
+    backgroundColor: Colors.warning100,
+  },
+  statusDotGreen: {
+    backgroundColor: Colors.success100,
+  },
+  checkInStatusText: {
+    ...Typography.body1,
+    marginLeft: Spacing.xxSmall,
+  },
+  symptomLogContainer: {
+    paddingBottom: Spacing.medium,
+    marginBottom: Spacing.medium,
+    borderBottomWidth: Outlines.hairline,
+    borderBottomColor: Colors.neutral10,
+  },
+  timeAndEditContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    marginBottom: Spacing.xSmall,
+  },
+  timeText: {
+    ...Typography.body2,
+    color: Colors.neutral100,
+  },
+  editText: {
+    ...Typography.body2,
+  },
+  symptomsContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+  symptomTextContainer: {
+    backgroundColor: Colors.neutral10,
+    marginBottom: Spacing.xxSmall,
+    marginRight: Spacing.xxSmall,
+    borderRadius: Outlines.borderRadiusMax,
+    paddingVertical: Spacing.xxxSmall,
+    paddingHorizontal: Spacing.xSmall,
+  },
+  symptomText: {
+    ...Typography.body2,
+  },
+})
+
+export default DaySummary

--- a/src/MyHealth/History.spec.tsx
+++ b/src/MyHealth/History.spec.tsx
@@ -15,9 +15,28 @@ jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 
 const defaultDate = dayjs(DateTimeUtils.daysAgo(2)).startOf("day").valueOf()
+const fifteenDaysAgo = dayjs(DateTimeUtils.daysAgo(15)).startOf("day").valueOf()
 
 describe("History", () => {
   describe("when a day is selected", () => {
+    describe("when a day > 14 days ago is selected", () => {
+      it('displays the "Datstore data older than 14 days" message', () => {
+        const { queryByText, getByTestId } = render(
+          <SymptomLogContext.Provider
+            value={factories.symptomLogContext.build({
+              dailyLogData: [],
+            })}
+          >
+            <History />
+          </SymptomLogContext.Provider>,
+        )
+        fireEvent.press(getByTestId(`calendar-day-${fifteenDaysAgo}`))
+        expect(
+          queryByText("Data older than 14 days is not stored"),
+        ).not.toBeNull()
+      })
+    })
+
     describe("before a day is manually selected", () => {
       it("displays the log for the current day", () => {
         const { queryByText } = render(

--- a/src/MyHealth/History.spec.tsx
+++ b/src/MyHealth/History.spec.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { fireEvent, cleanup, render } from "@testing-library/react-native"
+import { useNavigation } from "@react-navigation/native"
+
+import { factories } from "../factories"
+
+import History from "../MyHealth/History"
+import { SymptomLogContext } from "./SymptomLogContext"
+import { CheckInStatus } from "./symptoms"
+import { DateTimeUtils } from "../utils"
+import dayjs from "dayjs"
+
+afterEach(cleanup)
+jest.mock("@react-navigation/native")
+;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
+
+const defaultDate = dayjs(DateTimeUtils.daysAgo(2)).startOf("day").valueOf()
+
+describe("History", () => {
+  describe("when a day is selected", () => {
+    describe("before a day is manually selected", () => {
+      it("displays the log for the current day", () => {
+        const { queryByText } = render(
+          <SymptomLogContext.Provider
+            value={factories.symptomLogContext.build({
+              dailyLogData: [],
+            })}
+          >
+            <History />
+          </SymptomLogContext.Provider>,
+        )
+        expect(queryByText("You did not check in")).not.toBeNull()
+      })
+    })
+    describe("when a day without a checkin is selected", () => {
+      it("displays the appropriate message", () => {
+        const { queryByText, getByTestId } = render(
+          <SymptomLogContext.Provider
+            value={factories.symptomLogContext.build({
+              dailyLogData: [],
+            })}
+          >
+            <History />
+          </SymptomLogContext.Provider>,
+        )
+        fireEvent.press(getByTestId(`calendar-day-${defaultDate}`))
+        expect(queryByText("You did not check in")).not.toBeNull()
+      })
+    })
+    describe('when a day with a "Feeling Good" checkin is selected', () => {
+      it("displays the appropriate message", () => {
+        const { queryByText, getByTestId } = render(
+          <SymptomLogContext.Provider
+            value={factories.symptomLogContext.build({
+              dailyLogData: [
+                {
+                  date: defaultDate,
+                  checkIn: {
+                    status: CheckInStatus.FeelingGood,
+                    date: defaultDate,
+                  },
+                  logEntries: [],
+                },
+              ],
+            })}
+          >
+            <History />
+          </SymptomLogContext.Provider>,
+        )
+        fireEvent.press(getByTestId(`calendar-day-${defaultDate}`))
+        expect(queryByText("You were feeling well")).not.toBeNull()
+      })
+    })
+    describe('when a day with a "Not Feeling Good" checkin is selected', () => {
+      it("displays the appropriate message", () => {
+        const { queryByText, getByTestId } = render(
+          <SymptomLogContext.Provider
+            value={factories.symptomLogContext.build({
+              dailyLogData: [
+                {
+                  date: defaultDate,
+                  checkIn: {
+                    status: CheckInStatus.FeelingNotWell,
+                    date: defaultDate,
+                  },
+                  logEntries: [],
+                },
+              ],
+            })}
+          >
+            <History />
+          </SymptomLogContext.Provider>,
+        )
+        fireEvent.press(getByTestId(`calendar-day-${defaultDate}`))
+        expect(queryByText("You were not feeling well")).not.toBeNull()
+      })
+    })
+  })
+})

--- a/src/MyHealth/History.tsx
+++ b/src/MyHealth/History.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react"
+import React, { FunctionComponent } from "react"
 import { ScrollView, StyleSheet } from "react-native"
 
 import { useSymptomLogContext } from "./SymptomLogContext"
@@ -9,14 +9,16 @@ import DaySummary from "./DaySummary"
 import { DayLogData } from "./symptoms"
 
 const History: FunctionComponent = () => {
-  const { dailyLogData } = useSymptomLogContext()
-
-  const [selectedDay, setSelectedDay] = useState<DayLogData | null>(null)
+  const {
+    dailyLogData,
+    selectLogEntry,
+    selectedLogEntry,
+  } = useSymptomLogContext()
 
   const logDataHistory = toLogDataHistory(dailyLogData, 30)
 
   const handleOnSelectDate = (logData: DayLogData) => {
-    setSelectedDay(logData)
+    selectLogEntry(logData)
   }
 
   return (
@@ -29,10 +31,13 @@ const History: FunctionComponent = () => {
         <Calendar
           logDataHistory={logDataHistory}
           onSelectDate={handleOnSelectDate}
-          selectedDay={selectedDay}
+          selectedDay={selectedLogEntry}
         />
-        {selectedDay && (
-          <DaySummary key={selectedDay.checkIn.date} dayLogData={selectedDay} />
+        {selectedLogEntry && (
+          <DaySummary
+            key={selectedLogEntry.checkIn.date}
+            dayLogData={selectedLogEntry}
+          />
         )}
       </ScrollView>
     </>

--- a/src/MyHealth/History.tsx
+++ b/src/MyHealth/History.tsx
@@ -1,0 +1,114 @@
+import React, { FunctionComponent, useState } from "react"
+import { ScrollView, StyleSheet } from "react-native"
+
+import { useSymptomLogContext } from "./SymptomLogContext"
+import { Typography, Colors, Outlines, Spacing } from "../styles"
+import Calendar from "./Calendar"
+import { toLogDataHistory } from "./logDataHistory"
+import DaySummary from "./DaySummary"
+import { DayLogData } from "./symptoms"
+
+const History: FunctionComponent = () => {
+  const { dailyLogData } = useSymptomLogContext()
+
+  const [selectedDay, setSelectedDay] = useState<DayLogData | null>(null)
+
+  const logDataHistory = toLogDataHistory(dailyLogData, 30)
+
+  const handleOnSelectDate = (logData: DayLogData) => {
+    setSelectedDay(logData)
+  }
+
+  return (
+    <>
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
+      >
+        <Calendar
+          logDataHistory={logDataHistory}
+          onSelectDate={handleOnSelectDate}
+          selectedDay={selectedDay}
+        />
+        {selectedDay && (
+          <DaySummary key={selectedDay.checkIn.date} dayLogData={selectedDay} />
+        )}
+      </ScrollView>
+    </>
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primaryLightBackground,
+  },
+  contentContainer: {
+    paddingVertical: Spacing.large,
+    paddingHorizontal: Spacing.large,
+  },
+  dateText: {
+    ...Typography.header4,
+    marginBottom: Spacing.xxxSmall,
+  },
+  checkInStatusContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: Spacing.small,
+  },
+  statusDot: {
+    width: Spacing.xxSmall,
+    height: Spacing.xxSmall,
+    borderRadius: Outlines.borderRadiusMax,
+  },
+  statusDotGray: {
+    backgroundColor: Colors.neutral75,
+  },
+  statusDotOrange: {
+    backgroundColor: Colors.warning100,
+  },
+  statusDotGreen: {
+    backgroundColor: Colors.success100,
+  },
+  checkInStatusText: {
+    ...Typography.body1,
+    marginLeft: Spacing.xxSmall,
+  },
+  symptomLogContainer: {
+    paddingBottom: Spacing.medium,
+    marginBottom: Spacing.medium,
+    borderBottomWidth: Outlines.hairline,
+    borderBottomColor: Colors.neutral10,
+  },
+  timeAndEditContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    marginBottom: Spacing.xSmall,
+  },
+  timeText: {
+    ...Typography.body2,
+    color: Colors.neutral100,
+  },
+  editText: {
+    ...Typography.body2,
+  },
+  symptomsContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+  symptomTextContainer: {
+    backgroundColor: Colors.neutral10,
+    marginBottom: Spacing.xxSmall,
+    marginRight: Spacing.xxSmall,
+    borderRadius: Outlines.borderRadiusMax,
+    paddingVertical: Spacing.xxxSmall,
+    paddingHorizontal: Spacing.xSmall,
+  },
+  symptomText: {
+    ...Typography.body2,
+  },
+})
+
+export default History

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -1,148 +1,14 @@
 import React, { FunctionComponent, useState } from "react"
-import {
-  ScrollView,
-  StyleSheet,
-  TouchableOpacity,
-  View,
-  ViewStyle,
-} from "react-native"
-import { useNavigation } from "@react-navigation/native"
-import { StackNavigationProp } from "@react-navigation/stack"
+import { ScrollView, StyleSheet, TouchableOpacity, View } from "react-native"
 import { useTranslation } from "react-i18next"
 
 import { useSymptomLogContext } from "./SymptomLogContext"
-import { SymptomLogEntry, DayLogData, CheckInStatus } from "./symptoms"
 import { GlobalText } from "../components"
-import { posixToDayjs } from "../utils/dateTime"
-import { MyHealthStackScreens } from "../navigation"
-import { MyHealthStackParams } from "../navigation/MyHealthStack"
-import { Typography, Colors, Outlines, Spacing, Iconography } from "../styles"
+import { Typography, Colors, Spacing, Iconography } from "../styles"
 import { SvgXml } from "react-native-svg"
 import { Icons } from "../assets"
-import Calendar from "./Calendar"
-import { toLogDataHistory } from "./logDataHistory"
-
-type CheckInSummaryProps = {
-  status: CheckInStatus
-}
-
-const CheckInSummary: FunctionComponent<CheckInSummaryProps> = ({ status }) => {
-  const { t } = useTranslation()
-
-  type CheckInContent = {
-    text: string
-    colorStyle: ViewStyle
-  }
-
-  const determineCheckInStatusContent = (): CheckInContent => {
-    const didNotCheckInContent: CheckInContent = {
-      text: t("my_health.symptom_log.did_not_check_in"),
-      colorStyle: style.statusDotGray,
-    }
-    const feelingNotWellContent: CheckInContent = {
-      text: t("my_health.symptom_log.feeling_not_well"),
-      colorStyle: style.statusDotOrange,
-    }
-    const feelingGoodContent: CheckInContent = {
-      text: t("my_health.symptom_log.feeling_well"),
-      colorStyle: style.statusDotGreen,
-    }
-
-    switch (status) {
-      case CheckInStatus.NotCheckedIn:
-        return didNotCheckInContent
-      case CheckInStatus.FeelingNotWell:
-        return feelingNotWellContent
-      case CheckInStatus.FeelingGood:
-        return feelingGoodContent
-    }
-  }
-
-  const content = determineCheckInStatusContent()
-
-  return (
-    <View style={style.checkInStatusContainer}>
-      <View style={{ ...style.statusDot, ...content.colorStyle }} />
-      <GlobalText style={style.checkInStatusText}>{content.text}</GlobalText>
-    </View>
-  )
-}
-
-type LogEntryProps = {
-  logEntry: SymptomLogEntry
-}
-
-const LogEntry: FunctionComponent<LogEntryProps> = ({ logEntry }) => {
-  const { t } = useTranslation()
-  const navigation = useNavigation<StackNavigationProp<MyHealthStackParams>>()
-  const { symptoms, date } = logEntry
-
-  if (symptoms.length === 0) {
-    return null
-  }
-
-  const dayJsDate = posixToDayjs(date)
-
-  const handleOnPressEdit = () => {
-    navigation.navigate(MyHealthStackScreens.SelectSymptoms, {
-      logEntry: JSON.stringify(logEntry),
-    })
-  }
-
-  return (
-    <View style={style.symptomLogContainer}>
-      <View style={style.timeAndEditContainer}>
-        {dayJsDate && (
-          <GlobalText style={style.timeText}>
-            {dayJsDate.local().format("HH:mm A")}
-          </GlobalText>
-        )}
-        <TouchableOpacity
-          onPress={handleOnPressEdit}
-          accessibilityLabel={t("common.edit")}
-        >
-          <GlobalText style={style.editText}>{t("common.edit")}</GlobalText>
-        </TouchableOpacity>
-      </View>
-      <View style={style.symptomsContainer}>
-        {symptoms.map((symptom) => {
-          const translatedSymptom = t(`symptoms.${symptom}`)
-          return (
-            <View style={style.symptomTextContainer} key={translatedSymptom}>
-              <GlobalText style={style.symptomText}>
-                {translatedSymptom}
-              </GlobalText>
-            </View>
-          )
-        })}
-      </View>
-    </View>
-  )
-}
-
-type DaySummaryProps = {
-  dayLogData: DayLogData
-}
-
-const DaySummary: FunctionComponent<DaySummaryProps> = ({
-  dayLogData: { date, checkIn, logEntries },
-}) => {
-  const dayJsDate = posixToDayjs(date)
-
-  return (
-    <>
-      {dayJsDate && (
-        <GlobalText style={style.dateText}>
-          {dayJsDate.local().format("MMMM D, YYYY")}
-        </GlobalText>
-      )}
-      {checkIn && <CheckInSummary status={checkIn.status} />}
-      {logEntries.map((logEntry) => {
-        return <LogEntry key={logEntry.id} logEntry={logEntry} />
-      })}
-    </>
-  )
-}
+import History from "./History"
+import DaySummary from "./DaySummary"
 
 const OverTime: FunctionComponent = () => {
   const { t } = useTranslation()
@@ -154,13 +20,6 @@ const OverTime: FunctionComponent = () => {
 
   const noSymptomHistory = dailyLogData.length === 0
 
-  const [selectedDay, setSelectedDay] = useState<DayLogData | null>(null)
-
-  const logDataHistory = toLogDataHistory(dailyLogData, 30)
-
-  const handleOnSelectDate = (logData: DayLogData) => {
-    setSelectedDay(logData)
-  }
   const headerTitle =
     viewSelection === "List"
       ? t("symptom_checker.last_14_days")
@@ -207,23 +66,7 @@ const OverTime: FunctionComponent = () => {
           )}
         </ScrollView>
       ) : (
-        <ScrollView
-          style={style.container}
-          contentContainerStyle={style.contentContainer}
-          alwaysBounceVertical={false}
-        >
-          <Calendar
-            logDataHistory={logDataHistory}
-            onSelectDate={handleOnSelectDate}
-            selectedDay={selectedDay}
-          />
-          {selectedDay && (
-            <DaySummary
-              key={selectedDay.checkIn.date}
-              dayLogData={selectedDay}
-            />
-          )}
-        </ScrollView>
+        <History />
       )}
     </>
   )
@@ -237,67 +80,6 @@ const style = StyleSheet.create({
   contentContainer: {
     paddingVertical: Spacing.large,
     paddingHorizontal: Spacing.large,
-  },
-  dateText: {
-    ...Typography.header4,
-    marginBottom: Spacing.xxxSmall,
-  },
-  checkInStatusContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: Spacing.small,
-  },
-  statusDot: {
-    width: Spacing.xxSmall,
-    height: Spacing.xxSmall,
-    borderRadius: Outlines.borderRadiusMax,
-  },
-  statusDotGray: {
-    backgroundColor: Colors.neutral75,
-  },
-  statusDotOrange: {
-    backgroundColor: Colors.warning100,
-  },
-  statusDotGreen: {
-    backgroundColor: Colors.success100,
-  },
-  checkInStatusText: {
-    ...Typography.body1,
-    marginLeft: Spacing.xxSmall,
-  },
-  symptomLogContainer: {
-    paddingBottom: Spacing.medium,
-    marginBottom: Spacing.medium,
-    borderBottomWidth: Outlines.hairline,
-    borderBottomColor: Colors.neutral10,
-  },
-  timeAndEditContainer: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "flex-end",
-    marginBottom: Spacing.xSmall,
-  },
-  timeText: {
-    ...Typography.body2,
-    color: Colors.neutral100,
-  },
-  editText: {
-    ...Typography.body2,
-  },
-  symptomsContainer: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-  },
-  symptomTextContainer: {
-    backgroundColor: Colors.neutral10,
-    marginBottom: Spacing.xxSmall,
-    marginRight: Spacing.xxSmall,
-    borderRadius: Outlines.borderRadiusMax,
-    paddingVertical: Spacing.xxxSmall,
-    paddingHorizontal: Spacing.xSmall,
-  },
-  symptomText: {
-    ...Typography.body2,
   },
   noSymptomHistoryText: {
     alignSelf: "center",

--- a/src/MyHealth/OverTime.tsx
+++ b/src/MyHealth/OverTime.tsx
@@ -19,6 +19,8 @@ import { MyHealthStackParams } from "../navigation/MyHealthStack"
 import { Typography, Colors, Outlines, Spacing, Iconography } from "../styles"
 import { SvgXml } from "react-native-svg"
 import { Icons } from "../assets"
+import Calendar from "./Calendar"
+import { toLogDataHistory } from "./logDataHistory"
 
 type CheckInSummaryProps = {
   status: CheckInStatus
@@ -152,6 +154,13 @@ const OverTime: FunctionComponent = () => {
 
   const noSymptomHistory = dailyLogData.length === 0
 
+  const [selectedDay, setSelectedDay] = useState<DayLogData | null>(null)
+
+  const logDataHistory = toLogDataHistory(dailyLogData, 30)
+
+  const handleOnSelectDate = (logData: DayLogData) => {
+    setSelectedDay(logData)
+  }
   const headerTitle =
     viewSelection === "List"
       ? t("symptom_checker.last_14_days")
@@ -178,25 +187,44 @@ const OverTime: FunctionComponent = () => {
             height={Iconography.xSmall}
             accessibilityLabel="Toggle symptom log view"
             onPress={handleOnPressToggleView}
-            fill={Colors.primary100}
           />
         </TouchableOpacity>
       </View>
-      <ScrollView
-        style={style.container}
-        contentContainerStyle={style.contentContainer}
-        alwaysBounceVertical={false}
-      >
-        {noSymptomHistory ? (
-          <GlobalText style={style.noSymptomHistoryText}>
-            {t("symptom_checker.no_symptom_history")}
-          </GlobalText>
-        ) : (
-          dailyLogData.map((logData) => {
-            return <DaySummary key={logData.date} dayLogData={logData} />
-          })
-        )}
-      </ScrollView>
+      {viewSelection === "List" ? (
+        <ScrollView
+          style={style.container}
+          contentContainerStyle={style.contentContainer}
+          alwaysBounceVertical={false}
+        >
+          {noSymptomHistory ? (
+            <GlobalText style={style.noSymptomHistoryText}>
+              {t("symptom_checker.no_symptom_history")}
+            </GlobalText>
+          ) : (
+            dailyLogData.map((logData) => {
+              return <DaySummary key={logData.date} dayLogData={logData} />
+            })
+          )}
+        </ScrollView>
+      ) : (
+        <ScrollView
+          style={style.container}
+          contentContainerStyle={style.contentContainer}
+          alwaysBounceVertical={false}
+        >
+          <Calendar
+            logDataHistory={logDataHistory}
+            onSelectDate={handleOnSelectDate}
+            selectedDay={selectedDay}
+          />
+          {selectedDay && (
+            <DaySummary
+              key={selectedDay.checkIn.date}
+              dayLogData={selectedDay}
+            />
+          )}
+        </ScrollView>
+      )}
     </>
   )
 }
@@ -289,9 +317,6 @@ const style = StyleSheet.create({
     ...Typography.header3,
     paddingRight: Spacing.xxLarge,
     paddingTop: Spacing.xxSmall,
-  },
-  hidden: {
-    display: "none",
   },
 })
 

--- a/src/MyHealth/SymptomLogContext.tsx
+++ b/src/MyHealth/SymptomLogContext.tsx
@@ -33,6 +33,8 @@ import {
 
 export type SymptomLogState = {
   dailyLogData: DayLogData[]
+  selectLogEntry: (logEntry: DayLogData) => void
+  selectedLogEntry: DayLogData | null
   addLogEntry: (symptoms: Symptom[]) => Promise<OperationResponse>
   updateLogEntry: (entry: SymptomLogEntry) => Promise<OperationResponse>
   deleteLogEntry: (symptomLogEntryId: string) => Promise<OperationResponse>
@@ -44,6 +46,8 @@ export type SymptomLogState = {
 
 const initialState: SymptomLogState = {
   dailyLogData: [],
+  selectLogEntry: (_logEntry: DayLogData) => {},
+  selectedLogEntry: null,
   addLogEntry: (_symptoms: Symptom[]) => {
     return Promise.resolve(SUCCESS_RESPONSE)
   },
@@ -74,6 +78,13 @@ export const SymptomLogProvider: FunctionComponent = ({ children }) => {
   const [todaysCheckIn, setTodaysCheckIn] = useState<CheckIn>(
     initialState.todaysCheckIn,
   )
+  const [selectedLogEntry, setSelectedLogEntry] = useState(
+    initialState.selectedLogEntry,
+  )
+
+  const selectLogEntry = (logEntry: DayLogData) => {
+    setSelectedLogEntry(logEntry)
+  }
 
   const detectTodaysCheckIn = (rawCheckIns: CheckIn[]) => {
     const checkInAddedToday = rawCheckIns.find(({ date }) => {
@@ -172,6 +183,8 @@ export const SymptomLogProvider: FunctionComponent = ({ children }) => {
         addTodaysCheckIn,
         todaysCheckIn,
         dailyLogData,
+        selectLogEntry,
+        selectedLogEntry,
         addLogEntry,
         updateLogEntry,
         deleteLogEntry,

--- a/src/MyHealth/logDataHistory.spec.ts
+++ b/src/MyHealth/logDataHistory.spec.ts
@@ -4,12 +4,6 @@ import { factories } from "../factories"
 
 describe("toLogDataHistory", () => {
   describe("when there are no logs", () => {
-    it('populates entries with "NotCheckedIn" status', () => {
-      const logDataHistory = toLogDataHistory([], 30)
-      logDataHistory.forEach((entry: DayLogData) => {
-        expect(entry.checkIn.status).toEqual(CheckInStatus.NotCheckedIn)
-      })
-    })
     it("creates the requested number of entries", () => {
       const logDataHistory = toLogDataHistory([], 30)
       expect(logDataHistory.length).toEqual(30)
@@ -30,9 +24,15 @@ describe("toLogDataHistory", () => {
         expect(
           logDataHistory.filter(
             (entry: DayLogData) =>
+              entry.checkIn.status === CheckInStatus.TooOld,
+          ).length,
+        ).toEqual(14)
+        expect(
+          logDataHistory.filter(
+            (entry: DayLogData) =>
               entry.checkIn.status === CheckInStatus.NotCheckedIn,
           ).length,
-        ).toEqual(29)
+        ).toEqual(15)
       })
     })
   })

--- a/src/MyHealth/logDataHistory.spec.ts
+++ b/src/MyHealth/logDataHistory.spec.ts
@@ -1,0 +1,39 @@
+import { CheckInStatus, DayLogData } from "./symptoms"
+import { toLogDataHistory } from "../MyHealth/logDataHistory"
+import { factories } from "../factories"
+
+describe("toLogDataHistory", () => {
+  describe("when there are no logs", () => {
+    it('populates entries with "NotCheckedIn" status', () => {
+      const logDataHistory = toLogDataHistory([], 30)
+      logDataHistory.forEach((entry: DayLogData) => {
+        expect(entry.checkIn.status).toEqual(CheckInStatus.NotCheckedIn)
+      })
+    })
+    it("creates the requested number of entries", () => {
+      const logDataHistory = toLogDataHistory([], 30)
+      expect(logDataHistory.length).toEqual(30)
+    })
+  })
+
+  describe("when there are logs", () => {
+    describe("when there are checkins", () => {
+      it("populates entries with the checkin status from each checkin", () => {
+        const logData = factories.dayLogData.build()
+        const logDataHistory = toLogDataHistory([logData], 30)
+        expect(
+          logDataHistory.filter(
+            (entry: DayLogData) =>
+              entry.checkIn.status === CheckInStatus.FeelingGood,
+          ).length,
+        ).toEqual(1)
+        expect(
+          logDataHistory.filter(
+            (entry: DayLogData) =>
+              entry.checkIn.status === CheckInStatus.NotCheckedIn,
+          ).length,
+        ).toEqual(29)
+      })
+    })
+  })
+})

--- a/src/MyHealth/logDataHistory.ts
+++ b/src/MyHealth/logDataHistory.ts
@@ -1,4 +1,5 @@
 import dayjs from "dayjs"
+import { DateTimeUtils } from "../utils"
 
 import { CheckInStatus, DayLogData } from "./symptoms"
 
@@ -19,6 +20,9 @@ export const toLogDataHistory = (
     {},
   )
   return calendar.map((date: Posix) => {
+    const status = DateTimeUtils.isOlderThan14Days(date)
+      ? CheckInStatus.TooOld
+      : CheckInStatus.NotCheckedIn
     if (dateLogDataMap[date]) {
       return dateLogDataMap[date]
     } else {
@@ -26,7 +30,7 @@ export const toLogDataHistory = (
         date,
         logEntries: [],
         checkIn: {
-          status: CheckInStatus.NotCheckedIn,
+          status: status,
           date,
         },
       }

--- a/src/MyHealth/logDataHistory.ts
+++ b/src/MyHealth/logDataHistory.ts
@@ -1,0 +1,56 @@
+import dayjs from "dayjs"
+
+import { CheckInStatus, DayLogData } from "./symptoms"
+
+export type Posix = number
+
+export const toLogDataHistory = (
+  dayLogData: DayLogData[],
+  dayCount: number,
+  now = Date.now(),
+): DayLogData[] => {
+  const calendar = calendarDays(now, dayCount)
+  const dateLogDataMap: Record<Posix, DayLogData> = dayLogData.reduce(
+    (dict, element) => {
+      const startOfDay = dayjs(element.date).startOf("day").valueOf()
+      dict[startOfDay] = element
+      return dict
+    },
+    {},
+  )
+  return calendar.map((date: Posix) => {
+    if (dateLogDataMap[date]) {
+      return dateLogDataMap[date]
+    } else {
+      return {
+        date,
+        logEntries: [],
+        checkIn: {
+          status: CheckInStatus.NotCheckedIn,
+          date,
+        },
+      }
+    }
+  })
+}
+
+export const calendarDays = (today: Posix, totalDays: number): Posix[] => {
+  const saturday = nextSaturday(today)
+
+  const daysAgo = [...Array(totalDays)].map((_v, idx: number) => {
+    return totalDays - 1 - idx
+  })
+
+  return daysAgo.map(
+    (daysAgo: number): Posix => {
+      return dayjs(saturday).subtract(daysAgo, "day").startOf("day").valueOf()
+    },
+  )
+}
+
+const nextSaturday = (date: Posix): Posix => {
+  const saturdayDayOfWeek = 6
+  const dayOfWeek = dayjs(date).day()
+  const daysUntilNextSaturday = saturdayDayOfWeek - dayOfWeek
+  return dayjs(date).add(daysUntilNextSaturday, "day").valueOf()
+}

--- a/src/MyHealth/symptoms.ts
+++ b/src/MyHealth/symptoms.ts
@@ -23,6 +23,7 @@ export type Symptom =
 
 export enum CheckInStatus {
   NotCheckedIn,
+  TooOld,
   FeelingGood,
   FeelingNotWell,
 }

--- a/src/factories/dayLogData.tsx
+++ b/src/factories/dayLogData.tsx
@@ -1,0 +1,16 @@
+import { Factory } from "fishery"
+
+import { DateTimeUtils } from "../utils"
+import { CheckInStatus, DayLogData } from "../MyHealth/symptoms"
+
+export default Factory.define<DayLogData>(() => {
+  const defaultDate = DateTimeUtils.beginningOfDay(DateTimeUtils.daysAgo(2))
+  return {
+    date: defaultDate,
+    checkIn: {
+      date: defaultDate,
+      status: CheckInStatus.FeelingGood,
+    },
+    logEntries: [],
+  }
+})

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -1,6 +1,7 @@
 import { register } from "fishery"
 import analyticsContext from "./analyticsContext"
 import configurationContext from "./configurationContext"
+import dayLogData from "./dayLogData"
 import exposureContext from "./exposureContext"
 import exposureDatum from "./exposureDatum"
 import gaenStrategy from "./gaenStrategy"
@@ -10,6 +11,7 @@ import rawExposure from "./rawExposure"
 export const factories = register({
   analyticsContext,
   configurationContext,
+  dayLogData,
   exposureContext,
   exposureDatum,
   gaenStrategy,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -346,7 +346,8 @@
     "symptom_log": {
       "feeling_well": "You were feeling well",
       "feeling_not_well": "You were not feeling well",
-      "did_not_check_in": "You did not check in"
+      "did_not_check_in": "You did not check in",
+      "too_old": "Data older than 14 days is not stored"
     }
   },
   "symptoms": {

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -50,6 +50,7 @@ export const gradientNeutral75 = [neutral75, neutral100]
 // Transparent
 export const transparent = "rgba(0, 0, 0, 0)"
 export const transparentNeutral30 = applyOpacity(neutral30, 0.4)
+export const transparentPrimaryText = applyOpacity(neutral140, 0.3)
 
 // Backgrounds
 export const primaryLightBackground = white

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -36,6 +36,10 @@ export const isInFuture = (date: Posix): boolean => {
   return date > Date.now()
 }
 
+export const isOlderThan14Days = (date: Posix): boolean => {
+  return date < daysAgo(14)
+}
+
 export const posixToDayjs = (posixDate: Posix): Dayjs | null => {
   const dayJsDate = dayjs.utc(posixDate)
   return dayJsDate.isValid() ? dayJsDate : null


### PR DESCRIPTION
### Why 
We'd like users to be able to view their longer-term (4 week) symptom log/checkin history in the form of a calenday

### This Commit 
This commit implements a calendar view containing a 4-week window of the user's checkins. Because data older than 14 days is deleted from the device, dates prior to 14 days from the current date are disabled in the calendar.

![Oct-01-2020 11-50-34](https://user-images.githubusercontent.com/2637355/94832947-8c82c180-03dc-11eb-988b-ecdaa5cee533.gif)
