### PR TITLE
Add Guidance screen to Self Screener

### DIFF
--- a/src/SelfScreener/EmergencySymptomsQuestions.spec.tsx
+++ b/src/SelfScreener/EmergencySymptomsQuestions.spec.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from "@react-navigation/native"
 
 import { SelfScreenerContext } from "../SelfScreenerContext"
 import EmergencySymptomsQuestions from "./EmergencySymptomsQuestions"
-import { EmergencySymptom } from "./selfScreener"
+import { EmergencySymptom, SymptomGroup } from "./selfScreener"
 import { factories } from "../factories"
 import { SelfScreenerStackScreens } from "../navigation"
 
@@ -42,7 +42,7 @@ describe("EmergencySymptomsQuestions", () => {
           navigate: navigationSpy,
         })
         const context = factories.selfScreenerContext.build({
-          emergencySymptoms: [EmergencySymptom.SEVERE_DIFFICULTY_BREATHING],
+          symptomGroup: SymptomGroup.EMERGENCY,
         })
 
         const { getByText } = render(

--- a/src/SelfScreener/EmergencySymptomsQuestions.tsx
+++ b/src/SelfScreener/EmergencySymptomsQuestions.tsx
@@ -6,14 +6,18 @@ import { useNavigation } from "@react-navigation/native"
 import { SelfScreenerStackScreens } from "../navigation"
 import { Button, GlobalText } from "../components"
 
-import { EmergencySymptom } from "./selfScreener"
+import { EmergencySymptom, SymptomGroup } from "./selfScreener"
 import { useSelfScreenerContext } from "../SelfScreenerContext"
 import SymptomCheckbox from "./SymptomCheckbox"
 
 const EmergencySymptomsQuestions: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const { emergencySymptoms, updateSymptoms } = useSelfScreenerContext()
+  const {
+    symptomGroup,
+    emergencySymptoms,
+    updateSymptoms,
+  } = useSelfScreenerContext()
   const {
     CHEST_PAIN,
     SEVERE_DIFFICULTY_BREATHING,
@@ -22,7 +26,7 @@ const EmergencySymptomsQuestions: FunctionComponent = () => {
   } = EmergencySymptom
 
   const handleOnPressNext = () => {
-    if (emergencySymptoms.length > 0) {
+    if (symptomGroup === SymptomGroup.EMERGENCY) {
       return navigation.navigate(SelfScreenerStackScreens.CallEmergencyServices)
     }
 

--- a/src/SelfScreener/Guidance.spec.tsx
+++ b/src/SelfScreener/Guidance.spec.tsx
@@ -1,0 +1,126 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { SelfScreenerContext } from "../SelfScreenerContext"
+import Guidance from "./Guidance"
+import { factories } from "../factories"
+import { SymptomGroup } from "./selfScreener"
+
+describe("Guidance", () => {
+  it("displays the appropriate heading for primary 1 symptoms", () => {
+    const context = factories.selfScreenerContext.build({
+      symptomGroup: SymptomGroup.PRIMARY_1,
+    })
+    const { queryByText } = render(
+      <SelfScreenerContext.Provider value={context}>
+        <Guidance />
+      </SelfScreenerContext.Provider>,
+    )
+
+    expect(
+      queryByText(/You also have medical conditions that may put you at risk/),
+    ).not.toBeNull()
+  })
+
+  it("displays the appropriate heading for primary 2 symptoms", () => {
+    const context = factories.selfScreenerContext.build({
+      symptomGroup: SymptomGroup.PRIMARY_2,
+    })
+    const { queryByText } = render(
+      <SelfScreenerContext.Provider value={context}>
+        <Guidance />
+      </SelfScreenerContext.Provider>,
+    )
+
+    expect(
+      queryByText(/Your symptoms may be related to COVID-19/),
+    ).not.toBeNull()
+    expect(queryByText(/You also have medical conditions/)).toBeNull()
+  })
+
+  it("displays the appropriate heading for non covid symptoms", () => {
+    const context = factories.selfScreenerContext.build({
+      symptomGroup: SymptomGroup.NON_COVID,
+    })
+    const { queryByText } = render(
+      <SelfScreenerContext.Provider value={context}>
+        <Guidance />
+      </SelfScreenerContext.Provider>,
+    )
+
+    expect(queryByText(/Stay at home and monitor your symptoms/)).not.toBeNull()
+    expect(queryByText(/Your symptoms may be related to COVID-19/)).toBeNull()
+  })
+
+  it("displays the appropriate heading for no symptoms", () => {
+    const context = factories.selfScreenerContext.build({
+      symptomGroup: SymptomGroup.ASYMPTOMATIC,
+    })
+    const { queryByText } = render(
+      <SelfScreenerContext.Provider value={context}>
+        <Guidance />
+      </SelfScreenerContext.Provider>,
+    )
+
+    expect(queryByText(/Good to hear you’re feeling fine./)).not.toBeNull()
+    expect(queryByText(/Your symptoms may be related to COVID-19/)).toBeNull()
+  })
+
+  describe("displaying instructions", () => {
+    it("displays the appropriate instructions for primary 1 symptoms", () => {
+      const context = factories.selfScreenerContext.build({
+        symptomGroup: SymptomGroup.PRIMARY_1,
+      })
+      const { queryByText } = render(
+        <SelfScreenerContext.Provider value={context}>
+          <Guidance />
+        </SelfScreenerContext.Provider>,
+      )
+
+      const callYourDoctorSoon =
+        "Call your healthcare provider, clinician advice line, or telemedicine provider within 24 hours."
+      expect(queryByText(callYourDoctorSoon)).not.toBeNull()
+    })
+
+    it("displays the appropriate instructions for secondary 1 symptoms", () => {
+      const context = factories.selfScreenerContext.build({
+        symptomGroup: SymptomGroup.SECONDARY_1,
+      })
+      const { queryByText } = render(
+        <SelfScreenerContext.Provider value={context}>
+          <Guidance />
+        </SelfScreenerContext.Provider>,
+      )
+
+      const stayAtHome = "Stay at home except to get medical care."
+      expect(queryByText(stayAtHome)).not.toBeNull()
+    })
+
+    it("displays the appropriate instructions for non covid symptoms", () => {
+      const context = factories.selfScreenerContext.build({
+        symptomGroup: SymptomGroup.NON_COVID,
+      })
+      const { queryByText } = render(
+        <SelfScreenerContext.Provider value={context}>
+          <Guidance />
+        </SelfScreenerContext.Provider>,
+      )
+
+      const stayAtHome = /if you get worse symptoms, stay at home/
+      expect(queryByText(stayAtHome)).not.toBeNull()
+    })
+
+    it("displays the appropriate instructions for no symptoms", () => {
+      const context = factories.selfScreenerContext.build({
+        symptomGroup: SymptomGroup.ASYMPTOMATIC,
+      })
+      const { queryByText } = render(
+        <SelfScreenerContext.Provider value={context}>
+          <Guidance />
+        </SelfScreenerContext.Provider>,
+      )
+
+      const stayAtHome = /Stay home for 14 days/
+      expect(queryByText(stayAtHome)).not.toBeNull()
+    })
+  })
+})

--- a/src/SelfScreener/Guidance.tsx
+++ b/src/SelfScreener/Guidance.tsx
@@ -1,0 +1,65 @@
+import React, { FunctionComponent } from "react"
+import { useTranslation } from "react-i18next"
+import { View } from "react-native"
+import { GlobalText } from "../components"
+import { useSelfScreenerContext } from "../SelfScreenerContext"
+import { SymptomGroup } from "./selfScreener"
+import * as Instructions from "./Instructions"
+
+const Guidance: FunctionComponent = () => {
+  const { t } = useTranslation()
+  const { symptomGroup } = useSelfScreenerContext()
+
+  if (symptomGroup === null) {
+    return <></>
+  }
+
+  const introForSymptomGroup = (group: SymptomGroup) => {
+    switch (group) {
+      case SymptomGroup.PRIMARY_1:
+        return t("self_screener.guidance.you_have_underlying_conditions")
+      case SymptomGroup.PRIMARY_2:
+      case SymptomGroup.SECONDARY_2:
+      case SymptomGroup.PRIMARY_3:
+      case SymptomGroup.SECONDARY_1:
+        return t("self_screener.guidance.your_symptoms_might_be_related")
+      case SymptomGroup.NON_COVID:
+        return t("self_screener.guidance.monitor_your_symptoms")
+      case SymptomGroup.ASYMPTOMATIC:
+        return t("self_screener.guidance.feeling_fine")
+      default:
+        return t("self_screener.guidance.feeling_fine")
+    }
+  }
+
+  const instructionsForSymptomGroup = (group: SymptomGroup) => {
+    switch (group) {
+      case SymptomGroup.PRIMARY_1:
+      case SymptomGroup.PRIMARY_2:
+      case SymptomGroup.SECONDARY_2:
+        return <Instructions.CallYourHealthcareProvider />
+      case SymptomGroup.PRIMARY_3:
+      case SymptomGroup.SECONDARY_1:
+        return <Instructions.StayHomeExceptForMedicalCare />
+      case SymptomGroup.NON_COVID:
+        return <Instructions.WatchForSymptoms />
+      case SymptomGroup.ASYMPTOMATIC:
+        return <Instructions.Quarantine />
+      default:
+        return <Instructions.Quarantine />
+    }
+  }
+
+  return (
+    <View>
+      <GlobalText>{t("self_screener.guidance.guidance")}</GlobalText>
+      <GlobalText>{introForSymptomGroup(symptomGroup)}</GlobalText>
+      <GlobalText>
+        {t("self_screener.guidance.how_to_care_for_yourself_and_others")}
+      </GlobalText>
+      {instructionsForSymptomGroup(symptomGroup)}
+    </View>
+  )
+}
+
+export default Guidance

--- a/src/SelfScreener/Instructions.tsx
+++ b/src/SelfScreener/Instructions.tsx
@@ -1,0 +1,86 @@
+import React, { FunctionComponent } from "react"
+import { View } from "react-native"
+import { GlobalText } from "../components"
+import { useTranslation } from "react-i18next"
+
+export const CallYourHealthcareProvider: FunctionComponent = () => {
+  const { t } = useTranslation()
+  return (
+    <View>
+      <GlobalText>
+        {t("self_screener.guidance.call_your_healthcare_provider")}
+      </GlobalText>
+      <GlobalText>{t("self_screener.guidance.stay_at_home")}</GlobalText>
+      <GlobalText>{t("self_screener.guidance.dont_go_to_work")}</GlobalText>
+      <GlobalText>
+        {t("self_screener.guidance.dont_use_public_transport")}
+      </GlobalText>
+      <GlobalText>{t("self_screener.guidance.seek_medical_care")}</GlobalText>
+      <GlobalText>{t("self_screener.guidance.find_telehealth")}</GlobalText>
+      <GlobalText>
+        {t("self_screener.guidance.take_care_of_yourself")}
+      </GlobalText>
+      <GlobalText>{t("self_screener.guidance.protect_others")}</GlobalText>
+    </View>
+  )
+}
+
+export const StayHomeExceptForMedicalCare: FunctionComponent = () => {
+  const { t } = useTranslation()
+
+  return (
+    <View>
+      <GlobalText>{t("self_screener.guidance.stay_at_home")}</GlobalText>
+      <GlobalText>{t("self_screener.guidance.dont_go_to_work")}</GlobalText>
+      <GlobalText>
+        {t("self_screener.guidance.dont_use_public_transport")}
+      </GlobalText>
+      <GlobalText>{t("self_screener.guidance.seek_medical_care")}</GlobalText>
+      <GlobalText>
+        {t("self_screener.guidance.take_care_of_yourself")}
+      </GlobalText>
+      <GlobalText>{t("self_screener.guidance.protect_others")}</GlobalText>
+    </View>
+  )
+}
+
+export const WatchForSymptoms: FunctionComponent = () => {
+  const { t } = useTranslation()
+  return (
+    <View>
+      <GlobalText>
+        {t("self_screener.guidance.watch_for_covid_symptoms")}
+      </GlobalText>
+      <GlobalText>{t("self_screener.guidance.if_symptoms_develop")}</GlobalText>
+
+      <GlobalText>
+        {t("self_screener.guidance.may_help_you_feel_better")}
+      </GlobalText>
+
+      <GlobalText>{t("self_screener.guidance.rest")}</GlobalText>
+
+      <GlobalText>{t("self_screener.guidance.drink_water")}</GlobalText>
+      <GlobalText>{t("self_screener.guidance.cover_coughs")}</GlobalText>
+      <GlobalText>{t("self_screener.guidance.clean_hands")}</GlobalText>
+    </View>
+  )
+}
+
+export const Quarantine: FunctionComponent = () => {
+  const { t } = useTranslation()
+
+  return (
+    <View>
+      <GlobalText>{t("self_screener.guidance.stay_home_14_days")}</GlobalText>
+      <GlobalText>{t("self_screener.guidance.take_temperature")}</GlobalText>
+      <GlobalText>
+        {t("self_screener.guidance.practice_social_distancing")}
+      </GlobalText>
+      <GlobalText>{t("self_screener.guidance.stay_6_feet_away")}</GlobalText>
+      <GlobalText>
+        {t("self_screener.guidance.stay_away_from_higher_risk_people")}
+      </GlobalText>
+      <GlobalText>{t("self_screener.guidance.follow_cdc_guidance")}</GlobalText>
+    </View>
+  )
+}

--- a/src/SelfScreener/Summary.tsx
+++ b/src/SelfScreener/Summary.tsx
@@ -2,15 +2,49 @@ import React, { FunctionComponent } from "react"
 import { View } from "react-native"
 import { useTranslation } from "react-i18next"
 
-import { GlobalText } from "../components"
+import { Button, GlobalText } from "../components"
+import { useSelfScreenerContext } from "../SelfScreenerContext"
+import { SymptomGroup } from "./selfScreener"
+import { SelfScreenerStackScreens } from "../navigation"
+import { useNavigation } from "@react-navigation/native"
 
 const Summary: FunctionComponent = () => {
   const { t } = useTranslation()
+  const navigation = useNavigation()
+  const { symptomGroup } = useSelfScreenerContext()
+
+  const getSummaryTextForSymptomGroup = (): string => {
+    switch (symptomGroup) {
+      case SymptomGroup.PRIMARY_1:
+        return t("self_screener.summary.primary_symptom_group_1")
+      case SymptomGroup.PRIMARY_2:
+        return t("self_screener.summary.primary_symptom_group_2")
+      case SymptomGroup.PRIMARY_3:
+        return t("self_screener.summary.primary_symptom_group_3")
+      case SymptomGroup.SECONDARY_1:
+        return t("self_screener.summary.secondary_symptom_group_1")
+      case SymptomGroup.SECONDARY_2:
+        return t("self_screener.summary.secondary_symptom_group_2")
+      case SymptomGroup.NON_COVID:
+        return t("self_screener.summary.non_covid_symptom_group")
+      case SymptomGroup.ASYMPTOMATIC:
+        return t("self_screener.summary.asymptomatic_group")
+      default:
+        return t("self_screener.summary.asymptomatic_group")
+    }
+  }
+
+  const handleOnPressNext = () => {
+    navigation.navigate(SelfScreenerStackScreens.Guidance)
+  }
+
   return (
     <View>
-      <GlobalText>
-        {t("self_screener.summary.sorry_youre_not_feeling_well")}
-      </GlobalText>
+      <GlobalText>{getSummaryTextForSymptomGroup()}</GlobalText>
+      <Button
+        label={t("self_screener.summary.get_my_guidance")}
+        onPress={handleOnPressNext}
+      />
     </View>
   )
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -291,6 +291,35 @@
       "other": "Other",
       "vomiting_or_diarrhea": "Vomiting or diarrhea"
     },
+    "guidance": {
+      "call_your_healthcare_provider": "Call your healthcare provider, clinician advice line, or telemedicine provider within 24 hours.",
+      "clean_hands": "Clean your hands often.",
+      "cover_coughs": "Cover your coughs and sneezes.",
+      "dont_go_to_work": "Do not go to work, school, or public areas.",
+      "dont_use_public_transport": "Do not use public transportation or ride sharing.",
+      "drink_water": "Drink plenty of water and other clear liquids to prevent fluid loss (dehydration).",
+      "feeling_fine": "Good to hear you’re feeling fine. You shuold monitor your symptoms and stay at home.",
+      "find_telehealth": "Find telehealth services",
+      "follow_cdc_guidance": "If you develop symptoms, follow CDC guidance.",
+      "guidance": "Guidance",
+      "how_to_care_for_yourself_and_others": "How to care for yourself and others while sick with COVID-19 symptoms:",
+      "if_symptoms_develop": "If you develop any of these symptoms or if you start to feel worse, call your healthcare provider, clinician advice line, or telemedicine provider.",
+      "may_help_you_feel_better": "Here are some steps that may help you feel better:",
+      "monitor_your_symptoms": "Sorry you’re feeling ill. Stay at home and monitor your symptoms. Call your provider if you get worse symptoms, stay at home.",
+      "practice_social_distancing": "Practice social distancing.",
+      "protect_others": "Take these steps to help protect others from getting sick.",
+      "rest": "Stay at home and rest.",
+      "seek_medical_care": "If you think it is an emergency or you feel worse, seek medical care.",
+      "stay_6_feet_away": "Stay at least 6 feet away from others and stay out of crowded places.",
+      "stay_at_home": "Stay at home except to get medical care.",
+      "stay_away_from_higher_risk_people": "If possible, stay away from people who are at higher risk for getting very sick from COVID-19.",
+      "stay_home_14_days": "Stay home for 14 days.",
+      "take_care_of_yourself": "Learn how to take care of yourself or someone else who is sick.",
+      "take_temperature": "Take your temperature twice a day and watch for symptoms of COVID-19.",
+      "watch_for_covid_symptoms": "Watch for COVID-19 symptoms.",
+      "you_have_underlying_conditions": "Sorry you’re not feeling well. Your symptoms may be related to COVID-19. You also have medical conditions that may put you at risk of becoming more seriously ill.",
+      "your_symptoms_might_be_related": "Sorry you’re not feeling well. Your symptoms may be related to COVID-19."
+    },
     "intro": {
       "agree_and_start_screener": "Agree and start screener",
       "covid19_self_screener": "COVID-19 Self Screener"
@@ -300,7 +329,14 @@
       "one_more_question": ""
     },
     "summary": {
-      "sorry_youre_not_feeling_well": "Sorry to hear you're not feeling well."
+      "asymptomatic_group": "Glad to hear you’re feeling well!\nEven though you’re not ill, you should stay home for 14 days. COVID-19 may be spread by people who are not showing symptoms.",
+      "get_my_guidance": "Get my guidance",
+      "non_covid_symptom_group": "Sorry you’re not feeling well.\nBased on your answers, you’re not currently showing common symptoms of COVID-19.",
+      "primary_symptom_group_1": "Sorry you’re not feeling well.\nYour symptoms may be related to COVID-19. You also have medical conditions that may put you at risk of becoming more seriously ill.",
+      "primary_symptom_group_2": "Sorry you’re not feeling well.\nBased on your answers, your symptoms may be related to COVID-19.",
+      "primary_symptom_group_3": "Sorry you’re not feeling well.\nBased on your answers, your symptoms may be related to COVID-19.",
+      "secondary_symptom_group_1": "Sorry you’re not feeling well.\nBased on your answers, your symptoms may be related to COVID-19.",
+      "secondary_symptom_group_2": "Sorry you’re not feeling well. Based on your answers, your symptoms may be related to COVID-19."
     },
     "underlying_conditions": {
       "blood_disorder": "Blood disorder, such as sickle cell disease or thalassemia",

--- a/src/navigation/SelfScreenerStack.tsx
+++ b/src/navigation/SelfScreenerStack.tsx
@@ -10,6 +10,7 @@ import GeneralSymptomsSummary from "../SelfScreener/GeneralSymptomsSummary"
 import UnderlyingConditions from "../SelfScreener/UnderlyingConditions"
 import AgeRangeQuestion from "../SelfScreener/AgeRangeQuestion"
 import Summary from "../SelfScreener/Summary"
+import Guidance from "../SelfScreener/Guidance"
 import { SelfScreenerProvider } from "../SelfScreenerContext"
 
 const Stack = createStackNavigator()
@@ -60,6 +61,11 @@ const SelfAssessmentStack: FunctionComponent = () => {
         <Stack.Screen
           name={SelfScreenerStackScreens.Summary}
           component={Summary}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name={SelfScreenerStackScreens.Guidance}
+          component={Guidance}
           options={{ headerShown: false }}
         />
       </Stack.Navigator>

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -185,6 +185,7 @@ export type SelfScreenerStackScreen =
   | "UnderlyingConditions"
   | "AgeRange"
   | "Summary"
+  | "Guidance"
 
 export const SelfScreenerStackScreens: {
   [key in SelfScreenerStackScreen]: SelfScreenerStackScreen
@@ -198,6 +199,7 @@ export const SelfScreenerStackScreens: {
   UnderlyingConditions: "UnderlyingConditions",
   AgeRange: "AgeRange",
   Summary: "Summary",
+  Guidance: "Guidance",
 }
 export type Stack =
   | "Activation"


### PR DESCRIPTION
Why:
As a user, I want to get personalized guidance when I say that I am
experiencing symptoms and give my demographic information.

This commit:
Adds a `Guidance` screen, which reads the calculated `symptomGroup`
value from the SelfScreener context. Based on the user's symptom group,
it displays the appropriate CDC-recommended guidance and tells the user
what to do.

This commit also updates the EmergencySymptomsQuestions component to use
the `symptomGroup` from context instead of re-calculating the value
based on the length of the emergencySymptoms array.

![guidance](https://user-images.githubusercontent.com/21161427/94738565-96a1b300-033d-11eb-859a-1125b388f01f.gif)
