### PR TITLE
Add SymptomGroup to context

### DIFF
--- a/src/SelfScreener/EmergencySymptomsQuestions.spec.tsx
+++ b/src/SelfScreener/EmergencySymptomsQuestions.spec.tsx
@@ -15,7 +15,7 @@ describe("EmergencySymptomsQuestions", () => {
 
     const updateSymptomsSpy = jest.fn()
     const context = factories.selfScreenerContext.build({
-      updateEmergencySymptoms: updateSymptomsSpy,
+      updateSymptoms: updateSymptomsSpy,
     })
 
     const { getByText } = render(
@@ -30,7 +30,7 @@ describe("EmergencySymptomsQuestions", () => {
 
     fireEvent.press(difficultyBreathingCheckbox)
     expect(updateSymptomsSpy).toHaveBeenCalledWith(
-      EmergencySymptom.DIFFICULTY_BREATHING,
+      EmergencySymptom.SEVERE_DIFFICULTY_BREATHING,
     )
   })
 
@@ -42,7 +42,7 @@ describe("EmergencySymptomsQuestions", () => {
           navigate: navigationSpy,
         })
         const context = factories.selfScreenerContext.build({
-          emergencySymptoms: [EmergencySymptom.DIFFICULTY_BREATHING],
+          emergencySymptoms: [EmergencySymptom.SEVERE_DIFFICULTY_BREATHING],
         })
 
         const { getByText } = render(

--- a/src/SelfScreener/EmergencySymptomsQuestions.tsx
+++ b/src/SelfScreener/EmergencySymptomsQuestions.tsx
@@ -13,13 +13,10 @@ import SymptomCheckbox from "./SymptomCheckbox"
 const EmergencySymptomsQuestions: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const {
-    emergencySymptoms,
-    updateEmergencySymptoms,
-  } = useSelfScreenerContext()
+  const { emergencySymptoms, updateSymptoms } = useSelfScreenerContext()
   const {
     CHEST_PAIN,
-    DIFFICULTY_BREATHING,
+    SEVERE_DIFFICULTY_BREATHING,
     LIGHTHEADEDNESS,
     DISORIENTATION,
   } = EmergencySymptom
@@ -36,7 +33,7 @@ const EmergencySymptomsQuestions: FunctionComponent = () => {
     switch (symptom) {
       case EmergencySymptom.CHEST_PAIN:
         return t("self_screener.emergency_symptoms.chest_pain")
-      case EmergencySymptom.DIFFICULTY_BREATHING:
+      case EmergencySymptom.SEVERE_DIFFICULTY_BREATHING:
         return t("self_screener.emergency_symptoms.difficulty_breathing")
       case EmergencySymptom.LIGHTHEADEDNESS:
         return t("self_screener.emergency_symptoms.lightheadedness")
@@ -52,22 +49,22 @@ const EmergencySymptomsQuestions: FunctionComponent = () => {
       </GlobalText>
       <SymptomCheckbox
         label={emergencySymptomToString(CHEST_PAIN)}
-        onPress={() => updateEmergencySymptoms(CHEST_PAIN)}
+        onPress={() => updateSymptoms(CHEST_PAIN)}
         checked={emergencySymptoms.includes(CHEST_PAIN)}
       />
       <SymptomCheckbox
-        label={emergencySymptomToString(DIFFICULTY_BREATHING)}
-        onPress={() => updateEmergencySymptoms(DIFFICULTY_BREATHING)}
-        checked={emergencySymptoms.includes(DIFFICULTY_BREATHING)}
+        label={emergencySymptomToString(SEVERE_DIFFICULTY_BREATHING)}
+        onPress={() => updateSymptoms(SEVERE_DIFFICULTY_BREATHING)}
+        checked={emergencySymptoms.includes(SEVERE_DIFFICULTY_BREATHING)}
       />
       <SymptomCheckbox
         label={emergencySymptomToString(LIGHTHEADEDNESS)}
-        onPress={() => updateEmergencySymptoms(LIGHTHEADEDNESS)}
+        onPress={() => updateSymptoms(LIGHTHEADEDNESS)}
         checked={emergencySymptoms.includes(LIGHTHEADEDNESS)}
       />
       <SymptomCheckbox
         label={emergencySymptomToString(DISORIENTATION)}
-        onPress={() => updateEmergencySymptoms(DISORIENTATION)}
+        onPress={() => updateSymptoms(DISORIENTATION)}
         checked={emergencySymptoms.includes(DISORIENTATION)}
       />
       <Button

--- a/src/SelfScreener/GeneralSymptoms.spec.tsx
+++ b/src/SelfScreener/GeneralSymptoms.spec.tsx
@@ -15,7 +15,7 @@ describe("GeneralSymptoms", () => {
       expect.assertions(1)
       const updateSymptomsSpy = jest.fn()
       const context = factories.selfScreenerContext.build({
-        updateSecondarySymptoms: updateSymptomsSpy,
+        updateSymptoms: updateSymptomsSpy,
       })
 
       const { getByText } = render(

--- a/src/SelfScreener/GeneralSymptoms.spec.tsx
+++ b/src/SelfScreener/GeneralSymptoms.spec.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from "@react-navigation/native"
 
 import { SelfScreenerContext } from "../SelfScreenerContext"
 import GeneralSymptoms from "./GeneralSymptoms"
-import { GeneralSymptom } from "./selfScreener"
+import { PrimarySymptom, SecondarySymptom } from "./selfScreener"
 import { factories } from "../factories"
 import { SelfScreenerStackScreens } from "../navigation"
 
@@ -15,7 +15,7 @@ describe("GeneralSymptoms", () => {
       expect.assertions(1)
       const updateSymptomsSpy = jest.fn()
       const context = factories.selfScreenerContext.build({
-        updateGeneralSymptoms: updateSymptomsSpy,
+        updateSecondarySymptoms: updateSymptomsSpy,
       })
 
       const { getByText } = render(
@@ -27,7 +27,7 @@ describe("GeneralSymptoms", () => {
       const achingCheckbox = getByText("Aching throughout the body")
 
       fireEvent.press(achingCheckbox)
-      expect(updateSymptomsSpy).toHaveBeenCalledWith(GeneralSymptom.ACHING)
+      expect(updateSymptomsSpy).toHaveBeenCalledWith(SecondarySymptom.ACHING)
     })
   })
 
@@ -38,7 +38,7 @@ describe("GeneralSymptoms", () => {
         navigate: navigationSpy,
       })
       const context = factories.selfScreenerContext.build({
-        generalSymptoms: [GeneralSymptom.COUGH],
+        primarySymptoms: [PrimarySymptom.COUGH],
       })
 
       const { getByText } = render(

--- a/src/SelfScreener/GeneralSymptoms.tsx
+++ b/src/SelfScreener/GeneralSymptoms.tsx
@@ -7,35 +7,34 @@ import { SelfScreenerStackScreens } from "../navigation"
 import { useSelfScreenerContext } from "../SelfScreenerContext"
 
 import { Button, GlobalText } from "../components"
-import {
-  GeneralSymptom,
-  OtherSymptom,
-  PrimarySymptom,
-  SecondarySymptom,
-} from "./selfScreener"
+import { OtherSymptom, PrimarySymptom, SecondarySymptom } from "./selfScreener"
 
 import SymptomCheckbox from "./SymptomCheckbox"
 
 const GeneralSymptoms: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const { FEVER_OR_CHILLS, COUGH, DIFFICULTY_BREATHING } = PrimarySymptom
+  const {
+    FEVER_OR_CHILLS,
+    COUGH,
+    MODERATE_DIFFICULTY_BREATHING,
+  } = PrimarySymptom
   const { ACHING, LOSS_OF_SMELL_TASTE_APPETITE } = SecondarySymptom
   const { VOMITING_OR_DIARRHEA, OTHER } = OtherSymptom
   const {
     primarySymptoms,
     secondarySymptoms,
     otherSymptoms,
-    updatePrimarySymptoms,
-    updateSecondarySymptoms,
-    updateOtherSymptoms,
+    updateSymptoms,
   } = useSelfScreenerContext()
 
-  const symptomToString = (symptom: GeneralSymptom) => {
+  const symptomToString = (
+    symptom: PrimarySymptom | SecondarySymptom | OtherSymptom,
+  ) => {
     switch (symptom) {
       case FEVER_OR_CHILLS:
         return t("self_screener.general_symptoms.fever_or_chills")
-      case DIFFICULTY_BREATHING:
+      case MODERATE_DIFFICULTY_BREATHING:
         return t("self_screener.general_symptoms.difficulty_breathing")
       case COUGH:
         return t("self_screener.general_symptoms.cough")
@@ -63,37 +62,37 @@ const GeneralSymptoms: FunctionComponent = () => {
       </GlobalText>
       <SymptomCheckbox
         label={symptomToString(FEVER_OR_CHILLS)}
-        onPress={() => updatePrimarySymptoms(FEVER_OR_CHILLS)}
+        onPress={() => updateSymptoms(FEVER_OR_CHILLS)}
         checked={primarySymptoms.includes(FEVER_OR_CHILLS)}
       />
       <SymptomCheckbox
-        label={symptomToString(DIFFICULTY_BREATHING)}
-        onPress={() => updatePrimarySymptoms(DIFFICULTY_BREATHING)}
-        checked={primarySymptoms.includes(DIFFICULTY_BREATHING)}
+        label={symptomToString(MODERATE_DIFFICULTY_BREATHING)}
+        onPress={() => updateSymptoms(MODERATE_DIFFICULTY_BREATHING)}
+        checked={primarySymptoms.includes(MODERATE_DIFFICULTY_BREATHING)}
       />
       <SymptomCheckbox
         label={symptomToString(COUGH)}
-        onPress={() => updatePrimarySymptoms(COUGH)}
+        onPress={() => updateSymptoms(COUGH)}
         checked={primarySymptoms.includes(COUGH)}
       />
       <SymptomCheckbox
         label={symptomToString(LOSS_OF_SMELL_TASTE_APPETITE)}
-        onPress={() => updateSecondarySymptoms(LOSS_OF_SMELL_TASTE_APPETITE)}
+        onPress={() => updateSymptoms(LOSS_OF_SMELL_TASTE_APPETITE)}
         checked={secondarySymptoms.includes(LOSS_OF_SMELL_TASTE_APPETITE)}
       />
       <SymptomCheckbox
         label={symptomToString(VOMITING_OR_DIARRHEA)}
-        onPress={() => updateOtherSymptoms(VOMITING_OR_DIARRHEA)}
+        onPress={() => updateSymptoms(VOMITING_OR_DIARRHEA)}
         checked={otherSymptoms.includes(VOMITING_OR_DIARRHEA)}
       />
       <SymptomCheckbox
         label={symptomToString(ACHING)}
-        onPress={() => updateSecondarySymptoms(ACHING)}
+        onPress={() => updateSymptoms(ACHING)}
         checked={secondarySymptoms.includes(ACHING)}
       />
       <SymptomCheckbox
         label={symptomToString(OTHER)}
-        onPress={() => updateOtherSymptoms(OTHER)}
+        onPress={() => updateSymptoms(OTHER)}
         checked={otherSymptoms.includes(OTHER)}
       />
       <Button

--- a/src/SelfScreener/GeneralSymptoms.tsx
+++ b/src/SelfScreener/GeneralSymptoms.tsx
@@ -7,23 +7,29 @@ import { SelfScreenerStackScreens } from "../navigation"
 import { useSelfScreenerContext } from "../SelfScreenerContext"
 
 import { Button, GlobalText } from "../components"
-import { GeneralSymptom } from "./selfScreener"
+import {
+  GeneralSymptom,
+  OtherSymptom,
+  PrimarySymptom,
+  SecondarySymptom,
+} from "./selfScreener"
 
 import SymptomCheckbox from "./SymptomCheckbox"
 
 const GeneralSymptoms: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
+  const { FEVER_OR_CHILLS, COUGH, DIFFICULTY_BREATHING } = PrimarySymptom
+  const { ACHING, LOSS_OF_SMELL_TASTE_APPETITE } = SecondarySymptom
+  const { VOMITING_OR_DIARRHEA, OTHER } = OtherSymptom
   const {
-    FEVER_OR_CHILLS,
-    DIFFICULTY_BREATHING,
-    COUGH,
-    LOSS_OF_SMELL_TASTE_APPETITE,
-    VOMITING_OR_DIARRHEA,
-    ACHING,
-    OTHER,
-  } = GeneralSymptom
-  const { generalSymptoms, updateGeneralSymptoms } = useSelfScreenerContext()
+    primarySymptoms,
+    secondarySymptoms,
+    otherSymptoms,
+    updatePrimarySymptoms,
+    updateSecondarySymptoms,
+    updateOtherSymptoms,
+  } = useSelfScreenerContext()
 
   const symptomToString = (symptom: GeneralSymptom) => {
     switch (symptom) {
@@ -35,10 +41,10 @@ const GeneralSymptoms: FunctionComponent = () => {
         return t("self_screener.general_symptoms.cough")
       case LOSS_OF_SMELL_TASTE_APPETITE:
         return t("self_screener.general_symptoms.loss_of_smell_taste_appetite")
-      case VOMITING_OR_DIARRHEA:
-        return t("self_screener.general_symptoms.vomiting_or_diarrhea")
       case ACHING:
         return t("self_screener.general_symptoms.aching")
+      case VOMITING_OR_DIARRHEA:
+        return t("self_screener.general_symptoms.vomiting_or_diarrhea")
       case OTHER:
         return t("self_screener.general_symptoms.other")
     }
@@ -48,6 +54,8 @@ const GeneralSymptoms: FunctionComponent = () => {
     navigation.navigate(SelfScreenerStackScreens.GeneralSymptomsSummary)
   }
 
+  const noSymptomsSelected =
+    [...primarySymptoms, ...secondarySymptoms, ...otherSymptoms].length === 0
   return (
     <ScrollView>
       <GlobalText>
@@ -55,44 +63,44 @@ const GeneralSymptoms: FunctionComponent = () => {
       </GlobalText>
       <SymptomCheckbox
         label={symptomToString(FEVER_OR_CHILLS)}
-        onPress={() => updateGeneralSymptoms(FEVER_OR_CHILLS)}
-        checked={generalSymptoms.includes(FEVER_OR_CHILLS)}
+        onPress={() => updatePrimarySymptoms(FEVER_OR_CHILLS)}
+        checked={primarySymptoms.includes(FEVER_OR_CHILLS)}
       />
       <SymptomCheckbox
         label={symptomToString(DIFFICULTY_BREATHING)}
-        onPress={() => updateGeneralSymptoms(DIFFICULTY_BREATHING)}
-        checked={generalSymptoms.includes(DIFFICULTY_BREATHING)}
+        onPress={() => updatePrimarySymptoms(DIFFICULTY_BREATHING)}
+        checked={primarySymptoms.includes(DIFFICULTY_BREATHING)}
       />
       <SymptomCheckbox
         label={symptomToString(COUGH)}
-        onPress={() => updateGeneralSymptoms(COUGH)}
-        checked={generalSymptoms.includes(COUGH)}
+        onPress={() => updatePrimarySymptoms(COUGH)}
+        checked={primarySymptoms.includes(COUGH)}
       />
       <SymptomCheckbox
         label={symptomToString(LOSS_OF_SMELL_TASTE_APPETITE)}
-        onPress={() => updateGeneralSymptoms(LOSS_OF_SMELL_TASTE_APPETITE)}
-        checked={generalSymptoms.includes(LOSS_OF_SMELL_TASTE_APPETITE)}
+        onPress={() => updateSecondarySymptoms(LOSS_OF_SMELL_TASTE_APPETITE)}
+        checked={secondarySymptoms.includes(LOSS_OF_SMELL_TASTE_APPETITE)}
       />
       <SymptomCheckbox
         label={symptomToString(VOMITING_OR_DIARRHEA)}
-        onPress={() => updateGeneralSymptoms(VOMITING_OR_DIARRHEA)}
-        checked={generalSymptoms.includes(VOMITING_OR_DIARRHEA)}
+        onPress={() => updateOtherSymptoms(VOMITING_OR_DIARRHEA)}
+        checked={otherSymptoms.includes(VOMITING_OR_DIARRHEA)}
       />
       <SymptomCheckbox
         label={symptomToString(ACHING)}
-        onPress={() => updateGeneralSymptoms(ACHING)}
-        checked={generalSymptoms.includes(ACHING)}
+        onPress={() => updateSecondarySymptoms(ACHING)}
+        checked={secondarySymptoms.includes(ACHING)}
       />
       <SymptomCheckbox
         label={symptomToString(OTHER)}
-        onPress={() => updateGeneralSymptoms(OTHER)}
-        checked={generalSymptoms.includes(OTHER)}
+        onPress={() => updateOtherSymptoms(OTHER)}
+        checked={otherSymptoms.includes(OTHER)}
       />
       <Button
         label={t("common.next")}
         onPress={handleOnPressNext}
         hasRightArrow
-        disabled={generalSymptoms.length === 0}
+        disabled={noSymptomsSelected}
       />
     </ScrollView>
   )

--- a/src/SelfScreener/selfScreener.spec.ts
+++ b/src/SelfScreener/selfScreener.spec.ts
@@ -1,0 +1,144 @@
+import { factories } from "../factories"
+import {
+  EmergencySymptom,
+  determineSymptomGroup,
+  SecondarySymptom,
+  OtherSymptom,
+  PrimarySymptom,
+  SymptomGroup,
+  UnderlyingCondition,
+  AgeRange,
+} from "./selfScreener"
+
+describe("determineSymptomGroup", () => {
+  describe("when a user reports experiencing an emergency symptom", () => {
+    it("returns the emergency symptom group", () => {
+      expect.assertions(1)
+      const answers = factories.selfScreenerAnswers.build({
+        emergencySymptoms: [EmergencySymptom.CHEST_PAIN],
+      })
+
+      expect(determineSymptomGroup(answers)).toEqual(
+        SymptomGroup.EMERGENCY_SYMPTOM_GROUP,
+      )
+    })
+  })
+
+  describe("when a user is not experiencing emergency symptoms", () => {
+    describe("when a user with underlying conditions is experiencing primarySymptoms", () => {
+      it("returns the first primary symptom group", () => {
+        expect.assertions(1)
+        const answers = factories.selfScreenerAnswers.build({
+          primarySymptoms: [PrimarySymptom.FEVER_OR_CHILLS],
+          underlyingConditions: [UnderlyingCondition.SMOKING],
+        })
+
+        expect(determineSymptomGroup(answers)).toEqual(
+          SymptomGroup.PRIMARY_SYMPTOM_GROUP_1,
+        )
+      })
+    })
+
+    describe("when a user over 65 is experiencing primary symptoms", () => {
+      it("returns the second  primary symptom group", () => {
+        expect.assertions(1)
+        const answers = factories.selfScreenerAnswers.build({
+          primarySymptoms: [PrimarySymptom.FEVER_OR_CHILLS],
+          ageRange: AgeRange.SIXTY_FIVE_AND_OVER,
+        })
+
+        expect(determineSymptomGroup(answers)).toEqual(
+          SymptomGroup.PRIMARY_SYMPTOM_GROUP_2,
+        )
+      })
+    })
+
+    describe("when a user under 65 with no underlying conditions is experiencing primary symptoms", () => {
+      it("returns the third primary symptom group", () => {
+        expect.assertions(1)
+        const answers = factories.selfScreenerAnswers.build({
+          primarySymptoms: [PrimarySymptom.COUGH],
+          ageRange: AgeRange.EIGHTEEN_TO_SIXTY_FOUR,
+        })
+
+        expect(determineSymptomGroup(answers)).toEqual(
+          SymptomGroup.PRIMARY_SYMPTOM_GROUP_3,
+        )
+      })
+    })
+
+    describe("when a user under 65 with underlying conditions is experiencing secondary symptoms", () => {
+      it("returns the first secondary symptom group", () => {
+        expect.assertions(1)
+        const answers = factories.selfScreenerAnswers.build({
+          secondarySymptoms: [SecondarySymptom.LOSS_OF_SMELL_TASTE_APPETITE],
+          ageRange: AgeRange.EIGHTEEN_TO_SIXTY_FOUR,
+          underlyingConditions: [UnderlyingCondition.HIGH_BLOOD_PRESSURE],
+        })
+
+        expect(determineSymptomGroup(answers)).toEqual(
+          SymptomGroup.SECONDARY_SYMPTOM_GROUP_1,
+        )
+      })
+    })
+
+    describe("when a user over 65 with no underlying conditions is experiencing secondary symptoms", () => {
+      it("returns the first secondary symptom group", () => {
+        expect.assertions(1)
+
+        const answers = factories.selfScreenerAnswers.build({
+          secondarySymptoms: [SecondarySymptom.ACHING],
+          ageRange: AgeRange.SIXTY_FIVE_AND_OVER,
+        })
+
+        expect(determineSymptomGroup(answers)).toEqual(
+          SymptomGroup.SECONDARY_SYMPTOM_GROUP_1,
+        )
+      })
+    })
+
+    describe("when a user under 65 with no underlying conditions is experiencing secondary symptoms", () => {
+      it("returns the second secondary symptom group", () => {
+        expect.assertions(1)
+
+        const answers = factories.selfScreenerAnswers.build({
+          secondarySymptoms: [SecondarySymptom.LOSS_OF_SMELL_TASTE_APPETITE],
+          ageRange: AgeRange.EIGHTEEN_TO_SIXTY_FOUR,
+        })
+
+        expect(determineSymptomGroup(answers)).toEqual(
+          SymptomGroup.SECONDARY_SYMPTOM_GROUP_2,
+        )
+      })
+    })
+
+    describe("when a user is experiencing non-COVID symptoms", () => {
+      it("returns the non-COVID symptom group", () => {
+        expect.assertions(1)
+
+        const answers = factories.selfScreenerAnswers.build({
+          otherSymptoms: [OtherSymptom.VOMITING_OR_DIARRHEA],
+        })
+
+        expect(determineSymptomGroup(answers)).toEqual(
+          SymptomGroup.NON_COVID_SYMPTOM_GROUP,
+        )
+      })
+    })
+
+    describe("when a user is not experiencing any symptoms", () => {
+      it("returns the asymptomatic group", () => {
+        expect.assertions(1)
+
+        const answers = factories.selfScreenerAnswers.build({
+          ageRange: AgeRange.SIXTY_FIVE_AND_OVER,
+          underlyingConditions: [UnderlyingCondition.PREGNANCY],
+        })
+
+        expect(determineSymptomGroup(answers)).toEqual(
+          SymptomGroup.ASYMPTOMATIC_GROUP,
+        )
+      })
+    })
+  })
+})

--- a/src/SelfScreener/selfScreener.spec.ts
+++ b/src/SelfScreener/selfScreener.spec.ts
@@ -18,9 +18,7 @@ describe("determineSymptomGroup", () => {
         emergencySymptoms: [EmergencySymptom.CHEST_PAIN],
       })
 
-      expect(determineSymptomGroup(answers)).toEqual(
-        SymptomGroup.EMERGENCY_SYMPTOM_GROUP,
-      )
+      expect(determineSymptomGroup(answers)).toEqual(SymptomGroup.EMERGENCY)
     })
   })
 
@@ -33,9 +31,7 @@ describe("determineSymptomGroup", () => {
           underlyingConditions: [UnderlyingCondition.SMOKING],
         })
 
-        expect(determineSymptomGroup(answers)).toEqual(
-          SymptomGroup.PRIMARY_SYMPTOM_GROUP_1,
-        )
+        expect(determineSymptomGroup(answers)).toEqual(SymptomGroup.PRIMARY_1)
       })
     })
 
@@ -47,9 +43,7 @@ describe("determineSymptomGroup", () => {
           ageRange: AgeRange.SIXTY_FIVE_AND_OVER,
         })
 
-        expect(determineSymptomGroup(answers)).toEqual(
-          SymptomGroup.PRIMARY_SYMPTOM_GROUP_2,
-        )
+        expect(determineSymptomGroup(answers)).toEqual(SymptomGroup.PRIMARY_2)
       })
     })
 
@@ -61,9 +55,7 @@ describe("determineSymptomGroup", () => {
           ageRange: AgeRange.EIGHTEEN_TO_SIXTY_FOUR,
         })
 
-        expect(determineSymptomGroup(answers)).toEqual(
-          SymptomGroup.PRIMARY_SYMPTOM_GROUP_3,
-        )
+        expect(determineSymptomGroup(answers)).toEqual(SymptomGroup.PRIMARY_3)
       })
     })
 
@@ -76,9 +68,7 @@ describe("determineSymptomGroup", () => {
           underlyingConditions: [UnderlyingCondition.HIGH_BLOOD_PRESSURE],
         })
 
-        expect(determineSymptomGroup(answers)).toEqual(
-          SymptomGroup.SECONDARY_SYMPTOM_GROUP_1,
-        )
+        expect(determineSymptomGroup(answers)).toEqual(SymptomGroup.SECONDARY_1)
       })
     })
 
