### PR TITLE
Standardize naming of Screen types

### DIFF
--- a/src/Activation/AcceptTermsOfService.tsx
+++ b/src/Activation/AcceptTermsOfService.tsx
@@ -13,7 +13,7 @@ import { SvgXml } from "react-native-svg"
 
 import { Icons } from "../assets"
 import { GlobalText, Button, GradientBackground } from "../components"
-import { ActivationScreens, useStatusBarEffect } from "../navigation"
+import { ActivationStackScreens, useStatusBarEffect } from "../navigation"
 import { useConfigurationContext } from "../ConfigurationContext"
 
 import {
@@ -33,7 +33,7 @@ const AcceptTermsOfService: FunctionComponent = () => {
   const navigation = useNavigation()
 
   const handleOnPressNext = () => {
-    navigation.navigate(ActivationScreens.ActivateProximityTracing)
+    navigation.navigate(ActivationStackScreens.ActivateProximityTracing)
   }
 
   const checkboxIcon = boxChecked

--- a/src/Activation/ActivateLocation.tsx
+++ b/src/Activation/ActivateLocation.tsx
@@ -10,7 +10,7 @@ import {
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
-import { ActivationScreens } from "../navigation"
+import { ActivationStackScreens } from "../navigation"
 import { GlobalText, Button } from "../components"
 import { useApplicationName } from "../hooks/useApplicationInfo"
 import { useSystemServicesContext } from "../SystemServicesContext"
@@ -27,12 +27,12 @@ const ActivateLocation: FunctionComponent = () => {
   useEffect(() => {
     const isLocationOn = locationPermissions === "RequiredOn"
     if (isLocationOn) {
-      navigation.navigate(ActivationScreens.ActivationSummary)
+      navigation.navigate(ActivationStackScreens.ActivationSummary)
     }
   })
 
   const handleOnPressMaybeLater = () => {
-    navigation.navigate(ActivationScreens.ActivationSummary)
+    navigation.navigate(ActivationStackScreens.ActivationSummary)
   }
 
   const showLocationAccessAlert = () => {

--- a/src/Activation/ActivateProximityTracing.tsx
+++ b/src/Activation/ActivateProximityTracing.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
 import { usePermissionsContext } from "../PermissionsContext"
-import { ActivationScreens } from "../navigation"
+import { ActivationStackScreens } from "../navigation"
 import { GlobalText, Button } from "../components"
 import { useSystemServicesContext } from "../SystemServicesContext"
 import { isPlatformiOS } from "../utils"
@@ -28,11 +28,11 @@ const ActivateProximityTracing: FunctionComponent = () => {
 
   const navigateToNextScreen = () => {
     if (isPlatformiOS()) {
-      navigation.navigate(ActivationScreens.NotificationPermissions)
+      navigation.navigate(ActivationStackScreens.NotificationPermissions)
     } else {
       isLocationRequiredAndOff
-        ? navigation.navigate(ActivationScreens.ActivateLocation)
-        : navigation.navigate(ActivationScreens.ActivationSummary)
+        ? navigation.navigate(ActivationStackScreens.ActivateLocation)
+        : navigation.navigate(ActivationStackScreens.ActivationSummary)
     }
   }
 

--- a/src/Activation/NotificationPermissions.tsx
+++ b/src/Activation/NotificationPermissions.tsx
@@ -9,7 +9,7 @@ import {
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
-import { ActivationScreens } from "../navigation"
+import { ActivationStackScreens } from "../navigation"
 import { usePermissionsContext } from "../PermissionsContext"
 import { GlobalText, Button } from "../components"
 
@@ -25,11 +25,11 @@ const NotificationsPermissions: FunctionComponent = () => {
       notification.request()
       resolve()
     })
-    navigation.navigate(ActivationScreens.ActivationSummary)
+    navigation.navigate(ActivationStackScreens.ActivationSummary)
   }
 
   const handleOnPressMaybeLater = () => {
-    navigation.navigate(ActivationScreens.ActivationSummary)
+    navigation.navigate(ActivationStackScreens.ActivationSummary)
   }
 
   return (

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
@@ -7,7 +7,7 @@ import CodeInputForm from "./CodeInputForm"
 import { AffectedUserProvider } from "../AffectedUserContext"
 import * as API from "../verificationAPI"
 import * as Hmac from "../hmac"
-import { AffectedUserFlowScreens } from "../../navigation"
+import { AffectedUserFlowStackScreens } from "../../navigation"
 import { ExposureContext } from "../../ExposureContext"
 import { factories } from "../../factories"
 
@@ -89,7 +89,7 @@ describe("CodeInputForm", () => {
         expect(apiSpy).toHaveBeenCalledWith(code)
         expect(postTokenSpy).toHaveBeenCalledWith(verificationToken, hmacDigest)
         expect(navigateSpy).toHaveBeenCalledWith(
-          AffectedUserFlowScreens.AffectedUserPublishConsent,
+          AffectedUserFlowStackScreens.AffectedUserPublishConsent,
         )
       })
     })

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -21,7 +21,7 @@ import { useExposureContext } from "../../ExposureContext"
 import {
   Stacks,
   useStatusBarEffect,
-  AffectedUserFlowScreens,
+  AffectedUserFlowStackScreens,
 } from "../../navigation"
 
 import { Icons } from "../../assets"
@@ -104,7 +104,7 @@ const CodeInputForm: FunctionComponent = () => {
           setExposureSubmissionCredentials(certificate, hmacKey)
           Keyboard.dismiss()
           navigation.navigate(
-            AffectedUserFlowScreens.AffectedUserPublishConsent,
+            AffectedUserFlowStackScreens.AffectedUserPublishConsent,
           )
         } else {
           const errorMessage = showCertificateError(certResponse.error)

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from "@react-navigation/native"
 import { Alert } from "react-native"
 
 import PublishConsentForm from "./PublishConsentForm"
-import { AffectedUserFlowScreens } from "../../navigation"
+import { AffectedUserFlowStackScreens } from "../../navigation"
 import { ExposureContext } from "../../ExposureContext"
 import { factories } from "../../factories"
 import * as ExposureAPI from "../exposureNotificationAPI"
@@ -126,7 +126,7 @@ describe("PublishConsentForm", () => {
         )
         expect(storeRevisionTokenSpy).toHaveBeenCalledWith(newRevisionToken)
         expect(navigateSpy).toHaveBeenCalledWith(
-          AffectedUserFlowScreens.AffectedUserComplete,
+          AffectedUserFlowStackScreens.AffectedUserComplete,
         )
       })
     })

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -15,8 +15,8 @@ import { ExposureKey } from "../../exposureKey"
 import { GlobalText, Button } from "../../components"
 import {
   useStatusBarEffect,
-  AffectedUserFlowScreens,
-  ModalScreens,
+  AffectedUserFlowStackScreens,
+  ModalStackScreens,
   Stacks,
 } from "../../navigation"
 import { Icons } from "../../assets"
@@ -81,7 +81,9 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
       [
         {
           onPress: () =>
-            navigation.navigate(AffectedUserFlowScreens.AffectedUserComplete),
+            navigation.navigate(
+              AffectedUserFlowStackScreens.AffectedUserComplete,
+            ),
         },
       ],
     )
@@ -131,7 +133,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
     setIsLoading(false)
     if (response.kind === "success") {
       storeRevisionToken(response.revisionToken)
-      navigation.navigate(AffectedUserFlowScreens.AffectedUserComplete)
+      navigation.navigate(AffectedUserFlowStackScreens.AffectedUserComplete)
     } else if (response.kind === "no-op") {
       handleNoOpResponse(response)
     } else {
@@ -149,7 +151,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
 
   const handleOnPressProtectPrivacy = () => {
     navigation.navigate(Stacks.Modal, {
-      screen: ModalScreens.ProtectPrivacy,
+      screen: ModalStackScreens.ProtectPrivacy,
     })
   }
 

--- a/src/AffectedUserFlow/Start.tsx
+++ b/src/AffectedUserFlow/Start.tsx
@@ -13,7 +13,7 @@ import { SvgXml } from "react-native-svg"
 import { StatusBar, GlobalText, Button } from "../components"
 import {
   useStatusBarEffect,
-  AffectedUserFlowScreens,
+  AffectedUserFlowStackScreens,
   Stacks,
 } from "../navigation"
 
@@ -26,7 +26,7 @@ export const ExportIntro: FunctionComponent = () => {
   const navigation = useNavigation()
 
   const handleOnPressNext = () => {
-    navigation.navigate(AffectedUserFlowScreens.AffectedUserCodeInput)
+    navigation.navigate(AffectedUserFlowStackScreens.AffectedUserCodeInput)
   }
 
   const handleOnPressCancel = () => {

--- a/src/AffectedUserFlow/index.tsx
+++ b/src/AffectedUserFlow/index.tsx
@@ -7,10 +7,13 @@ import CodeInput from "./CodeInput/CodeInputScreen"
 import Complete from "./Complete"
 import PublishConsent from "./PublishConsent/PublishConsentScreen"
 
-import { AffectedUserFlowScreen, AffectedUserFlowScreens } from "../navigation"
+import {
+  AffectedUserFlowStackScreen,
+  AffectedUserFlowStackScreens,
+} from "../navigation"
 
 type AffectedUserFlowStackParams = {
-  [key in AffectedUserFlowScreen]: undefined
+  [key in AffectedUserFlowStackScreen]: undefined
 }
 const Stack = createStackNavigator<AffectedUserFlowStackParams>()
 
@@ -23,19 +26,19 @@ const AffectedUserStack: FunctionComponent = () => {
         }}
       >
         <Stack.Screen
-          name={AffectedUserFlowScreens.AffectedUserStart}
+          name={AffectedUserFlowStackScreens.AffectedUserStart}
           component={Start}
         />
         <Stack.Screen
-          name={AffectedUserFlowScreens.AffectedUserCodeInput}
+          name={AffectedUserFlowStackScreens.AffectedUserCodeInput}
           component={CodeInput}
         />
         <Stack.Screen
-          name={AffectedUserFlowScreens.AffectedUserPublishConsent}
+          name={AffectedUserFlowStackScreens.AffectedUserPublishConsent}
           component={PublishConsent}
         />
         <Stack.Screen
-          name={AffectedUserFlowScreens.AffectedUserComplete}
+          name={AffectedUserFlowStackScreens.AffectedUserComplete}
           component={Complete}
         />
       </Stack.Navigator>

--- a/src/Connect/index.tsx
+++ b/src/Connect/index.tsx
@@ -11,7 +11,7 @@ import {
   loadAuthorityLinks,
   applyTranslations,
 } from "../configuration/authorityLinks"
-import { Stacks, ModalScreens, useStatusBarEffect } from "../navigation"
+import { Stacks, ModalStackScreens, useStatusBarEffect } from "../navigation"
 import {
   ListItem,
   ListItemSeparator,
@@ -58,7 +58,7 @@ const ConnectScreen: FunctionComponent = () => {
 
   const handleOnPressHowTheAppWorks = () => {
     navigation.navigate(Stacks.Modal, {
-      screen: ModalScreens.HowItWorksReviewFromConnect,
+      screen: ModalStackScreens.HowItWorksReviewFromConnect,
     })
   }
 

--- a/src/ExposureHistory/History/ExposureListItem.tsx
+++ b/src/ExposureHistory/History/ExposureListItem.tsx
@@ -8,7 +8,7 @@ import { GlobalText } from "../../components"
 import { ExposureDatum, exposureWindowBucket } from "../../exposure"
 
 import { Icons } from "../../assets"
-import { ExposureHistoryScreens } from "../../navigation"
+import { ExposureHistoryStackScreens } from "../../navigation"
 import {
   Iconography,
   Colors,
@@ -49,7 +49,7 @@ const ExposureListItem: FunctionComponent<ExposureListItemProps> = ({
       underlayColor={Colors.secondary50}
       style={style.container}
       onPress={() =>
-        navigation.navigate(ExposureHistoryScreens.ExposureDetail, {
+        navigation.navigate(ExposureHistoryStackScreens.ExposureDetail, {
           exposureDatum,
         })
       }

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -20,7 +20,7 @@ import ExposureList from "./ExposureList"
 import NoExposures from "./NoExposures"
 
 import { Icons } from "../../assets"
-import { ExposureHistoryScreens } from "../../navigation"
+import { ExposureHistoryStackScreens } from "../../navigation"
 import { Buttons, Spacing, Typography, Colors } from "../../styles"
 
 type Posix = number
@@ -42,7 +42,7 @@ const History: FunctionComponent<HistoryProps> = ({
   const previousExposuresRef = useRef<ExposureDatum[]>()
 
   const handleOnPressMoreInfo = () => {
-    navigation.navigate(ExposureHistoryScreens.MoreInfo)
+    navigation.navigate(ExposureHistoryStackScreens.MoreInfo)
   }
 
   const handleOnRefresh = () => {

--- a/src/ExposureHistory/index.tsx
+++ b/src/ExposureHistory/index.tsx
@@ -10,7 +10,7 @@ const toExposureList = (exposureInfo: ExposureInfo): ExposureDatum[] => {
   return exposureInfo
 }
 
-const ExposureHistoryScreen: FunctionComponent = () => {
+const ExposureHistoryStackScreen: FunctionComponent = () => {
   const {
     lastExposureDetectionDate,
     exposureInfo,
@@ -33,4 +33,4 @@ const ExposureHistoryScreen: FunctionComponent = () => {
   )
 }
 
-export default ExposureHistoryScreen
+export default ExposureHistoryStackScreen

--- a/src/Home/BluetoothActivationStatus.tsx
+++ b/src/Home/BluetoothActivationStatus.tsx
@@ -4,7 +4,7 @@ import { useSystemServicesContext } from "../SystemServicesContext"
 import { ActivationStatus } from "./ActivationStatus"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
-import { HomeScreens } from "../navigation"
+import { HomeStackScreens } from "../navigation"
 import { openAppSettings } from "../gaen/nativeModule"
 
 export const BluetoothActivationStatus: FunctionComponent = () => {
@@ -17,7 +17,7 @@ export const BluetoothActivationStatus: FunctionComponent = () => {
   }
 
   const handleOnPressShowInfo = () => {
-    navigation.navigate(HomeScreens.BluetoothInfo)
+    navigation.navigate(HomeStackScreens.BluetoothInfo)
   }
 
   const showFixBluetoothAlert = () => {

--- a/src/Home/LocationActivationStatus.tsx
+++ b/src/Home/LocationActivationStatus.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next"
 
 import { useSystemServicesContext } from "../SystemServicesContext"
 import { ActivationStatus } from "./ActivationStatus"
-import { HomeScreens } from "../navigation"
+import { HomeStackScreens } from "../navigation"
 import { openAppSettings } from "../gaen/nativeModule"
 
 export const LocationActivationStatus: FunctionComponent = () => {
@@ -18,7 +18,7 @@ export const LocationActivationStatus: FunctionComponent = () => {
   }
 
   const handleOnPressShowInfo = () => {
-    navigation.navigate(HomeScreens.LocationInfo)
+    navigation.navigate(HomeStackScreens.LocationInfo)
   }
 
   const showFixLocationAlert = () => {

--- a/src/Home/ProximityTracingActivationStatus.tsx
+++ b/src/Home/ProximityTracingActivationStatus.tsx
@@ -7,7 +7,7 @@ import {
   usePermissionsContext,
   ENPermissionStatus,
 } from "../PermissionsContext"
-import { HomeScreens } from "../navigation"
+import { HomeStackScreens } from "../navigation"
 import { ActivationStatus } from "./ActivationStatus"
 import { useApplicationName } from "../hooks/useApplicationInfo"
 import { openAppSettings } from "../gaen/nativeModule"
@@ -59,7 +59,7 @@ export const ProximityTracingActivationStatus: FunctionComponent = () => {
   }
 
   const handleOnPressShowInfo = () => {
-    navigation.navigate(HomeScreens.ProximityTracingInfo)
+    navigation.navigate(HomeStackScreens.ProximityTracingInfo)
   }
 
   const isENEnabled = status === ENPermissionStatus.ENABLED

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -23,7 +23,7 @@ import {
   ENPermissionStatus,
 } from "../PermissionsContext"
 import { useSystemServicesContext } from "../SystemServicesContext"
-import { ModalScreens, useStatusBarEffect, Stacks } from "../navigation"
+import { ModalStackScreens, useStatusBarEffect, Stacks } from "../navigation"
 import { useApplicationName } from "../hooks/useApplicationInfo"
 import {
   StatusBar,
@@ -73,7 +73,7 @@ const Home: FunctionComponent = () => {
 
   const handleOnPressReportTestResult = () => {
     navigation.navigate(Stacks.Modal, {
-      screen: ModalScreens.AffectedUserStack,
+      screen: ModalStackScreens.AffectedUserStack,
     })
   }
 

--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -34,13 +34,13 @@ type HowItWorksScreenContent = {
 }
 
 interface HowItWorksScreenProps {
-  HowItWorksScreenContent: HowItWorksScreenContent
+  howItWorksScreenContent: HowItWorksScreenContent
   totalScreenCount: number
   destinationOnSkip: Stack
 }
 
-const HowItWorksStackScreen: FunctionComponent<HowItWorksScreenProps> = ({
-  HowItWorksScreenContent,
+const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
+  howItWorksScreenContent,
   totalScreenCount,
   destinationOnSkip,
 }) => {
@@ -100,18 +100,18 @@ const HowItWorksStackScreen: FunctionComponent<HowItWorksScreenProps> = ({
         >
           <View>
             <Image
-              source={HowItWorksScreenContent.image}
-              accessibilityLabel={HowItWorksScreenContent.imageLabel}
+              source={howItWorksScreenContent.image}
+              accessibilityLabel={howItWorksScreenContent.imageLabel}
               accessible
               style={style.image}
               resizeMode={"contain"}
             />
             <PositionDots
-              highlightedDotIdx={HowItWorksScreenContent.screenNumber}
+              highlightedDotIdx={howItWorksScreenContent.screenNumber}
               totalDotCount={totalScreenCount}
             />
             <GlobalText style={style.headerText}>
-              {HowItWorksScreenContent.header}
+              {howItWorksScreenContent.header}
             </GlobalText>
           </View>
         </ScrollView>
@@ -120,8 +120,8 @@ const HowItWorksStackScreen: FunctionComponent<HowItWorksScreenProps> = ({
             <Button
               customButtonStyle={style.nextButton}
               customButtonInnerStyle={style.nextButtonGradient}
-              label={HowItWorksScreenContent.primaryButtonLabel}
-              onPress={HowItWorksScreenContent.primaryButtonOnPress}
+              label={howItWorksScreenContent.primaryButtonLabel}
+              onPress={howItWorksScreenContent.primaryButtonOnPress}
               hasRightArrow
             />
             <TouchableOpacity onPress={handleOnPressProtectPrivacy}>
@@ -272,6 +272,6 @@ const dotsStyle = StyleSheet.create({
   },
 })
 
-const MemoizedHowItWorksStackScreen = React.memo(HowItWorksStackScreen)
+const MemoizedHowItWorksScreen = React.memo(HowItWorksScreen)
 
-export default MemoizedHowItWorksStackScreen
+export default MemoizedHowItWorksScreen

--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -14,7 +14,12 @@ import { useTranslation } from "react-i18next"
 import LinearGradient from "react-native-linear-gradient"
 import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 import { StatusBar, GlobalText, Button } from "../components"
-import { ModalScreens, Stacks, Stack, useStatusBarEffect } from "../navigation"
+import {
+  ModalStackScreens,
+  Stacks,
+  Stack,
+  useStatusBarEffect,
+} from "../navigation"
 import { getLocalNames } from "../locales/languages"
 
 import { Layout, Outlines, Colors, Spacing, Typography } from "../styles"
@@ -29,13 +34,13 @@ type HowItWorksScreenContent = {
 }
 
 interface HowItWorksScreenProps {
-  howItWorksScreenContent: HowItWorksScreenContent
+  HowItWorksScreenContent: HowItWorksScreenContent
   totalScreenCount: number
   destinationOnSkip: Stack
 }
 
-const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
-  howItWorksScreenContent,
+const HowItWorksStackScreen: FunctionComponent<HowItWorksScreenProps> = ({
+  HowItWorksScreenContent,
   totalScreenCount,
   destinationOnSkip,
 }) => {
@@ -51,7 +56,7 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
 
   const handleOnPressSelectLanguage = () => {
     navigation.navigate(Stacks.Modal, {
-      screen: ModalScreens.LanguageSelection,
+      screen: ModalStackScreens.LanguageSelection,
     })
   }
 
@@ -60,7 +65,9 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
   }
 
   const handleOnPressProtectPrivacy = () => {
-    navigation.navigate(Stacks.Modal, { screen: ModalScreens.ProtectPrivacy })
+    navigation.navigate(Stacks.Modal, {
+      screen: ModalStackScreens.ProtectPrivacy,
+    })
   }
 
   return (
@@ -93,18 +100,18 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
         >
           <View>
             <Image
-              source={howItWorksScreenContent.image}
-              accessibilityLabel={howItWorksScreenContent.imageLabel}
+              source={HowItWorksScreenContent.image}
+              accessibilityLabel={HowItWorksScreenContent.imageLabel}
               accessible
               style={style.image}
               resizeMode={"contain"}
             />
             <PositionDots
-              highlightedDotIdx={howItWorksScreenContent.screenNumber}
+              highlightedDotIdx={HowItWorksScreenContent.screenNumber}
               totalDotCount={totalScreenCount}
             />
             <GlobalText style={style.headerText}>
-              {howItWorksScreenContent.header}
+              {HowItWorksScreenContent.header}
             </GlobalText>
           </View>
         </ScrollView>
@@ -113,8 +120,8 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
             <Button
               customButtonStyle={style.nextButton}
               customButtonInnerStyle={style.nextButtonGradient}
-              label={howItWorksScreenContent.primaryButtonLabel}
-              onPress={howItWorksScreenContent.primaryButtonOnPress}
+              label={HowItWorksScreenContent.primaryButtonLabel}
+              onPress={HowItWorksScreenContent.primaryButtonOnPress}
               hasRightArrow
             />
             <TouchableOpacity onPress={handleOnPressProtectPrivacy}>
@@ -265,6 +272,6 @@ const dotsStyle = StyleSheet.create({
   },
 })
 
-const MemoizedHowItWorksScreen = React.memo(HowItWorksScreen)
+const MemoizedHowItWorksStackScreen = React.memo(HowItWorksStackScreen)
 
-export default MemoizedHowItWorksScreen
+export default MemoizedHowItWorksStackScreen

--- a/src/MyHealth/SelectSymptoms.spec.tsx
+++ b/src/MyHealth/SelectSymptoms.spec.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent, waitFor } from "@testing-library/react-native"
 import { useNavigation, useRoute } from "@react-navigation/native"
 
 import SelectSymptomsScreen from "./SelectSymptoms"
-import { Stacks, ModalScreens } from "../navigation"
+import { Stacks, ModalStackScreens } from "../navigation"
 import { SymptomLogContext } from "./SymptomLogContext"
 import { factories } from "../factories"
 
@@ -51,7 +51,7 @@ describe("SelectSymptomsScreen", () => {
             symptoms: ["cough", "fever"],
           })
           expect(navigateSpy).toHaveBeenCalledWith(Stacks.Modal, {
-            screen: ModalScreens.AtRiskRecommendation,
+            screen: ModalStackScreens.AtRiskRecommendation,
           })
         })
       })
@@ -215,7 +215,7 @@ describe("SelectSymptomsScreen", () => {
         await waitFor(() => {
           expect(addLogEntrySpy).toHaveBeenCalledWith([coughSymptom])
           expect(navigateSpy).toHaveBeenCalledWith(Stacks.Modal, {
-            screen: ModalScreens.AtRiskRecommendation,
+            screen: ModalStackScreens.AtRiskRecommendation,
           })
         })
       })

--- a/src/MyHealth/SelectSymptoms.tsx
+++ b/src/MyHealth/SelectSymptoms.tsx
@@ -9,7 +9,7 @@ import {
 import { useTranslation } from "react-i18next"
 import { useNavigation, useRoute, RouteProp } from "@react-navigation/native"
 
-import { useStatusBarEffect, Stacks, ModalScreens } from "../navigation"
+import { useStatusBarEffect, Stacks, ModalStackScreens } from "../navigation"
 import { useSymptomLogContext } from "./SymptomLogContext"
 import { GlobalText, Button, StatusBar } from "../components"
 import {
@@ -138,7 +138,7 @@ const SelectSymptomsScreen: FunctionComponent = () => {
     const currentHealthAssessment = determineHealthAssessment(selectedSymptoms)
     if (currentHealthAssessment === HealthAssessment.AtRisk) {
       navigation.navigate(Stacks.Modal, {
-        screen: ModalScreens.AtRiskRecommendation,
+        screen: ModalStackScreens.AtRiskRecommendation,
       })
     } else {
       navigation.goBack()

--- a/src/Settings/ENDebugMenu.tsx
+++ b/src/Settings/ENDebugMenu.tsx
@@ -14,7 +14,7 @@ import { GlobalText } from "../components"
 import { useOnboardingContext } from "../OnboardingContext"
 import { useSymptomLogContext } from "../MyHealth/SymptomLogContext"
 import { NativeModule } from "../gaen"
-import { NavigationProp, SettingsScreens } from "../navigation"
+import { NavigationProp, SettingsStackScreens } from "../navigation"
 import { useStatusBarEffect } from "../navigation/index"
 
 import { Colors, Spacing, Typography, Outlines } from "../styles"
@@ -123,7 +123,7 @@ const ENDebugMenu: FunctionComponent<ENDebugMenuProps> = ({ navigation }) => {
             <DebugMenuListItem
               label="Show Local Diagnosis Keys"
               onPress={() => {
-                navigation.navigate(SettingsScreens.ENLocalDiagnosisKey)
+                navigation.navigate(SettingsStackScreens.ENLocalDiagnosisKey)
               }}
             />
             <DebugMenuListItem
@@ -155,7 +155,9 @@ const ENDebugMenu: FunctionComponent<ENDebugMenuProps> = ({ navigation }) => {
             <DebugMenuListItem
               label="Show Exposures"
               onPress={() => {
-                navigation.navigate(SettingsScreens.ExposureListDebugScreen)
+                navigation.navigate(
+                  SettingsStackScreens.ExposureListDebugScreen,
+                )
               }}
             />
             <DebugMenuListItem

--- a/src/Settings/ShareAnonymizedDataListItem.spec.tsx
+++ b/src/Settings/ShareAnonymizedDataListItem.spec.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from "@react-navigation/native"
 import { AnalyticsContext } from "../AnalyticsContext"
 import ShareAnonymizedDataListItem from "./ShareAnonymizedDataListItem"
 import { factories } from "../factories"
-import { ModalScreens, Stacks } from "../navigation"
+import { ModalStackScreens, Stacks } from "../navigation"
 
 jest.mock("@react-navigation/native")
 describe("ShareAnonymizedDataListItem", () => {
@@ -60,7 +60,7 @@ describe("ShareAnonymizedDataListItem", () => {
     const shareDataListItem = getByText("Share Anonymized Data")
     fireEvent.press(shareDataListItem)
     expect(navigationSpy).toHaveBeenCalledWith(Stacks.Modal, {
-      screen: ModalScreens.AnonymizedDataConsent,
+      screen: ModalStackScreens.AnonymizedDataConsent,
     })
   })
 })

--- a/src/Settings/ShareAnonymizedDataListItem.tsx
+++ b/src/Settings/ShareAnonymizedDataListItem.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next"
 
 import { useAnalyticsContext } from "../AnalyticsContext"
 import { GlobalText } from "../components"
-import { ModalScreens, Stacks } from "../navigation"
+import { ModalStackScreens, Stacks } from "../navigation"
 import { Icons } from "../assets"
 import { Colors, Iconography, Typography, Spacing } from "../styles"
 
@@ -17,7 +17,7 @@ const ShareAnonymizedDataListItem: FunctionComponent = () => {
 
   const onPressShareAnonymizedData = () => {
     navigation.navigate(Stacks.Modal, {
-      screen: ModalScreens.AnonymizedDataConsent,
+      screen: ModalStackScreens.AnonymizedDataConsent,
     })
   }
 

--- a/src/Settings/index.tsx
+++ b/src/Settings/index.tsx
@@ -8,8 +8,8 @@ import { getLocalNames } from "../locales/languages"
 import {
   useStatusBarEffect,
   Stacks,
-  ModalScreens,
-  SettingsScreens,
+  ModalStackScreens,
+  SettingsStackScreens,
 } from "../navigation"
 import { useConfigurationContext } from "../ConfigurationContext"
 import { ListItem, ListItemSeparator } from "../components"
@@ -37,13 +37,13 @@ const Settings: FunctionComponent = () => {
 
   const handleOnPressSelectLanguage = () => {
     navigation.navigate(Stacks.Modal, {
-      screen: ModalScreens.LanguageSelection,
+      screen: ModalStackScreens.LanguageSelection,
     })
   }
 
   const handleOnPressHowTheAppWorks = () => {
     navigation.navigate(Stacks.Modal, {
-      screen: ModalScreens.HowItWorksReviewFromSettings,
+      screen: ModalStackScreens.HowItWorksReviewFromSettings,
     })
   }
 
@@ -54,7 +54,7 @@ const Settings: FunctionComponent = () => {
   }
   const legal: SettingsListItem = {
     label: t("screen_titles.legal"),
-    onPress: () => navigation.navigate(SettingsScreens.Legal),
+    onPress: () => navigation.navigate(SettingsStackScreens.Legal),
     icon: Icons.Document,
   }
   const howTheAppWorks: SettingsListItem = {
@@ -64,7 +64,7 @@ const Settings: FunctionComponent = () => {
   }
   const debugMenu: SettingsListItem = {
     label: "EN Debug Menu",
-    onPress: () => navigation.navigate(SettingsScreens.ENDebugMenu),
+    onPress: () => navigation.navigate(SettingsStackScreens.ENDebugMenu),
     icon: Icons.Document,
   }
 

--- a/src/Welcome.tsx
+++ b/src/Welcome.tsx
@@ -13,7 +13,7 @@ import LinearGradient from "react-native-linear-gradient"
 import { StatusBar, GlobalText, Button, GradientBackground } from "./components"
 import { getLocalNames } from "./locales/languages"
 import { useApplicationName } from "./hooks/useApplicationInfo"
-import { ModalScreens, useStatusBarEffect, Stacks } from "./navigation"
+import { ModalStackScreens, useStatusBarEffect, Stacks } from "./navigation"
 import {
   loadAuthorityCopy,
   authorityCopyTranslation,
@@ -40,7 +40,7 @@ const Welcome: FunctionComponent = () => {
 
   const handleOnPressSelectLanguage = () => {
     navigation.navigate(Stacks.Modal, {
-      screen: ModalScreens.LanguageSelection,
+      screen: ModalStackScreens.LanguageSelection,
     })
   }
 

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -9,7 +9,7 @@ import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
 import { GlobalText } from "../components"
-import { Stacks, ActivationScreen, ActivationScreens } from "./index"
+import { Stacks, ActivationStackScreen, ActivationStackScreens } from "./index"
 import { useSystemServicesContext } from "../SystemServicesContext"
 
 import ActivateProximityTracing from "../Activation/ActivateProximityTracing"
@@ -23,7 +23,7 @@ import AcceptTermsOfService from "../Activation/AcceptTermsOfService"
 import { useConfigurationContext } from "../ConfigurationContext"
 
 type ActivationStackParams = {
-  [key in ActivationScreen]: undefined
+  [key in ActivationStackScreen]: undefined
 }
 
 const Stack = createStackNavigator<ActivationStackParams>()
@@ -35,27 +35,27 @@ const ActivationStack: FunctionComponent = () => {
   const { displayAcceptTermsOfService } = useConfigurationContext()
 
   interface ActivationStep {
-    screenName: ActivationScreen
+    screenName: ActivationStackScreen
     component: FunctionComponent
   }
 
   const acceptTermsOfServiceStep: ActivationStep = {
-    screenName: ActivationScreens.AcceptTermsOfService,
+    screenName: ActivationStackScreens.AcceptTermsOfService,
     component: AcceptTermsOfService,
   }
 
   const activateProximityTracing: ActivationStep = {
-    screenName: ActivationScreens.ActivateProximityTracing,
+    screenName: ActivationStackScreens.ActivateProximityTracing,
     component: ActivateProximityTracing,
   }
 
   const activateLocation: ActivationStep = {
-    screenName: ActivationScreens.ActivateLocation,
+    screenName: ActivationStackScreens.ActivateLocation,
     component: ActivateLocation,
   }
 
   const notificationPermissions: ActivationStep = {
-    screenName: ActivationScreens.NotificationPermissions,
+    screenName: ActivationStackScreens.NotificationPermissions,
     component: NotificationPermissions,
   }
 
@@ -135,7 +135,7 @@ const ActivationStack: FunctionComponent = () => {
 
   return (
     <Stack.Navigator
-      initialRouteName={ActivationScreens.AcceptTermsOfService}
+      initialRouteName={ActivationStackScreens.AcceptTermsOfService}
       screenOptions={screenOptions}
     >
       {activationSteps.map((step, idx) => {
@@ -156,7 +156,7 @@ const ActivationStack: FunctionComponent = () => {
         )
       })}
       <Stack.Screen
-        name={ActivationScreens.ActivationSummary}
+        name={ActivationStackScreens.ActivationSummary}
         component={ActivationSummary}
         options={{
           headerRight: () => HeaderRight({}),

--- a/src/navigation/ExposureHistoryStack.tsx
+++ b/src/navigation/ExposureHistoryStack.tsx
@@ -3,12 +3,12 @@ import { useNavigation } from "@react-navigation/native"
 import { createStackNavigator, HeaderBackButton } from "@react-navigation/stack"
 import { useTranslation } from "react-i18next"
 
-import ExposureHistoryScreen from "../ExposureHistory/index"
+import ExposureHistoryStackScreen from "../ExposureHistory/index"
 import MoreInfo from "../ExposureHistory/MoreInfo"
 import ExposureDetail from "../ExposureHistory/ExposureDetail"
 import {
-  ExposureHistoryScreens,
-  ExposureHistoryScreen as Screen,
+  ExposureHistoryStackScreens,
+  ExposureHistoryStackScreen as Screen,
 } from "./index"
 
 import { Headers, Colors } from "../styles"
@@ -24,12 +24,12 @@ const ExposureHistoryStack: FunctionComponent = () => {
   return (
     <Stack.Navigator>
       <Stack.Screen
-        name={ExposureHistoryScreens.ExposureHistory}
-        component={ExposureHistoryScreen}
+        name={ExposureHistoryStackScreens.ExposureHistory}
+        component={ExposureHistoryStackScreen}
         options={{ headerShown: false }}
       />
       <Stack.Screen
-        name={ExposureHistoryScreens.MoreInfo}
+        name={ExposureHistoryStackScreens.MoreInfo}
         component={MoreInfo}
         options={{
           ...Headers.headerScreenOptions,
@@ -37,7 +37,7 @@ const ExposureHistoryStack: FunctionComponent = () => {
         }}
       />
       <Stack.Screen
-        name={ExposureHistoryScreens.ExposureDetail}
+        name={ExposureHistoryStackScreens.ExposureDetail}
         component={ExposureDetail}
         options={{
           ...Headers.headerLightOptions,

--- a/src/navigation/ExposureHistoryStack.tsx
+++ b/src/navigation/ExposureHistoryStack.tsx
@@ -3,18 +3,18 @@ import { useNavigation } from "@react-navigation/native"
 import { createStackNavigator, HeaderBackButton } from "@react-navigation/stack"
 import { useTranslation } from "react-i18next"
 
-import ExposureHistoryStackScreen from "../ExposureHistory/index"
+import ExposureHistoryScreen from "../ExposureHistory/index"
 import MoreInfo from "../ExposureHistory/MoreInfo"
 import ExposureDetail from "../ExposureHistory/ExposureDetail"
 import {
   ExposureHistoryStackScreens,
-  ExposureHistoryStackScreen as Screen,
+  ExposureHistoryStackScreen,
 } from "./index"
 
 import { Headers, Colors } from "../styles"
 
 type ExposureHistoryStackParams = {
-  [key in Screen]: undefined
+  [key in ExposureHistoryStackScreen]: undefined
 }
 const Stack = createStackNavigator<ExposureHistoryStackParams>()
 
@@ -25,7 +25,7 @@ const ExposureHistoryStack: FunctionComponent = () => {
     <Stack.Navigator>
       <Stack.Screen
         name={ExposureHistoryStackScreens.ExposureHistory}
-        component={ExposureHistoryStackScreen}
+        component={ExposureHistoryScreen}
         options={{ headerShown: false }}
       />
       <Stack.Screen

--- a/src/navigation/HomeStack.tsx
+++ b/src/navigation/HomeStack.tsx
@@ -4,7 +4,7 @@ import {
   TransitionPresets,
 } from "@react-navigation/stack"
 
-import { HomeScreens } from "./index"
+import { HomeStackScreens } from "./index"
 import Home from "../Home"
 import BluetoothInfo from "../Home/BluetoothInfo"
 import ProximityTracingInfo from "../Home/ProximityTracingInfo"
@@ -26,19 +26,19 @@ const cardScreenOptions = {
 const HomeStack: FunctionComponent = () => {
   return (
     <Stack.Navigator screenOptions={screenOptions}>
-      <Stack.Screen name={HomeScreens.Home} component={Home} />
+      <Stack.Screen name={HomeStackScreens.Home} component={Home} />
       <Stack.Screen
-        name={HomeScreens.BluetoothInfo}
+        name={HomeStackScreens.BluetoothInfo}
         component={BluetoothInfo}
         options={cardScreenOptions}
       />
       <Stack.Screen
-        name={HomeScreens.ProximityTracingInfo}
+        name={HomeStackScreens.ProximityTracingInfo}
         component={ProximityTracingInfo}
         options={cardScreenOptions}
       />
       <Stack.Screen
-        name={HomeScreens.LocationInfo}
+        name={HomeStackScreens.LocationInfo}
         component={LocationInfo}
         options={cardScreenOptions}
       />

--- a/src/navigation/HowItWorksStack.tsx
+++ b/src/navigation/HowItWorksStack.tsx
@@ -5,8 +5,8 @@ import { useNavigation } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
 
 import {
-  HowItWorksScreen as HowItWorksScreenType,
-  HowItWorksScreens,
+  HowItWorksStackScreen,
+  HowItWorksStackScreens,
   Stack as StackType,
 } from "../navigation/index"
 import HowItWorksScreen from "../HowItWorks/HowItWorksScreen"
@@ -20,7 +20,7 @@ interface HowItWorksStackProps {
 }
 
 type HowItWorksScreenDatum = {
-  name: HowItWorksScreenType
+  name: HowItWorksStackScreen
   image: ImageSourcePropType
   imageLabel: string
   header: string
@@ -35,43 +35,43 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
   const navigation = useNavigation()
 
   const introduction: HowItWorksScreenDatum = {
-    name: HowItWorksScreens.Introduction,
+    name: HowItWorksStackScreens.Introduction,
     image: Images.HowItWorksIntroduction,
     imageLabel: t("onboarding.screen1_image_label"),
     header: t("onboarding.screen1_header"),
     primaryButtonLabel: t("onboarding.screen1_button"),
     primaryButtonOnPress: () =>
-      navigation.navigate(HowItWorksScreens.PhoneRemembersDevices),
+      navigation.navigate(HowItWorksStackScreens.PhoneRemembersDevices),
   }
   const phoneRemembersDevices: HowItWorksScreenDatum = {
-    name: HowItWorksScreens.PhoneRemembersDevices,
+    name: HowItWorksStackScreens.PhoneRemembersDevices,
     image: Images.HowItWorksPhoneRemembersDevice,
     imageLabel: t("onboarding.screen2_image_label"),
     header: t("onboarding.screen2_header"),
     primaryButtonLabel: t("onboarding.screen2_button"),
     primaryButtonOnPress: () =>
-      navigation.navigate(HowItWorksScreens.PersonalPrivacy),
+      navigation.navigate(HowItWorksStackScreens.PersonalPrivacy),
   }
   const personalPrivacy: HowItWorksScreenDatum = {
-    name: HowItWorksScreens.PersonalPrivacy,
+    name: HowItWorksStackScreens.PersonalPrivacy,
     image: Images.HowItWorksPersonalPrivacy,
     imageLabel: t("onboarding.screen3_image_label"),
     header: t("onboarding.screen3_header"),
     primaryButtonLabel: t("onboarding.screen3_button"),
     primaryButtonOnPress: () =>
-      navigation.navigate(HowItWorksScreens.GetNotified),
+      navigation.navigate(HowItWorksStackScreens.GetNotified),
   }
   const getNotified: HowItWorksScreenDatum = {
-    name: HowItWorksScreens.GetNotified,
+    name: HowItWorksStackScreens.GetNotified,
     image: Images.HowItWorksGetNotified,
     imageLabel: t("onboarding.screen4_image_label"),
     header: t("onboarding.screen4_header"),
     primaryButtonLabel: t("onboarding.screen4_button"),
     primaryButtonOnPress: () =>
-      navigation.navigate(HowItWorksScreens.ValueProposition),
+      navigation.navigate(HowItWorksStackScreens.ValueProposition),
   }
   const valueProposition: HowItWorksScreenDatum = {
-    name: HowItWorksScreens.ValueProposition,
+    name: HowItWorksStackScreens.ValueProposition,
     image: Images.HowItWorksValueProposition,
     imageLabel: t("onboarding.screen5_image_label"),
     header: t("onboarding.screen5_header"),
@@ -81,7 +81,7 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
     },
   }
 
-  const howItWorksScreenData: HowItWorksScreenDatum[] = [
+  const HowItWorksScreenData: HowItWorksScreenDatum[] = [
     introduction,
     phoneRemembersDevices,
     personalPrivacy,
@@ -91,21 +91,21 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
 
   const toStackScreen = (datum: HowItWorksScreenDatum, idx: number) => {
     const screenNumber = idx + 1
-    const howItWorksScreenDisplayDatum = {
+    const HowItWorksScreenDisplayDatum = {
       screenNumber,
       ...datum,
     }
 
     return (
       <Stack.Screen
-        key={howItWorksScreenDisplayDatum.header}
-        name={howItWorksScreenDisplayDatum.name}
+        key={HowItWorksScreenDisplayDatum.header}
+        name={HowItWorksScreenDisplayDatum.name}
       >
         {(props) => (
           <HowItWorksScreen
             {...props}
-            howItWorksScreenContent={howItWorksScreenDisplayDatum}
-            totalScreenCount={howItWorksScreenData.length}
+            HowItWorksScreenContent={HowItWorksScreenDisplayDatum}
+            totalScreenCount={HowItWorksScreenData.length}
             destinationOnSkip={destinationOnSkip}
           />
         )}
@@ -115,7 +115,7 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
 
   return (
     <Stack.Navigator headerMode="none">
-      {howItWorksScreenData.map((data, idx) => toStackScreen(data, idx))}
+      {HowItWorksScreenData.map((data, idx) => toStackScreen(data, idx))}
     </Stack.Navigator>
   )
 }

--- a/src/navigation/HowItWorksStack.tsx
+++ b/src/navigation/HowItWorksStack.tsx
@@ -81,7 +81,7 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
     },
   }
 
-  const HowItWorksScreenData: HowItWorksScreenDatum[] = [
+  const howItWorksScreenData: HowItWorksScreenDatum[] = [
     introduction,
     phoneRemembersDevices,
     personalPrivacy,
@@ -91,21 +91,21 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
 
   const toStackScreen = (datum: HowItWorksScreenDatum, idx: number) => {
     const screenNumber = idx + 1
-    const HowItWorksScreenDisplayDatum = {
+    const howItWorksScreenDisplayDatum = {
       screenNumber,
       ...datum,
     }
 
     return (
       <Stack.Screen
-        key={HowItWorksScreenDisplayDatum.header}
-        name={HowItWorksScreenDisplayDatum.name}
+        key={howItWorksScreenDisplayDatum.header}
+        name={howItWorksScreenDisplayDatum.name}
       >
         {(props) => (
           <HowItWorksScreen
             {...props}
-            HowItWorksScreenContent={HowItWorksScreenDisplayDatum}
-            totalScreenCount={HowItWorksScreenData.length}
+            howItWorksScreenContent={howItWorksScreenDisplayDatum}
+            totalScreenCount={howItWorksScreenData.length}
             destinationOnSkip={destinationOnSkip}
           />
         )}
@@ -115,7 +115,7 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
 
   return (
     <Stack.Navigator headerMode="none">
-      {HowItWorksScreenData.map((data, idx) => toStackScreen(data, idx))}
+      {howItWorksScreenData.map((data, idx) => toStackScreen(data, idx))}
     </Stack.Navigator>
   )
 }

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -11,7 +11,7 @@ import {
 } from "@react-navigation/native"
 
 import { useOnboardingContext } from "../OnboardingContext"
-import { WelcomeScreens, Stacks } from "./index"
+import { WelcomeStackScreens, Stacks } from "./index"
 import MainTabNavigator from "./MainTabNavigator"
 import HowItWorksStack from "./HowItWorksStack"
 import ActivationStack from "./ActivationStack"
@@ -97,7 +97,7 @@ const MainNavigator: FunctionComponent = () => {
         ) : (
           <>
             <Stack.Screen
-              name={WelcomeScreens.Welcome}
+              name={WelcomeStackScreens.Welcome}
               component={Welcome}
               options={defaultScreenOptions}
             />

--- a/src/navigation/ModalStack.tsx
+++ b/src/navigation/ModalStack.tsx
@@ -4,7 +4,7 @@ import {
   TransitionPresets,
 } from "@react-navigation/stack"
 
-import { Stacks, ModalScreens } from "./index"
+import { Stacks, ModalStackScreens } from "./index"
 import LanguageSelection from "../modals/LanguageSelection"
 import ProtectPrivacy from "../modals/ProtectPrivacy"
 import AffectedUserStack from "../AffectedUserFlow/"
@@ -18,12 +18,12 @@ const ModalStack: FunctionComponent = () => {
   return (
     <Stack.Navigator headerMode="none">
       <Stack.Screen
-        name={ModalScreens.LanguageSelection}
+        name={ModalStackScreens.LanguageSelection}
         component={LanguageSelection}
         options={TransitionPresets.ModalTransition}
       />
       <Stack.Screen
-        name={ModalScreens.ProtectPrivacy}
+        name={ModalStackScreens.ProtectPrivacy}
         component={ProtectPrivacy}
         options={TransitionPresets.ModalTransition}
       />
@@ -45,11 +45,11 @@ const ModalStack: FunctionComponent = () => {
         )}
       </Stack.Screen>
       <Stack.Screen
-        name={ModalScreens.AnonymizedDataConsent}
+        name={ModalStackScreens.AnonymizedDataConsent}
         component={AnonymizedDataConsentScreen}
       />
       <Stack.Screen
-        name={ModalScreens.AtRiskRecommendation}
+        name={ModalStackScreens.AtRiskRecommendation}
         component={AtRiskRecommendationScreen}
         options={{
           ...TransitionPresets.ModalTransition,

--- a/src/navigation/SelfScreenerStack.tsx
+++ b/src/navigation/SelfScreenerStack.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react"
 import { createStackNavigator } from "@react-navigation/stack"
-import { SelfScreenerScreens } from "."
+import { SelfScreenerStackScreens } from "."
 import SelfScreenerIntro from "../SelfScreener/SelfScreenerIntro"
 
 const Stack = createStackNavigator()
@@ -8,7 +8,7 @@ const SelfAssessmentStack: FunctionComponent = () => {
   return (
     <Stack.Navigator>
       <Stack.Screen
-        name={SelfScreenerScreens.SelfScreenerIntro}
+        name={SelfScreenerStackScreens.SelfScreenerIntro}
         component={SelfScreenerIntro}
         options={{ headerShown: false }}
       />

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -12,7 +12,7 @@ import Legal from "../Settings/Legal"
 import ENDebugMenu from "../Settings/ENDebugMenu"
 import ENLocalDiagnosisKey from "../Settings/ENLocalDiagnosisKeyScreen"
 import ExposureListDebug from "../Settings/ExposureListDebugScreen"
-import { SettingsScreens } from "./index"
+import { SettingsStackScreens } from "./index"
 
 import { Colors, Headers } from "../styles"
 
@@ -52,24 +52,24 @@ const SettingsStack: FunctionComponent = () => {
 
   return (
     <Stack.Navigator screenOptions={defaultScreenOptions}>
-      <Stack.Screen name={SettingsScreens.Settings} component={Settings} />
+      <Stack.Screen name={SettingsStackScreens.Settings} component={Settings} />
       <Stack.Screen
-        name={SettingsScreens.Legal}
+        name={SettingsStackScreens.Legal}
         component={Legal}
         options={{ headerTitle: t("screen_titles.legal") }}
       />
       <Stack.Screen
-        name={SettingsScreens.ENDebugMenu}
+        name={SettingsStackScreens.ENDebugMenu}
         component={ENDebugMenu}
         options={{ headerTitle: t("screen_titles.debug") }}
       />
       <Stack.Screen
-        name={SettingsScreens.ExposureListDebugScreen}
+        name={SettingsStackScreens.ExposureListDebugScreen}
         component={ExposureListDebug}
         options={{ headerTitle: t("screen_titles.exposures") }}
       />
       <Stack.Screen
-        name={SettingsScreens.ENLocalDiagnosisKey}
+        name={SettingsStackScreens.ENLocalDiagnosisKey}
         component={ENLocalDiagnosisKey}
       />
     </Stack.Navigator>

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -14,15 +14,15 @@ export type NavigationProp = NavigationScreenProp<
   NavigationParams
 >
 
-export type ActivationScreen =
+export type ActivationStackScreen =
   | "AcceptTermsOfService"
   | "ActivateProximityTracing"
   | "ActivateLocation"
   | "NotificationPermissions"
   | "ActivationSummary"
 
-export const ActivationScreens: {
-  [key in ActivationScreen]: ActivationScreen
+export const ActivationStackScreens: {
+  [key in ActivationStackScreen]: ActivationStackScreen
 } = {
   AcceptTermsOfService: "AcceptTermsOfService",
   ActivateProximityTracing: "ActivateProximityTracing",
@@ -31,14 +31,14 @@ export const ActivationScreens: {
   ActivationSummary: "ActivationSummary",
 }
 
-export type HomeScreen =
+export type HomeStackScreen =
   | "Home"
   | "BluetoothInfo"
   | "ProximityTracingInfo"
   | "LocationInfo"
 
-export const HomeScreens: {
-  [key in HomeScreen]: HomeScreen
+export const HomeStackScreens: {
+  [key in HomeStackScreen]: HomeStackScreen
 } = {
   Home: "Home",
   BluetoothInfo: "BluetoothInfo",
@@ -46,15 +46,15 @@ export const HomeScreens: {
   LocationInfo: "LocationInfo",
 }
 
-export type HowItWorksScreen =
+export type HowItWorksStackScreen =
   | "Introduction"
   | "PhoneRemembersDevices"
   | "PersonalPrivacy"
   | "GetNotified"
   | "ValueProposition"
 
-export const HowItWorksScreens: {
-  [key in HowItWorksScreen]: HowItWorksScreen
+export const HowItWorksStackScreens: {
+  [key in HowItWorksStackScreen]: HowItWorksStackScreen
 } = {
   Introduction: "Introduction",
   PhoneRemembersDevices: "PhoneRemembersDevices",
@@ -63,13 +63,13 @@ export const HowItWorksScreens: {
   ValueProposition: "ValueProposition",
 }
 
-export type ExposureHistoryScreen =
+export type ExposureHistoryStackScreen =
   | "ExposureHistory"
   | "ExposureDetail"
   | "MoreInfo"
 
-export const ExposureHistoryScreens: {
-  [key in ExposureHistoryScreen]: ExposureHistoryScreen
+export const ExposureHistoryStackScreens: {
+  [key in ExposureHistoryStackScreen]: ExposureHistoryStackScreen
 } = {
   ExposureHistory: "ExposureHistory",
   ExposureDetail: "ExposureDetail",
@@ -83,6 +83,7 @@ export type ExposureHistoryStackParamList = {
 }
 
 export type CallbackStackScreen = "Form" | "Success"
+
 export const CallbackStackScreens: {
   [key in CallbackStackScreen]: CallbackStackScreen
 } = {
@@ -98,7 +99,7 @@ export const ConnectStackScreens: {
   Connect: "Connect",
 }
 
-export type ModalScreen =
+export type ModalStackScreen =
   | "LanguageSelection"
   | "ProtectPrivacy"
   | "AffectedUserStack"
@@ -107,8 +108,8 @@ export type ModalScreen =
   | "AnonymizedDataConsent"
   | "AtRiskRecommendation"
 
-export const ModalScreens: {
-  [key in ModalScreen]: ModalScreen
+export const ModalStackScreens: {
+  [key in ModalStackScreen]: ModalStackScreen
 } = {
   LanguageSelection: "LanguageSelection",
   ProtectPrivacy: "ProtectPrivacy",
@@ -119,7 +120,7 @@ export const ModalScreens: {
   AtRiskRecommendation: "AtRiskRecommendation",
 }
 
-export type SettingsScreen =
+export type SettingsStackScreen =
   | "Settings"
   | "Legal"
   | "ENDebugMenu"
@@ -127,8 +128,8 @@ export type SettingsScreen =
   | "ExposureListDebugScreen"
   | "ENLocalDiagnosisKey"
 
-export const SettingsScreens: {
-  [key in SettingsScreen]: SettingsScreen
+export const SettingsStackScreens: {
+  [key in SettingsStackScreen]: SettingsStackScreen
 } = {
   Settings: "Settings",
   Legal: "Legal",
@@ -138,7 +139,7 @@ export const SettingsScreens: {
   ExposureListDebugScreen: "ExposureListDebugScreen",
 }
 
-export type AffectedUserFlowScreen =
+export type AffectedUserFlowStackScreen =
   | "AffectedUserStart"
   | "AffectedUserCodeInput"
   | "AffectedUserPublishConsent"
@@ -146,8 +147,8 @@ export type AffectedUserFlowScreen =
   | "AffectedUserExportDone"
   | "AffectedUserComplete"
 
-export const AffectedUserFlowScreens: {
-  [key in AffectedUserFlowScreen]: AffectedUserFlowScreen
+export const AffectedUserFlowStackScreens: {
+  [key in AffectedUserFlowStackScreen]: AffectedUserFlowStackScreen
 } = {
   AffectedUserStart: "AffectedUserStart",
   AffectedUserCodeInput: "AffectedUserCodeInput",
@@ -157,9 +158,11 @@ export const AffectedUserFlowScreens: {
   AffectedUserComplete: "AffectedUserComplete",
 }
 
-export type WelcomeScreen = "Welcome"
+export type WelcomeStackScreen = "Welcome"
 
-export const WelcomeScreens: { [key in WelcomeScreen]: WelcomeScreen } = {
+export const WelcomeStackScreens: {
+  [key in WelcomeStackScreen]: WelcomeStackScreen
+} = {
   Welcome: "Welcome",
 }
 
@@ -172,10 +175,10 @@ export const MyHealthStackScreens: {
   SelectSymptoms: "SelectSymptoms",
 }
 
-export type SelfScreenerScreen = "SelfScreenerIntro"
+export type SelfScreenerStackScreen = "SelfScreenerIntro"
 
-export const SelfScreenerScreens: {
-  [key in SelfScreenerScreen]: SelfScreenerScreen
+export const SelfScreenerStackScreens: {
+  [key in SelfScreenerStackScreen]: SelfScreenerStackScreen
 } = {
   SelfScreenerIntro: "SelfScreenerIntro",
 }


### PR DESCRIPTION
Why:
----
Prior to this commit, we had some screen types using the pattern
"XScreen" (e.g. "HomeScreen") and others using the pattern
"XStackScreen" (e.g. "HomeStackScreen"). We would like the pattern we
use to be consistent.

This commit:
----
Updates all Screen types to use the pattern "XStackScreen" as in
"HomeStackScreen".