### PR TITLE
(Android) Do not translate app name

### DIFF
--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-    <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-</resources>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
-</resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck Bluetooth</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck Bluetooth</string>
-</resources>

--- a/android/app/src/main/res/values-fil/strings.xml
+++ b/android/app/src/main/res/values-fil/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
-</resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
-</resources>

--- a/android/app/src/main/res/values-ht/strings.xml
+++ b/android/app/src/main/res/values-ht/strings.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-</resources>

--- a/android/app/src/main/res/values-id/strings.xml
+++ b/android/app/src/main/res/values-id/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
-</resources>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
-</resources>

--- a/android/app/src/main/res/values-ml/strings.xml
+++ b/android/app/src/main/res/values-ml/strings.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-</resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
-</resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck Bluetooth</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck Bluetooth</string>
-</resources>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">BT do PathCheck</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">BT do PathCheck</string>
-</resources>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
-</resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck Bluetooth</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck Bluetooth</string>
-</resources>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
-</resources>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resources>
-  <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
-</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,8 +2,6 @@
 <resources>
   <!-- Shown on app info, app switcher, etc -->
   <string name="app_name" translatable="false">PathCheck BT</string>
-  <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
   <string name="exposure_notification_channel_description">Exposure notification alerts.</string>
   <string name="exposure_notification_channel_name">Exposure Notification</string>
   <string name="exposure_notification_message">Someone you were near has tested positive for COVID-19. Tap for more info.</string>


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
Translations for the `app_name` were added in this [PR](https://github.com/Path-Check/gaen-mobile/pull/297). That makes the app show different app names based on the OS language.
This PR removes those translations since we only have one app name per HA.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/GAEN-347