@@ -91,9 +81,7 @@ describe("determineSymptomGroup", () => {
           ageRange: AgeRange.SIXTY_FIVE_AND_OVER,
         })
 
-        expect(determineSymptomGroup(answers)).toEqual(
-          SymptomGroup.SECONDARY_SYMPTOM_GROUP_1,
-        )
+        expect(determineSymptomGroup(answers)).toEqual(SymptomGroup.SECONDARY_1)
       })
     })
 
@@ -106,9 +94,7 @@ describe("determineSymptomGroup", () => {
           ageRange: AgeRange.EIGHTEEN_TO_SIXTY_FOUR,
         })
 
-        expect(determineSymptomGroup(answers)).toEqual(
-          SymptomGroup.SECONDARY_SYMPTOM_GROUP_2,
-        )
+        expect(determineSymptomGroup(answers)).toEqual(SymptomGroup.SECONDARY_2)
       })
     })
 
@@ -120,9 +106,7 @@ describe("determineSymptomGroup", () => {
           otherSymptoms: [OtherSymptom.VOMITING_OR_DIARRHEA],
         })
 
-        expect(determineSymptomGroup(answers)).toEqual(
-          SymptomGroup.NON_COVID_SYMPTOM_GROUP,
-        )
+        expect(determineSymptomGroup(answers)).toEqual(SymptomGroup.NON_COVID)
       })
     })
 
