### PR TITLE
Allow configuration of emergencies phone number

### DIFF
--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent, createContext, useContext } from "react"
 import { Platform } from "react-native"
 import env from "react-native-config"
 
+const USA_EMERGENCY_NUMBER = "911"
+
 export interface Configuration {
   appDownloadLink: string
   appPackageName: string
@@ -9,6 +11,7 @@ export interface Configuration {
   displayCallbackForm: boolean
   displayMyHealth: boolean
   displaySelfScreener: boolean
+  emergencyPhoneNumber: string
   findATestCenterUrl: string | null
   healthAuthorityAdviceUrl: string
   healthAuthorityLearnMoreUrl: string
@@ -29,6 +32,7 @@ const initialState = {
   displayCallbackForm: false,
   displayMyHealth: false,
   displaySelfScreener: false,
+  emergencyPhoneNumber: "",
   findATestCenterUrl: null,
   healthAuthorityAdviceUrl: "",
   healthAuthorityLearnMoreUrl: "",
@@ -59,6 +63,8 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
   const displayCallbackForm = env.DISPLAY_CALLBACK_FORM === "true"
   const displayMyHealth = env.DISPLAY_SYMPTOM_CHECKER === "true"
   const displaySelfScreener = env.DISPLAY_SELF_SCREENER === "true"
+  const emergencyPhoneNumber =
+    env.EMERGENCY_PHONE_NUMBER || USA_EMERGENCY_NUMBER
   const healthAuthoritySupportsAnalytics = Boolean(env.MATOMO_URL)
   const healthAuthorityAnalyticsUrl = env.MATOMO_URL || null
   const healthAuthorityAnalyticsSiteId = parseInt(env.MATOMO_SITE_ID) || null
@@ -78,6 +84,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         displayCallbackForm,
         displayMyHealth,
         displaySelfScreener,
+        emergencyPhoneNumber,
         findATestCenterUrl,
         healthAuthorityAdviceUrl,
         healthAuthorityLearnMoreUrl,

--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -2,8 +2,6 @@ import React, { FunctionComponent, createContext, useContext } from "react"
 import { Platform } from "react-native"
 import env from "react-native-config"
 
-const USA_EMERGENCY_NUMBER = "911"
-
 export interface Configuration {
   appDownloadLink: string
   appPackageName: string
@@ -52,6 +50,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
   const {
     AUTHORITY_ADVICE_URL: healthAuthorityAdviceUrl,
     FIND_A_TEST_CENTER_URL: findATestCenterUrl,
+    EMERGENCY_PHONE_NUMBER: emergencyPhoneNumber,
     EULA_URL: eulaUrl,
     GAEN_AUTHORITY_NAME: healthAuthorityName,
     LEARN_MORE_URL: healthAuthorityLearnMoreUrl,
@@ -63,8 +62,6 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
   const displayCallbackForm = env.DISPLAY_CALLBACK_FORM === "true"
   const displayMyHealth = env.DISPLAY_SYMPTOM_CHECKER === "true"
   const displaySelfScreener = env.DISPLAY_SELF_SCREENER === "true"
-  const emergencyPhoneNumber =
-    env.EMERGENCY_PHONE_NUMBER || USA_EMERGENCY_NUMBER
   const healthAuthoritySupportsAnalytics = Boolean(env.MATOMO_URL)
   const healthAuthorityAnalyticsUrl = env.MATOMO_URL || null
   const healthAuthorityAnalyticsSiteId = parseInt(env.MATOMO_SITE_ID) || null

--- a/src/Connect/index.spec.tsx
+++ b/src/Connect/index.spec.tsx
@@ -105,4 +105,28 @@ describe("Connect", () => {
       expect(openURLSpy).toHaveBeenCalledWith(url)
     })
   })
+
+  it("dials the emergency phone number from the configuration", async () => {
+    const emergencyPhoneNumber = "emergencyPhoneNumber"
+
+    const openURLSpy = jest.spyOn(Linking, "openURL")
+    ;(useApplicationInfo as jest.Mock).mockReturnValueOnce({
+      applicationName: "applicationName",
+      versionInfo: "versionInfo",
+    })
+
+    const { getByLabelText } = render(
+      <ConfigurationContext.Provider
+        value={factories.configurationContext.build({ emergencyPhoneNumber })}
+      >
+        <ConnectScreen />
+      </ConfigurationContext.Provider>,
+    )
+
+    fireEvent.press(getByLabelText("Emergency Contact"))
+
+    await waitFor(() => {
+      expect(openURLSpy).toHaveBeenCalledWith(`tel:${emergencyPhoneNumber}`)
+    })
+  })
 })

--- a/src/Connect/index.tsx
+++ b/src/Connect/index.tsx
@@ -66,8 +66,19 @@ const ConnectScreen: FunctionComponent = () => {
     })
   }
 
