### PR TITLE
Cleanup stale my health data when view is loaded

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/CheckInModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/CheckInModule.java
@@ -51,4 +51,10 @@ public class CheckInModule extends ReactContextBaseJavaModule {
     RealmSecureStorageBte.INSTANCE.deleteCheckins();
     promise.resolve(null);
   }
+
+  @ReactMethod
+  public void deleteStaleCheckIns(Promise promise) {
+    RealmSecureStorageBte.INSTANCE.deleteStaleCheckIns();
+    promise.resolve(null);
+  }
 }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/SymptomLogEntryModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/SymptomLogEntryModule.java
@@ -62,4 +62,10 @@ public class SymptomLogEntryModule extends ReactContextBaseJavaModule {
     RealmSecureStorageBte.INSTANCE.deleteSymptomLogs();
     promise.resolve(null);
   }
+
+  @ReactMethod
+  public void deleteStaleSymptomLogs(Promise promise) {
+    RealmSecureStorageBte.INSTANCE.deleteStaleSymptomLogs();
+    promise.resolve(null);
+  }
 }

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -174,14 +174,22 @@ final class ExposureManager: NSObject {
     return btSecureStorage.storeCheckIn(checkInStatus)
   }
 
+  /// Deletes All CheckIns from Realm
+  @objc func deleteCheckins() {
+    return btSecureStorage.deleteCheckins()
+  }
+
+  @objc func deleteStaleCheckIns() {
+    btSecureStorage.deleteFourteenDaysOldCheckIns()
+  }
+
   /// Returns the symptom log entries as array of dictionaries
   @objc var symptomLogEntries: [[String: Any]] {
     return btSecureStorage.symptomLogEntries.map { $0.asDictionary }
   }
 
-  /// Deletes All CheckIns from Realm
-  @objc func deleteCheckins() {
-    return btSecureStorage.deleteCheckins()
+  @objc func deleteStaleLogEntries() {
+    btSecureStorage.deleteFourteenDaysOldSymptomLogEntries()
   }
 
   /// Persists SymptomLogEntry in Realm

--- a/ios/BT/Extensions/Foundation/Date+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Date+Extensions.swift
@@ -7,4 +7,7 @@ extension Date {
     Calendar.current.dateComponents([.hour], from: startDate, to: endDate).hour ?? 0
   }
   
+  static func daysAgoInPosix(_ days: Int) -> Int {
+    return Calendar.current.date(byAdding: DateComponents(day: -1 * days), to: Date())!.posixRepresentation
+  }
 }

--- a/ios/BT/Storage/BTSecureStorage.swift
+++ b/ios/BT/Storage/BTSecureStorage.swift
@@ -110,6 +110,14 @@ class BTSecureStorage: SafePathsSecureStorage {
     }
   }
 