@@ -136,7 +120,7 @@ describe("determineSymptomGroup", () => {
         })
 
         expect(determineSymptomGroup(answers)).toEqual(
-          SymptomGroup.ASYMPTOMATIC_GROUP,
+          SymptomGroup.ASYMPTOMATIC,
         )
       })
     })

--- a/src/SelfScreener/selfScreener.ts
+++ b/src/SelfScreener/selfScreener.ts
@@ -1,6 +1,6 @@
 export enum EmergencySymptom {
   CHEST_PAIN = "CHEST_PAIN",
-  DIFFICULTY_BREATHING = "DIFFICULTY_BREATHING",
+  SEVERE_DIFFICULTY_BREATHING = "SEVERE_DIFFICULTY_BREATHING",
   LIGHTHEADEDNESS = "LIGHTHEADEDNESS",
   DISORIENTATION = "DISORIENTATION",
 }
@@ -8,7 +8,7 @@ export enum EmergencySymptom {
 export enum PrimarySymptom {
   FEVER_OR_CHILLS = "FEVER_OR_CHILLS",
   COUGH = "COUGH",
-  DIFFICULTY_BREATHING = "DIFFICULTY_BREATHING",
+  MODERATE_DIFFICULTY_BREATHING = "MODERATE_DIFFICULTY_BREATHING",
 }
 
 export enum SecondarySymptom {
@@ -20,7 +20,11 @@ export enum OtherSymptom {
   OTHER = "OTHER",
 }
 
-export type GeneralSymptom = PrimarySymptom | SecondarySymptom | OtherSymptom
+export type GeneralSymptom =
+  | EmergencySymptom
+  | PrimarySymptom
+  | SecondarySymptom
+  | OtherSymptom
 
 export enum UnderlyingCondition {
   LUNG_DISEASE,
@@ -43,14 +47,14 @@ export enum AgeRange {
 }
 
 export enum SymptomGroup {
-  EMERGENCY_SYMPTOM_GROUP,
-  PRIMARY_SYMPTOM_GROUP_1,
-  PRIMARY_SYMPTOM_GROUP_2,
-  PRIMARY_SYMPTOM_GROUP_3,
-  SECONDARY_SYMPTOM_GROUP_1,
-  SECONDARY_SYMPTOM_GROUP_2,
-  NON_COVID_SYMPTOM_GROUP,
-  ASYMPTOMATIC_GROUP,
+  EMERGENCY,
+  PRIMARY_1,
+  PRIMARY_2,
+  PRIMARY_3,
+  SECONDARY_1,
+  SECONDARY_2,
+  NON_COVID,
+  ASYMPTOMATIC,
 }
 
 export type SelfScreenerAnswers = {
@@ -66,23 +70,23 @@ export const determineSymptomGroup = (
   answers: SelfScreenerAnswers,
 ): SymptomGroup => {
   if (isEmergencySymptomGroup(answers)) {
-    return SymptomGroup.EMERGENCY_SYMPTOM_GROUP
+    return SymptomGroup.EMERGENCY
   } else if (isPrimarySymptomGroup1(answers)) {
-    return SymptomGroup.PRIMARY_SYMPTOM_GROUP_1
+    return SymptomGroup.PRIMARY_1
   } else if (isPrimarySymptomGroup2(answers)) {
-    return SymptomGroup.PRIMARY_SYMPTOM_GROUP_2
+    return SymptomGroup.PRIMARY_2
   } else if (isPrimarySymptomGroup3(answers)) {
-    return SymptomGroup.PRIMARY_SYMPTOM_GROUP_3
+    return SymptomGroup.PRIMARY_3
   } else if (isSecondarySymptomGroup1(answers)) {
-    return SymptomGroup.SECONDARY_SYMPTOM_GROUP_1
+    return SymptomGroup.SECONDARY_1
   } else if (isSecondarySymptomGroup2(answers)) {
-    return SymptomGroup.SECONDARY_SYMPTOM_GROUP_2
+    return SymptomGroup.SECONDARY_2
   } else if (isNonCovidSymptomGroup(answers)) {
-    return SymptomGroup.NON_COVID_SYMPTOM_GROUP
+    return SymptomGroup.NON_COVID
   } else if (isAsymptomaticGroup(answers)) {
-    return SymptomGroup.ASYMPTOMATIC_GROUP
+    return SymptomGroup.ASYMPTOMATIC
   } else {
-    return SymptomGroup.ASYMPTOMATIC_GROUP
+    return SymptomGroup.ASYMPTOMATIC
   }
 }
 
@@ -162,7 +166,7 @@ const hasUnderlyingCondition = (
 }
 
 const isOver65 = (ageRange: AgeRange | null): boolean => {
-  return ageRange !== null && ageRange === AgeRange.SIXTY_FIVE_AND_OVER
+  return ageRange === AgeRange.SIXTY_FIVE_AND_OVER
 }
 
 const isUnder65 = (ageRange: AgeRange | null): boolean => {

--- a/src/SelfScreener/selfScreener.ts
+++ b/src/SelfScreener/selfScreener.ts
@@ -1,19 +1,26 @@
 export enum EmergencySymptom {
-  CHEST_PAIN,
-  DIFFICULTY_BREATHING,
-  LIGHTHEADEDNESS,
-  DISORIENTATION,
+  CHEST_PAIN = "CHEST_PAIN",
+  DIFFICULTY_BREATHING = "DIFFICULTY_BREATHING",
+  LIGHTHEADEDNESS = "LIGHTHEADEDNESS",
+  DISORIENTATION = "DISORIENTATION",
 }
 
-export enum GeneralSymptom {
-  FEVER_OR_CHILLS,
-  DIFFICULTY_BREATHING,
-  COUGH,
-  LOSS_OF_SMELL_TASTE_APPETITE,
-  VOMITING_OR_DIARRHEA,
-  ACHING,
-  OTHER,
+export enum PrimarySymptom {
+  FEVER_OR_CHILLS = "FEVER_OR_CHILLS",
+  COUGH = "COUGH",
+  DIFFICULTY_BREATHING = "DIFFICULTY_BREATHING",
 }
+
+export enum SecondarySymptom {
+  ACHING = "ACHING",
+  LOSS_OF_SMELL_TASTE_APPETITE = "LOSS_OF_SMELL_TASTE_APPETITE",
+}
+export enum OtherSymptom {
+  VOMITING_OR_DIARRHEA = "VOMITING_OR_DIARRHEA",
+  OTHER = "OTHER",
+}
+
+export type GeneralSymptom = PrimarySymptom | SecondarySymptom | OtherSymptom
 
 export enum UnderlyingCondition {
   LUNG_DISEASE,
@@ -33,4 +40,150 @@ export enum UnderlyingCondition {
 export enum AgeRange {
   EIGHTEEN_TO_SIXTY_FOUR,
   SIXTY_FIVE_AND_OVER,
+}
+
+export enum SymptomGroup {
+  EMERGENCY_SYMPTOM_GROUP,
+  PRIMARY_SYMPTOM_GROUP_1,
+  PRIMARY_SYMPTOM_GROUP_2,
+  PRIMARY_SYMPTOM_GROUP_3,
+  SECONDARY_SYMPTOM_GROUP_1,
+  SECONDARY_SYMPTOM_GROUP_2,
+  NON_COVID_SYMPTOM_GROUP,
+  ASYMPTOMATIC_GROUP,
+}
+
+export type SelfScreenerAnswers = {
+  emergencySymptoms: EmergencySymptom[]
+  primarySymptoms: PrimarySymptom[]
+  secondarySymptoms: SecondarySymptom[]
+  otherSymptoms: OtherSymptom[]
+  underlyingConditions: UnderlyingCondition[]
+  ageRange: AgeRange | null
+}
+
+export const determineSymptomGroup = (
+  answers: SelfScreenerAnswers,
+): SymptomGroup => {
+  if (isEmergencySymptomGroup(answers)) {
+    return SymptomGroup.EMERGENCY_SYMPTOM_GROUP
+  } else if (isPrimarySymptomGroup1(answers)) {
+    return SymptomGroup.PRIMARY_SYMPTOM_GROUP_1
+  } else if (isPrimarySymptomGroup2(answers)) {
+    return SymptomGroup.PRIMARY_SYMPTOM_GROUP_2
+  } else if (isPrimarySymptomGroup3(answers)) {
+    return SymptomGroup.PRIMARY_SYMPTOM_GROUP_3
+  } else if (isSecondarySymptomGroup1(answers)) {
+    return SymptomGroup.SECONDARY_SYMPTOM_GROUP_1
+  } else if (isSecondarySymptomGroup2(answers)) {
+    return SymptomGroup.SECONDARY_SYMPTOM_GROUP_2
+  } else if (isNonCovidSymptomGroup(answers)) {
+    return SymptomGroup.NON_COVID_SYMPTOM_GROUP
+  } else if (isAsymptomaticGroup(answers)) {
+    return SymptomGroup.ASYMPTOMATIC_GROUP
+  } else {
+    return SymptomGroup.ASYMPTOMATIC_GROUP
+  }
+}
+
+const isEmergencySymptomGroup = (answers: SelfScreenerAnswers): boolean => {
+  return hasEmergencySymptom(answers.emergencySymptoms)
+}
+
+const isPrimarySymptomGroup1 = (answers: SelfScreenerAnswers) => {
+  return (
+    hasPrimarySymptom(answers.primarySymptoms) &&
+    hasUnderlyingCondition(answers.underlyingConditions)
+  )
+}
+
+const isPrimarySymptomGroup2 = (answers: SelfScreenerAnswers) => {
+  return (
+    hasPrimarySymptom(answers.primarySymptoms) &&
+    isOver65(answers.ageRange) &&
+    !hasUnderlyingCondition(answers.underlyingConditions)
+  )
+}
+
+const isPrimarySymptomGroup3 = (answers: SelfScreenerAnswers) => {
+  return (
+    hasPrimarySymptom(answers.primarySymptoms) &&
+    isUnder65(answers.ageRange) &&
+    !hasUnderlyingCondition(answers.underlyingConditions)
+  )
+}
+
+const isSecondarySymptomGroup1 = (answers: SelfScreenerAnswers) => {
+  const isUnder65WithUnderlyingConditions =
+    isUnder65(answers.ageRange) &&
+    hasUnderlyingCondition(answers.underlyingConditions)
+  return (
+    !hasPrimarySymptom(answers.primarySymptoms) &&
+    hasSecondarySymptoms(answers.secondarySymptoms) &&
+    (isUnder65WithUnderlyingConditions || isOver65(answers.ageRange))
+  )
+}
+
+const isSecondarySymptomGroup2 = (answers: SelfScreenerAnswers) => {
+  return (
+    !hasPrimarySymptom(answers.primarySymptoms) &&
+    hasSecondarySymptoms(answers.secondarySymptoms) &&
+    isUnder65(answers.ageRange) &&
+    !hasUnderlyingCondition(answers.underlyingConditions)
+  )
+}
+
+const isNonCovidSymptomGroup = (answers: SelfScreenerAnswers) => {
+  return (
+    !hasPrimarySymptom(answers.primarySymptoms) &&
+    !hasSecondarySymptoms(answers.secondarySymptoms) &&
+    hasNonCovidSymptoms(answers.otherSymptoms)
+  )
+}
+
+const isAsymptomaticGroup = (answers: SelfScreenerAnswers) => {
+  return hasNoSymptoms(answers)
+}
+
+const hasEmergencySymptom = (
+  emergencySymptoms: EmergencySymptom[],
+): boolean => {
+  return emergencySymptoms.length > 0
+}
+
+const hasPrimarySymptom = (primarySymptoms: PrimarySymptom[]): boolean => {
+  return primarySymptoms.length > 0
+}
+
+const hasUnderlyingCondition = (
+  underlyingConditions: UnderlyingCondition[],
+): boolean => {
+  return underlyingConditions.length > 0
+}
+
+const isOver65 = (ageRange: AgeRange | null): boolean => {
+  return ageRange !== null && ageRange === AgeRange.SIXTY_FIVE_AND_OVER
+}
+
+const isUnder65 = (ageRange: AgeRange | null): boolean => {
+  return ageRange === null || ageRange === AgeRange.EIGHTEEN_TO_SIXTY_FOUR
+}
+
+const hasSecondarySymptoms = (
+  secondarySymptoms: SecondarySymptom[],
+): boolean => {
+  return secondarySymptoms.length > 0
+}
+
+const hasNonCovidSymptoms = (otherSymptoms: OtherSymptom[]): boolean => {
+  return otherSymptoms.length > 0
+}
+
+const hasNoSymptoms = (answers: SelfScreenerAnswers): boolean => {
+  const { primarySymptoms, secondarySymptoms, otherSymptoms } = answers
+  return (
+    primarySymptoms.length === 0 &&
+    secondarySymptoms.length === 0 &&
+    otherSymptoms.length === 0
+  )
 }

--- a/src/SelfScreenerContext.spec.tsx
+++ b/src/SelfScreenerContext.spec.tsx
@@ -300,17 +300,14 @@ const DisplayEmergencySymptoms: FunctionComponent = () => {
 const RemoveEmergencySymptom: FunctionComponent<{
   symptom: EmergencySymptom
 }> = ({ symptom }) => {
-  const {
-    emergencySymptoms,
-    updateEmergencySymptoms,
-  } = useSelfScreenerContext()
+  const { emergencySymptoms, updateSymptoms } = useSelfScreenerContext()
 
   useEffect(() => {
-    updateEmergencySymptoms(symptom)
+    updateSymptoms(symptom)
   }, [])
 
   const updateSymptom = () => {
-    updateEmergencySymptoms(symptom)
+    updateSymptoms(symptom)
   }
 
   return (
@@ -326,13 +323,10 @@ const RemoveEmergencySymptom: FunctionComponent<{
 const AddEmergencySymptom: FunctionComponent<{ symptom: EmergencySymptom }> = ({
   symptom,
 }) => {
-  const {
-    emergencySymptoms,
-    updateEmergencySymptoms,
-  } = useSelfScreenerContext()
+  const { emergencySymptoms, updateSymptoms } = useSelfScreenerContext()
 
   useEffect(() => {
-    updateEmergencySymptoms(symptom)
+    updateSymptoms(symptom)
   }, [])
 
   return (
@@ -359,10 +353,10 @@ const DisplayPrimarySymptoms: FunctionComponent = () => {
 const AddPrimarySymptom: FunctionComponent<{ symptom: PrimarySymptom }> = ({
   symptom,
 }) => {
-  const { primarySymptoms, updatePrimarySymptoms } = useSelfScreenerContext()
+  const { primarySymptoms, updateSymptoms } = useSelfScreenerContext()
 
   useEffect(() => {
-    updatePrimarySymptoms(symptom)
+    updateSymptoms(symptom)
   }, [])
 
   return (
@@ -377,14 +371,14 @@ const AddPrimarySymptom: FunctionComponent<{ symptom: PrimarySymptom }> = ({
 const RemovePrimarySymptom: FunctionComponent<{
   symptom: PrimarySymptom
 }> = ({ symptom }) => {
-  const { primarySymptoms, updatePrimarySymptoms } = useSelfScreenerContext()
+  const { primarySymptoms, updateSymptoms } = useSelfScreenerContext()
 
   useEffect(() => {
-    updatePrimarySymptoms(symptom)
+    updateSymptoms(symptom)
   }, [])
 
   const updateSymptom = () => {
-    updatePrimarySymptoms(symptom)
+    updateSymptoms(symptom)
   }
 
   return (

--- a/src/SelfScreenerContext.spec.tsx
+++ b/src/SelfScreenerContext.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps*/
 import React, { useEffect, FunctionComponent } from "react"
 import { fireEvent, render, waitFor } from "@testing-library/react-native"
 import { Text, View } from "react-native"
@@ -12,25 +13,23 @@ import { Button } from "./components"
 import {
   AgeRange,
   EmergencySymptom,
-  GeneralSymptom,
+  PrimarySymptom,
   UnderlyingCondition,
 } from "./SelfScreener/selfScreener"
 describe("SelfScreenerContext", () => {
   describe("emergency symptoms", () => {
-    describe("getting the current emergency symptoms", () => {
-      it("passes down the correct emergency symptoms to its children", () => {
-        const context = factories.selfScreenerContext.build({
-          emergencySymptoms: [EmergencySymptom.CHEST_PAIN],
-        })
-
-        const { queryByText } = render(
-          <SelfScreenerContext.Provider value={context}>
-            <DisplayEmergencySymptoms />
-          </SelfScreenerContext.Provider>,
-        )
-
-        expect(queryByText(/CHEST_PAIN/)).not.toBeNull()
+    it("passes down the correct emergency symptoms to its children", () => {
+      const context = factories.selfScreenerContext.build({
+        emergencySymptoms: [EmergencySymptom.CHEST_PAIN],
       })
+
+      const { queryByText } = render(
+        <SelfScreenerContext.Provider value={context}>
+          <DisplayEmergencySymptoms />
+        </SelfScreenerContext.Provider>,
+      )
+
+      expect(queryByText(/CHEST_PAIN/)).not.toBeNull()
     })
 
     describe("updating emergency symptoms", () => {
@@ -72,143 +71,139 @@ describe("SelfScreenerContext", () => {
   })
 
   describe("general symptoms", () => {
-    describe("getting the current general symptoms", () => {
-      it("passes down the current general symptoms to its children", () => {
-        expect.assertions(1)
+    it("passes down the current general symptoms to its children", () => {
+      expect.assertions(1)
 
-        const context = factories.selfScreenerContext.build({
-          generalSymptoms: [GeneralSymptom.COUGH],
-        })
-        const { queryByText } = render(
-          <SelfScreenerContext.Provider value={context}>
-            <DisplayGeneralSymptoms />
-          </SelfScreenerContext.Provider>,
-        )
-
-        expect(queryByText(/COUGH/)).not.toBeNull()
-      })
-    })
-
-    describe("updatating general symptoms", () => {
-      describe("when the current symptom is currently selected", () => {
-        it("removes the symptom from context", async () => {
-          expect.assertions(1)
-
-          const { queryByText, getByText } = render(
-            <SelfScreenerProvider>
-              <RemoveGeneralSymptom
-                symptom={GeneralSymptom.LOSS_OF_SMELL_TASTE_APPETITE}
-              />
-            </SelfScreenerProvider>,
-          )
-
-          const updateButton = getByText("Update")
-          fireEvent.press(updateButton)
-
-          await waitFor(() => {
-            expect(queryByText(/LOSS_OF_SMELL_TASTE_APPETITE/)).toBeNull()
-          })
-        })
-      })
-      describe("when the current symptom is not currently selected", () => {
-        it("adds the symptom to context", async () => {
-          expect.assertions(1)
-          const { queryByText } = render(
-            <SelfScreenerProvider>
-              <AddGeneralSymptom symptom={GeneralSymptom.FEVER_OR_CHILLS} />
-            </SelfScreenerProvider>,
-          )
-
-          await waitFor(() => {
-            expect(queryByText(/FEVER_OR_CHILLS/)).not.toBeNull()
-          })
-        })
-      })
-    })
-  })
-
-  describe("underlying conditions", () => {
-    describe("getting the current underlying conditions", () => {
-      it("passes down the correct conditions to its children", () => {
-        expect.assertions(1)
-        const context = factories.selfScreenerContext.build({
-          underlyingConditions: [UnderlyingCondition.BLOOD_DISORDER],
-        })
-
-        const { queryByText } = render(
-          <SelfScreenerContext.Provider value={context}>
-            <DisplayUnderlyingConditions />
-          </SelfScreenerContext.Provider>,
-        )
-
-        expect(queryByText(/BLOOD_DISORDER/)).not.toBeNull()
-      })
-    })
-    describe("updating underlying conditions", () => {
-      describe("when the condition is currently selected", () => {
-        it("removes the condition", async () => {
-          expect.assertions(1)
-
-          const { queryByText, getByText } = render(
-            <SelfScreenerProvider>
-              <RemoveUnderlyingCondition
-                condition={UnderlyingCondition.SMOKING}
-              />
-            </SelfScreenerProvider>,
-          )
-
-          const updateButton = getByText("Update")
-          fireEvent.press(updateButton)
-
-          await waitFor(() => {
-            expect(queryByText(/SMOKING/)).toBeNull()
-          })
-        })
-      })
-
-      describe("when the condition is not currently selected", () => {
-        it("adds the symptom to context", async () => {
-          expect.assertions(1)
-          const { queryByText } = render(
-            <SelfScreenerProvider>
-              <AddUnderlyingCondition
-                condition={UnderlyingCondition.KIDNEY_DISEASE}
-              />
-            </SelfScreenerProvider>,
-          )
-
-          await waitFor(() => {
-            expect(queryByText(/KIDNEY_DISEASE/)).not.toBeNull()
-          })
-        })
-      })
-    })
-  })
-
-  describe("age range", () => {
-    it("passes down the age range to its children", () => {
       const context = factories.selfScreenerContext.build({
-        ageRange: AgeRange.EIGHTEEN_TO_SIXTY_FOUR,
+        primarySymptoms: [PrimarySymptom.COUGH],
       })
       const { queryByText } = render(
         <SelfScreenerContext.Provider value={context}>
-          <DisplayAgeRange />
+          <DisplayPrimarySymptoms />
         </SelfScreenerContext.Provider>,
       )
 
-      expect(queryByText(/EIGHTEEN_TO_SIXTY_FOUR/)).not.toBeNull()
+      expect(queryByText(/COUGH/)).not.toBeNull()
     })
+  })
 
-    it("updates the age range", async () => {
+  describe("updatating general symptoms", () => {
+    describe("when the current symptom is currently selected", () => {
+      it("removes the symptom from context", async () => {
+        expect.assertions(1)
+
+        const { queryByText, getByText } = render(
+          <SelfScreenerProvider>
+            <RemovePrimarySymptom symptom={PrimarySymptom.FEVER_OR_CHILLS} />
+          </SelfScreenerProvider>,
+        )
+
+        const updateButton = getByText("Update")
+        fireEvent.press(updateButton)
+
+        await waitFor(() => {
+          expect(queryByText(/FEVER_OR_CHILLS/)).toBeNull()
+        })
+      })
+    })
+    describe("when the current symptom is not currently selected", () => {
+      it("adds the symptom to context", async () => {
+        expect.assertions(1)
+        const { queryByText } = render(
+          <SelfScreenerProvider>
+            <AddPrimarySymptom symptom={PrimarySymptom.FEVER_OR_CHILLS} />
+          </SelfScreenerProvider>,
+        )
+
+        await waitFor(() => {
+          expect(queryByText(/FEVER_OR_CHILLS/)).not.toBeNull()
+        })
+      })
+    })
+  })
+})
+
+describe("underlying conditions", () => {
+  describe("getting the current underlying conditions", () => {
+    it("passes down the correct conditions to its children", () => {
+      expect.assertions(1)
+      const context = factories.selfScreenerContext.build({
+        underlyingConditions: [UnderlyingCondition.BLOOD_DISORDER],
+      })
+
       const { queryByText } = render(
-        <SelfScreenerProvider>
-          <UpdateAgeRange range={AgeRange.SIXTY_FIVE_AND_OVER} />
-        </SelfScreenerProvider>,
+        <SelfScreenerContext.Provider value={context}>
+          <DisplayUnderlyingConditions />
+        </SelfScreenerContext.Provider>,
       )
 
-      await waitFor(() => {
-        expect(queryByText(/SIXTY_FIVE_AND_OVER/)).not.toBeNull()
+      expect(queryByText(/BLOOD_DISORDER/)).not.toBeNull()
+    })
+  })
+  describe("updating underlying conditions", () => {
+    describe("when the condition is currently selected", () => {
+      it("removes the condition", async () => {
+        expect.assertions(1)
+
+        const { queryByText, getByText } = render(
+          <SelfScreenerProvider>
+            <RemoveUnderlyingCondition
+              condition={UnderlyingCondition.SMOKING}
+            />
+          </SelfScreenerProvider>,
+        )
+
+        const updateButton = getByText("Update")
+        fireEvent.press(updateButton)
+
+        await waitFor(() => {
+          expect(queryByText(/SMOKING/)).toBeNull()
+        })
       })
+    })
+
+    describe("when the condition is not currently selected", () => {
+      it("adds the symptom to context", async () => {
+        expect.assertions(1)
+        const { queryByText } = render(
+          <SelfScreenerProvider>
+            <AddUnderlyingCondition
+              condition={UnderlyingCondition.KIDNEY_DISEASE}
+            />
+          </SelfScreenerProvider>,
+        )
+
+        await waitFor(() => {
+          expect(queryByText(/KIDNEY_DISEASE/)).not.toBeNull()
+        })
+      })
+    })
+  })
+})
+
+describe("age range", () => {
+  it("passes down the age range to its children", () => {
+    const context = factories.selfScreenerContext.build({
+      ageRange: AgeRange.EIGHTEEN_TO_SIXTY_FOUR,
+    })
+    const { queryByText } = render(
+      <SelfScreenerContext.Provider value={context}>
+        <DisplayAgeRange />
+      </SelfScreenerContext.Provider>,
+    )
+
+    expect(queryByText(/EIGHTEEN_TO_SIXTY_FOUR/)).not.toBeNull()
+  })
+
+  it("updates the age range", async () => {
+    const { queryByText } = render(
+      <SelfScreenerProvider>
+        <UpdateAgeRange range={AgeRange.SIXTY_FIVE_AND_OVER} />
+      </SelfScreenerProvider>,
+    )
+
+    await waitFor(() => {
+      expect(queryByText(/SIXTY_FIVE_AND_OVER/)).not.toBeNull()
     })
   })
 })
@@ -349,53 +344,53 @@ const AddEmergencySymptom: FunctionComponent<{ symptom: EmergencySymptom }> = ({
   )
 }
 
-const DisplayGeneralSymptoms: FunctionComponent = () => {
-  const { generalSymptoms } = useSelfScreenerContext()
+const DisplayPrimarySymptoms: FunctionComponent = () => {
+  const { primarySymptoms } = useSelfScreenerContext()
 
   return (
     <View>
-      {generalSymptoms.map((s) => {
-        return <Text key={s}>{GeneralSymptom[s]}</Text>
+      {primarySymptoms.map((s) => {
+        return <Text key={s}>{s}</Text>
       })}
     </View>
   )
 }
 
-const AddGeneralSymptom: FunctionComponent<{ symptom: GeneralSymptom }> = ({
+const AddPrimarySymptom: FunctionComponent<{ symptom: PrimarySymptom }> = ({
   symptom,
 }) => {
-  const { generalSymptoms, updateGeneralSymptoms } = useSelfScreenerContext()
+  const { primarySymptoms, updatePrimarySymptoms } = useSelfScreenerContext()
 
   useEffect(() => {
-    updateGeneralSymptoms(symptom)
+    updatePrimarySymptoms(symptom)
   }, [])
 
   return (
     <View>
-      {generalSymptoms.map((s) => {
-        return <Text key={s}>{GeneralSymptom[s]}</Text>
+      {primarySymptoms.map((s) => {
+        return <Text key={s}>{s}</Text>
       })}
     </View>
   )
 }
 
-const RemoveGeneralSymptom: FunctionComponent<{
-  symptom: GeneralSymptom
+const RemovePrimarySymptom: FunctionComponent<{
+  symptom: PrimarySymptom
 }> = ({ symptom }) => {
-  const { generalSymptoms, updateGeneralSymptoms } = useSelfScreenerContext()
+  const { primarySymptoms, updatePrimarySymptoms } = useSelfScreenerContext()
 
   useEffect(() => {
-    updateGeneralSymptoms(symptom)
+    updatePrimarySymptoms(symptom)
   }, [])
 
   const updateSymptom = () => {
-    updateGeneralSymptoms(symptom)
+    updatePrimarySymptoms(symptom)
   }
 
   return (
     <View>
-      {generalSymptoms.map((s) => {
-        return <Text key={s}>{GeneralSymptom[s]}</Text>
+      {primarySymptoms.map((s) => {
+        return <Text key={s}>{s}</Text>
       })}
       <Button onPress={updateSymptom} label="Update" />
     </View>

--- a/src/SelfScreenerContext.tsx
+++ b/src/SelfScreenerContext.tsx
@@ -15,18 +15,16 @@ import {
   UnderlyingCondition,
   determineSymptomGroup,
   SelfScreenerAnswers,
+  GeneralSymptom,
 } from "./SelfScreener/selfScreener"
 
 export type SelfScreenerContextState = {
   emergencySymptoms: EmergencySymptom[]
-  updateEmergencySymptoms: (symptom: EmergencySymptom) => void
   primarySymptoms: PrimarySymptom[]
-  updatePrimarySymptoms: (symptom: PrimarySymptom) => void
   secondarySymptoms: SecondarySymptom[]
-  updateSecondarySymptoms: (symptom: SecondarySymptom) => void
   otherSymptoms: OtherSymptom[]
-  updateOtherSymptoms: (symptom: OtherSymptom) => void
   underlyingConditions: UnderlyingCondition[]
+  updateSymptoms: (symptom: GeneralSymptom) => void
   updateUnderlyingConditions: (condition: UnderlyingCondition) => void
   ageRange: AgeRange | null
   updateAgeRange: (range: AgeRange) => void
@@ -35,13 +33,10 @@ export type SelfScreenerContextState = {
 
 const initialState = {
   emergencySymptoms: [],
-  updateEmergencySymptoms: () => {},
   primarySymptoms: [],
-  updatePrimarySymptoms: () => {},
   secondarySymptoms: [],
-  updateSecondarySymptoms: () => {},
   otherSymptoms: [],
-  updateOtherSymptoms: () => {},
+  updateSymptoms: () => {},
   underlyingConditions: [],
   updateUnderlyingConditions: () => {},
   ageRange: null,
@@ -71,17 +66,32 @@ export const SelfScreenerProvider: FunctionComponent = ({ children }) => {
     ageRange,
   })
 
+  const updateSymptoms = (symptom: GeneralSymptom) => {
+    if (isEmergencySymptom(symptom)) {
+      return updateEmergencySymptoms(symptom)
+    }
+
+    if (isPrimarySymptom(symptom)) {
+      return updatePrimarySymptoms(symptom)
+    }
+
+    if (isSecondarySymptom(symptom)) {
+      return updateSecondarySymptoms(symptom)
+    }
+
+    if (isOtherSymptom(symptom)) {
+      return updateOtherSymptoms(symptom)
+    }
+  }
+
   return (
     <SelfScreenerContext.Provider
       value={{
         emergencySymptoms,
-        updateEmergencySymptoms,
         primarySymptoms,
-        updatePrimarySymptoms,
         secondarySymptoms,
-        updateSecondarySymptoms,
         otherSymptoms,
-        updateOtherSymptoms,
+        updateSymptoms,
         underlyingConditions,
         updateUnderlyingConditions,
         ageRange,
@@ -220,4 +230,41 @@ export const useSelfScreenerContext = (): SelfScreenerContextState => {
   }
 
   return context
+}
+
+const isEmergencySymptom = (
+  symptom: GeneralSymptom,
+): symptom is EmergencySymptom => {
+  return (
+    symptom === EmergencySymptom.SEVERE_DIFFICULTY_BREATHING ||
+    symptom === EmergencySymptom.CHEST_PAIN ||
+    symptom === EmergencySymptom.DISORIENTATION ||
+    symptom === EmergencySymptom.LIGHTHEADEDNESS
+  )
+}
+
+const isPrimarySymptom = (
+  symptom: GeneralSymptom,
+): symptom is PrimarySymptom => {
+  return (
+    symptom === PrimarySymptom.COUGH ||
+    symptom === PrimarySymptom.FEVER_OR_CHILLS ||
+    symptom === PrimarySymptom.MODERATE_DIFFICULTY_BREATHING
+  )
+}
+
+const isSecondarySymptom = (
+  symptom: GeneralSymptom,
+): symptom is SecondarySymptom => {
+  return (
+    symptom === SecondarySymptom.ACHING ||
+    symptom === SecondarySymptom.LOSS_OF_SMELL_TASTE_APPETITE
+  )
+}
+
+const isOtherSymptom = (symptom: GeneralSymptom): symptom is OtherSymptom => {
+  return (
+    symptom === OtherSymptom.OTHER ||
+    symptom === OtherSymptom.VOMITING_OR_DIARRHEA
+  )
 }

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -6,6 +6,7 @@ import exposureDatum from "./exposureDatum"
 import gaenStrategy from "./gaenStrategy"
 import symptomLogContext from "./symptomLogContext"
 import selfScreenerContext from "./selfScreenerContext"
+import selfScreenerAnswers from "./selfScreenerAnswers"
 import rawExposure from "./rawExposure"
 
 export const factories = register({
@@ -16,5 +17,6 @@ export const factories = register({
   gaenStrategy,
   symptomLogContext,
   selfScreenerContext,
+  selfScreenerAnswers,
   rawExposure,
 })

--- a/src/factories/selfScreenerAnswers.ts
+++ b/src/factories/selfScreenerAnswers.ts
@@ -1,0 +1,13 @@
+import { Factory } from "fishery"
+import { SelfScreenerAnswers } from "src/SelfScreener/selfScreener"
+
+export default Factory.define<SelfScreenerAnswers>(() => {
+  return {
+    emergencySymptoms: [],
+    primarySymptoms: [],
+    secondarySymptoms: [],
+    otherSymptoms: [],
+    underlyingConditions: [],
+    ageRange: null,
+  }
+})

--- a/src/factories/selfScreenerContext.ts
+++ b/src/factories/selfScreenerContext.ts
@@ -3,13 +3,10 @@ import { SelfScreenerContextState } from "../SelfScreenerContext"
 
 export default Factory.define<SelfScreenerContextState>(() => ({
   emergencySymptoms: [],
-  updateEmergencySymptoms: () => {},
   primarySymptoms: [],
-  updatePrimarySymptoms: () => {},
   secondarySymptoms: [],
-  updateSecondarySymptoms: () => {},
   otherSymptoms: [],
-  updateOtherSymptoms: () => {},
+  updateSymptoms: () => {},
   underlyingConditions: [],
   updateUnderlyingConditions: () => {},
   ageRange: null,

--- a/src/factories/selfScreenerContext.ts
+++ b/src/factories/selfScreenerContext.ts
@@ -4,10 +4,15 @@ import { SelfScreenerContextState } from "../SelfScreenerContext"
 export default Factory.define<SelfScreenerContextState>(() => ({
   emergencySymptoms: [],
   updateEmergencySymptoms: () => {},
-  generalSymptoms: [],
-  updateGeneralSymptoms: () => {},
+  primarySymptoms: [],
+  updatePrimarySymptoms: () => {},
+  secondarySymptoms: [],
+  updateSecondarySymptoms: () => {},
+  otherSymptoms: [],
+  updateOtherSymptoms: () => {},
   underlyingConditions: [],
   updateUnderlyingConditions: () => {},
   ageRange: null,
   updateAgeRange: () => {},
+  symptomGroup: null,
 }))


### PR DESCRIPTION
Why:
As a user, I want to know how at risk I am so that I can get accurate
recommendations for my demographic information and symptoms.

This commit:
Adds a symptomGroup to the SelfScreenerContext and a list of possible
symptom groups. As a user fills out the self screener, we use the
useSymptomGroup hook to update the context with their risk category so
that we can show them useful information.

This required a significant change to our GeneralSymptoms and how they
are stored in the context. Though GeneralSymptoms are displayed together
in the UI, they are actually divided into PrimarySymtoms,
SecondarySymptoms and OtherSymptoms, which represent how relevant and
severe they are to determining whether the user at an elevated risk to
COVID-19.

Since the distinction between primary, secondary, and other symptoms is
core to the purpose of the SelfScreener (giving the user personalized
information), and displaying them as one screen is an implementation
detail for the view layer, I opted to change the data structure of the
SelfScreenerContext to separate symptoms by category instead of showing
them all together.

Though this means that each category of symptom now has its own hook and
setter function, it clarifies the complex conditionals for assigning
symptom groups in the core logic a lot.
