### PR TITLE
Use emergency phone number instead of default 911

### DIFF
--- a/src/SelfScreener/CallEmergencyServices.tsx
+++ b/src/SelfScreener/CallEmergencyServices.tsx
@@ -45,13 +45,13 @@ const CallEmergencyServices: FunctionComponent = () => {
           style={style.icon}
         />
         <GlobalText style={style.headerText}>
-          {t("self_screener.call911.seek_medical_attention")}
-        </GlobalText>
-        <GlobalText style={style.subheaderText}>
-          {t("self_screener.call911.urgent_medical_attention_needed")}
+          {t("self_screener.call_emergency_services.seek_medical_attention")}
         </GlobalText>
         <GlobalText style={style.bodyText}>
-          {t("self_screener.call911.based_on_your_symptoms")}
+          {t(
+            "self_screener.call_emergency_services.urgent_medical_attention_needed",
+            { emergencyPhoneNumber },
+          )}
         </GlobalText>
       </View>
       <TouchableOpacity
@@ -63,7 +63,9 @@ const CallEmergencyServices: FunctionComponent = () => {
         style={style.buttonContainer}
       >
         <GlobalText style={style.buttonText}>
-          {t("self_screener.call_emergency_services.call_emergency_services")}
+          {t("self_screener.call_emergency_services.call_emergencies", {
+            emergencyPhoneNumber,
+          })}
         </GlobalText>
         <SvgXml
           xml={Icons.Arrow}
@@ -83,7 +85,7 @@ const style = StyleSheet.create({
   },
   contentContainer: {
     flexGrow: 1,
-    justifyContent: "space-between",
+    justifyContent: "space-around",
     paddingVertical: Spacing.xxxHuge,
     paddingHorizontal: Spacing.large,
   },
@@ -94,14 +96,9 @@ const style = StyleSheet.create({
     ...Typography.header2,
     marginBottom: Spacing.small,
   },
-  subheaderText: {
-    ...Typography.header3,
-    marginBottom: Spacing.xLarge,
-  },
   bodyText: {
-    ...Typography.header4,
-    ...Typography.base,
-    marginBottom: Spacing.huge,
+    ...Typography.body1,
+    marginBottom: Spacing.xLarge,
   },
   buttonContainer: {
     ...Buttons.primary,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -266,12 +266,9 @@
       "sixty_five_and_over": "65+"
     },
     "call_emergency_services": {
-      "call_emergency_services": "Call 911"
-    },
-    "call911": {
-      "based_on_your_symptoms": "Based on your symptoms, you may need urgent medical care. Please call 911 or got to the nearest emergency department.\nTell the 911 operator or emergency staff if you have had contact with someone with COVID-19",
+      "call_emergencies": "Call {{emergencyPhoneNumber}}",
       "seek_medical_attention": "Seek medical attention immediately",
-      "urgent_medical_attention_needed": "Urgent medical attention may be needed. Please call 911 or go to the Emergency Department"
+      "urgent_medical_attention_needed": "Urgent medical attention may be needed. Please call {{emergencyPhoneNumber}} or go to the Emergency Department"
     },
     "emergency_symptoms": {
       "are_you_experiencing": "Are you experiencing any of these emergency symptoms?",


### PR DESCRIPTION
Why:
----

All references to the emergency phone number were hardcoded to the 911 on the self screener flow. We need to accommodate for different jurisdiction, needs.

This Commit:
----

- Use the emergencyPhoneNumber from the configuration context on the translations inside the self-screener

Co-authored-by: John Schoeman <johnschoeman1617@gmail.com>
