### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "PathCheckBT",
   "version": "0.0.1",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "clean": "rm -rf node_modules && yarn",


### PR DESCRIPTION
Why:
----
We would like to show a license in our package.json. Otherwise, we see a warning when
running terminal commands like `yarn`.

This commit:
----
- Add MIT license to package.json