+  func deleteFourteenDaysOldSymptomLogEntries() {
+    let realm = try! Realm(configuration: realmConfig)
+    try! realm.write {
+      let staleObjects = realm.objects(SymptomLogEntry.self).filter("date <= %@", Date.daysAgoInPosix(14))
+      realm.delete(staleObjects)
+    }
+  }
+
   func deleteSymptomLogEntries() {
     let realm = try! Realm(configuration: realmConfig)
     try! realm.write {
@@ -123,6 +131,14 @@ class BTSecureStorage: SafePathsSecureStorage {
     try! realm.write {
       let allObjects = realm.objects(CheckIn.self)
       realm.delete(allObjects)
+    }
+  }
+
+  func deleteFourteenDaysOldCheckIns() {
+    let realm = try! Realm(configuration: realmConfig)
+    try! realm.write {
+      let staleObjects = realm.objects(CheckIn.self).filter("date <= %@", Date.daysAgoInPosix(14))
+      realm.delete(staleObjects)
     }
   }
 
@@ -168,5 +184,4 @@ class BTSecureStorage: SafePathsSecureStorage {
     let realm = try! Realm(configuration: realmConfig)
     return Array(realm.objects(SymptomLogEntry.self))
   }
-
 }

--- a/ios/BT/bridge/CheckInModule.m
+++ b/ios/BT/bridge/CheckInModule.m
@@ -41,4 +41,12 @@ RCT_REMAP_METHOD(getCheckIns,
   resolve(checkInStatuses);
 }
 
+RCT_REMAP_METHOD(deleteStaleCheckIns,
+                 deleteStaleCheckInsWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [[ExposureManager shared] deleteStaleCheckIns];
+  resolve(nil);
+}
+
 @end

--- a/ios/BT/bridge/SymptomLogEntryModule.m
+++ b/ios/BT/bridge/SymptomLogEntryModule.m
@@ -56,6 +56,14 @@ RCT_REMAP_METHOD(deleteSymptomLogs,
   resolve(nil);
 }
 
+RCT_REMAP_METHOD(deleteStaleSymptomLogs,
+                 deleteStaleSymptomLogsWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [[ExposureManager shared] deleteStaleLogEntries];
+  resolve(nil);
+}
+
 RCT_REMAP_METHOD(getSymptomLogEntries,
                  getSymptomLogEntriesWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)

--- a/src/MyHealth/SymptomLogContext.spec.tsx
+++ b/src/MyHealth/SymptomLogContext.spec.tsx
@@ -8,7 +8,9 @@ import {
   getCheckIns,
   addCheckIn,
   createLogEntry,
-} from "../gaen/nativeModule"
+  deleteStaleCheckIns,
+  deleteStaleSymptomLogs,
+} from "./nativeModule"
 import {
   Symptom,
   CheckInStatus,
@@ -16,7 +18,7 @@ import {
 } from "./symptoms"
 import Logger from "../logger"
 
-jest.mock("../gaen/nativeModule.ts")
+jest.mock("./nativeModule.ts")
 jest.mock("./symptoms.ts")
 jest.mock("../logger.ts")
 describe("SymptomLogProvider", () => {
@@ -166,6 +168,22 @@ describe("SymptomLogProvider", () => {
 
       await waitFor(() => {
         expect(serializeSpy).toHaveBeenCalledWith(logEntries, checkIns)
+      })
+    })
+
+    it("deletes all the stale data on load", async () => {
+      const deleteStaleCheckInsSpy = deleteStaleCheckIns as jest.Mock
+      const deleteStaleSymptomLogsSpy = deleteStaleSymptomLogs as jest.Mock
+
+      render(
+        <SymptomLogProvider>
+          <CurrentCheckInStatus />
+        </SymptomLogProvider>,
+      )
+
+      await waitFor(() => {
+        expect(deleteStaleSymptomLogsSpy).toHaveBeenCalled()
+        expect(deleteStaleCheckInsSpy).toHaveBeenCalled()
       })
     })
 

--- a/src/MyHealth/SymptomLogContext.tsx
+++ b/src/MyHealth/SymptomLogContext.tsx
@@ -23,7 +23,9 @@ import {
   deleteLogEntry as removeLogEntry,
   deleteAllCheckIns as deleteCheckIns,
   deleteAllSymptomLogs as deleteLogs,
-} from "../gaen/nativeModule"
+  deleteStaleCheckIns,
+  deleteStaleSymptomLogs,
+} from "./nativeModule"
 import { isToday } from "../utils/dateTime"
 import {
   failureResponse,
@@ -87,7 +89,13 @@ export const SymptomLogProvider: FunctionComponent = ({ children }) => {
     setLogEntries(entries)
   }
 
+  const cleanupStaleData = async () => {
+    await deleteStaleCheckIns()
+    await deleteStaleSymptomLogs()
+  }
+
   useEffect(() => {
+    cleanupStaleData()
     fetchLogEntries()
     getCheckIns().then((checkIns) => {
       setCheckIns(checkIns)

--- a/src/MyHealth/nativeModule.ts
+++ b/src/MyHealth/nativeModule.ts
@@ -1,0 +1,55 @@
+import { NativeModules } from "react-native"
+
+import {
+  CheckIn,
+  SymptomLogEntry,
+  SymptomLogEntryAttributes,
+} from "../MyHealth/symptoms"
+
+// Check In Module
+const checkInModule = NativeModules.CheckInModule
+
+export const getCheckIns = async (): Promise<CheckIn[]> => {
+  return checkInModule.getCheckIns()
+}
+
+export const addCheckIn = (checkIn: CheckIn): Promise<void> => {
+  return checkInModule.addCheckIn(checkIn)
+}
+
+export const deleteAllCheckIns = async (): Promise<"success"> => {
+  return checkInModule.deleteCheckins()
+}
+
+export const deleteStaleCheckIns = async (): Promise<"success"> => {
+  return checkInModule.deleteStaleCheckIns()
+}
+
+// Symptom Log Entry Module
+const symptomLogEntryModule = NativeModules.SymptomLogEntryModule
+
+export const createLogEntry = (
+  entry: SymptomLogEntryAttributes,
+): Promise<void> => {
+  return symptomLogEntryModule.addSymptomLogEntry(entry)
+}
+
+export const modifyLogEntry = (entry: SymptomLogEntry): Promise<void> => {
+  return symptomLogEntryModule.updateSymptomLogEntry(entry)
+}
+
+export const deleteLogEntry = (symptomLogEntryId: string): Promise<void> => {
+  return symptomLogEntryModule.deleteSymptomLogEntry(symptomLogEntryId)
+}
+
+export const getLogEntries = (): Promise<SymptomLogEntry[]> => {
+  return symptomLogEntryModule.getSymptomLogEntries()
+}
+
+export const deleteAllSymptomLogs = async (): Promise<void> => {
+  return symptomLogEntryModule.deleteSymptomLogs()
+}
+
+export const deleteStaleSymptomLogs = async (): Promise<void> => {
+  return symptomLogEntryModule.deleteStaleSymptomLogs()
+}

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -11,11 +11,6 @@ import { ExposureKey } from "../exposureKey"
 import Logger from "../logger"
 
 import { toExposureInfo, RawExposure } from "./dataConverters"
-import {
-  CheckIn,
-  SymptomLogEntry,
-  SymptomLogEntryAttributes,
-} from "../MyHealth/symptoms"
 
 // Event Subscriptions
 export const subscribeToExposureEvents = (
@@ -271,44 +266,4 @@ const utilsModule = NativeModules.UtilsModule
 
 export const openAppSettings = (): void => {
   utilsModule.openAppSettings()
-}
-
-// Check In Module
-const checkInModule = NativeModules.CheckInModule
-
-export const getCheckIns = async (): Promise<CheckIn[]> => {
-  return checkInModule.getCheckIns()
-}
-
-export const addCheckIn = (checkIn: CheckIn): Promise<void> => {
-  return checkInModule.addCheckIn(checkIn)
-}
-
-export const deleteAllCheckIns = async (): Promise<"success"> => {
-  return checkInModule.deleteCheckins()
-}
-
-// Symptom Log Entry Module
-const symptomLogEntryModule = NativeModules.SymptomLogEntryModule
-
-export const createLogEntry = (
-  entry: SymptomLogEntryAttributes,
-): Promise<void> => {
-  return symptomLogEntryModule.addSymptomLogEntry(entry)
-}
-
-export const modifyLogEntry = (entry: SymptomLogEntry): Promise<void> => {
-  return symptomLogEntryModule.updateSymptomLogEntry(entry)
-}
-
-export const deleteLogEntry = (symptomLogEntryId: string): Promise<void> => {
-  return symptomLogEntryModule.deleteSymptomLogEntry(symptomLogEntryId)
-}
-
-export const getLogEntries = (): Promise<SymptomLogEntry[]> => {
-  return symptomLogEntryModule.getSymptomLogEntries()
-}
-
-export const deleteAllSymptomLogs = async (): Promise<void> => {
-  return symptomLogEntryModule.deleteSymptomLogs()
 }


### PR DESCRIPTION
Why:
----

The data we are storing on the device to populate the symptom log and the daily check-ins, should not be kept longer than the required period, currently 14 days.

This Commit:
----

- Add methods to delete the stale data on the iOS native side
- Add methods to delete stale data on the Android side
- Move native module for the my health into the same folder
- Cleanup old stale data before pulling info on the symptom log

Co-authored-by: Juan Cruz Soler <juancruz.gsoler@gmail.com>
