### PR TITLE
Remove unused debug action.

### DIFF
--- a/ios/BT/DebugAction.swift
+++ b/ios/BT/DebugAction.swift
@@ -1,6 +1,5 @@
 @objc enum DebugAction: Int {
   case fetchDiagnosisKeys,
-  detectExposuresNow,
   simulateExposureDetectionError,
   simulateExposure,
   fetchExposures,

--- a/ios/BT/ExposureManager+Debug.swift
+++ b/ios/BT/ExposureManager+Debug.swift
@@ -29,24 +29,6 @@ extension ExposureManager: ExposureManagerDebuggable {
           resolve(keys!.map { $0.asDictionary })
         }
       }
-    case .detectExposuresNow:
-      guard btSecureStorage.userState.remainingDailyFileProcessingCapacity > 0 else {
-        let hoursRemaining = 24 - Date.hourDifference(from: btSecureStorage.userState.dateLastPerformedFileCapacityReset ?? Date(),
-                                                      to: Date())
-        reject("Time window Error.",
-               "You have reached the exposure file submission limit. Please wait \(hoursRemaining) hours before detecting exposures again.",
-          GenericError.unknown)
-        return
-      }
-
-      detectExposures { result in
-        switch result {
-        case .success(let numberOfFilesProcessed):
-          resolve("Exposure detection successfully executed. Processed \(numberOfFilesProcessed) files.")
-        case .failure(let exposureError):
-          reject(exposureError.localizedDescription, exposureError.errorDescription, exposureError)
-        }
-      }
     case .simulateExposureDetectionError:
       btSecureStorage.exposureDetectionErrorLocalizedDescription = "Unable to connect to server."
       postExposureDetectionErrorNotification("Simulated Error")

--- a/ios/BT/bridge/DebugMenuModule.m
+++ b/ios/BT/bridge/DebugMenuModule.m
@@ -21,13 +21,6 @@ RCT_EXPORT_METHOD(forceAppCrash)
   @throw [NSException exceptionWithName:NSGenericException reason:@"Forced Crash (Debug)" userInfo:nil];
 }
 
-RCT_REMAP_METHOD(detectExposuresNow,
-                 detectExposuresNowWithResolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject)
-{
-  [[ExposureManager shared] handleDebugAction:DebugActionDetectExposuresNow resolve:resolve reject:reject];
-}
-
 RCT_REMAP_METHOD(simulateExposureDetectionError,
                  simulateExposureDetectionErrorWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -712,42 +712,6 @@ class ExposureManagerTests: XCTestCase {
     wait(for: [failExpectationResolve, failExpectationReject], timeout: 0)
   }
 
-  func testDebugDetectExposuresNow() {
-    let debugAction = DebugAction.detectExposuresNow
-    let btSecureStorageMock = BTSecureStorageMock(notificationCenter: NotificationCenter())
-    btSecureStorageMock.userStateHandler = {
-      let userState = UserState()
-      userState.remainingDailyFileProcessingCapacity = 0
-      return userState
-    }
-    var exposureManager = ExposureManager(btSecureStorage: btSecureStorageMock)
-
-    let failureExpectactionResolve = self.expectation(description: "resolve is not called")
-    let failureExpectationReject = self.expectation(description: "reject is  called")
-    failureExpectactionResolve.isInverted = true
-    exposureManager.handleDebugAction(debugAction, resolve: { (success) in
-      failureExpectactionResolve.fulfill()
-    }) { (_, _, _) in
-      failureExpectationReject.fulfill()
-    }
-    wait(for: [failureExpectactionResolve, failureExpectationReject], timeout: 0)
-
-    let apiClientMock = APIClientMock { (request, requestType) -> (AnyObject) in
-      XCTAssertEqual(requestType, RequestType.downloadKeys)
-      return Result<String>.failure(GenericError.unknown) as AnyObject
-    }
-    let failExpectationResolve = self.expectation(description: "resolve is not called")
-    failExpectationResolve.isInverted = true
-    let failExpectationReject = self.expectation(description: "reject is called")
-    exposureManager = ExposureManager(apiClient: apiClientMock, btSecureStorage: btSecureStorageMock)
-    exposureManager.handleDebugAction(debugAction, resolve: { (success) in
-      failExpectationResolve.fulfill()
-    }) { (_, _, _) in
-      failExpectationReject.fulfill()
-    }
-    wait(for: [failExpectationResolve, failExpectationReject], timeout: 0)
-  }
-
   func testDebugSimulateExposureDetectionError() {
     let debugAction = DebugAction.simulateExposureDetectionError
     let enManagerMock = ENManagerMock()


### PR DESCRIPTION
### Why
The `Detect Exposures Now` button was removed from the debug menu in #464 in favor of the new button on the `Exposure History` screen

### This Commit
This commit removes the related iOS implementation