-  const handleOnPressEmergencyContact = () => {
-    Linking.openURL(`tel:${emergencyPhoneNumber}`)
+  const listItems: ConnectListItem[] = []
+
+  if (emergencyPhoneNumber) {
+    const handleOnPressEmergencyContact = () => {
+      Linking.openURL(`tel:${emergencyPhoneNumber}`)
+    }
+
+    const emergencyContact: ConnectListItem = {
+      label: t("about.emergency_contact"),
+      onPress: handleOnPressEmergencyContact,
+      icon: Icons.ChatBubble,
+    }
+    listItems.push(emergencyContact)
   }
 
   const howTheAppWorks: ConnectListItem = {
@@ -76,13 +87,7 @@ const ConnectScreen: FunctionComponent = () => {
     icon: Icons.RestartWithCheck,
   }
 
-  const emergencyContact: ConnectListItem = {
-    label: t("about.emergency_contact"),
-    onPress: handleOnPressEmergencyContact,
-    icon: Icons.ChatBubble,
-  }
-
-  const listItems: ConnectListItem[] = [emergencyContact, howTheAppWorks]
+  listItems.push(howTheAppWorks)
 
   if (displayCallbackForm) {
     const callbackForm: ConnectListItem = {

--- a/src/Connect/index.tsx
+++ b/src/Connect/index.tsx
@@ -40,7 +40,11 @@ const ConnectScreen: FunctionComponent = () => {
   } = useTranslation()
   const osInfo = `${Platform.OS} v${Platform.Version}`
   const { applicationName, versionInfo } = useApplicationInfo()
-  const { healthAuthorityName, displayCallbackForm } = useConfigurationContext()
+  const {
+    healthAuthorityName,
+    displayCallbackForm,
+    emergencyPhoneNumber,
+  } = useConfigurationContext()
 
   const aboutContent = authorityCopyTranslation(
     loadAuthorityCopy("about"),
@@ -63,7 +67,7 @@ const ConnectScreen: FunctionComponent = () => {
   }
 
   const handleOnPressEmergencyContact = () => {
-    Linking.openURL("tel:911")
+    Linking.openURL(`tel:${emergencyPhoneNumber}`)
   }
 
   const howTheAppWorks: ConnectListItem = {
@@ -71,6 +75,7 @@ const ConnectScreen: FunctionComponent = () => {
     onPress: handleOnPressHowTheAppWorks,
     icon: Icons.RestartWithCheck,
   }
+
   const emergencyContact: ConnectListItem = {
     label: t("about.emergency_contact"),
     onPress: handleOnPressEmergencyContact,

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -8,6 +8,7 @@ export default Factory.define<Configuration>(() => ({
   displayCallbackForm: false,
   displayMyHealth: false,
   displaySelfScreener: false,
+  emergencyPhoneNumber: "emergencyPhoneNumber",
   findATestCenterUrl: "findATestCenterUrl",
   healthAuthorityAdviceUrl: "authorityAdviceUrl",
   healthAuthorityLearnMoreUrl: "authorityLearnMoreUrl",


### PR DESCRIPTION
Why:
----

The emergency contact phone number varies from authority to authority and should be allowed to be configured.

This Commit:
----

- Adds the `emergencyPhoneNumber` argument to the configuration context, this one has a default value since all of the current use cases won't require an update