### PR TITLE
Return a truthy value from setup scripts

### DIFF
--- a/bin/set_ha.sh
+++ b/bin/set_ha.sh
@@ -40,6 +40,7 @@ def download_all_assets
   download_links_file(HA_LABEL, ACCESS_TOKEN)
   download_brand_colors_file(HA_LABEL, ACCESS_TOKEN)
   fetch_configurable_images(HA_LABEL, ACCESS_TOKEN)
+  true
 end
 
 if fetching_env_succeeded && system("./bin/configure_builds.sh") &&


### PR DESCRIPTION
Why:
----

A truthy value should be returned from the setup scripts group so the exit status of the script is `0`
