### PR TITLE
Navigate to self screener from my health

### DIFF
--- a/src/ExposureHistory/ExposureDetail.spec.tsx
+++ b/src/ExposureHistory/ExposureDetail.spec.tsx
@@ -154,7 +154,7 @@ describe("ExposureDetail", () => {
       expect(selfScreenerButton).not.toBeNull()
       fireEvent.press(selfScreenerButton)
       expect(navigateSpy).toHaveBeenCalledWith(Stacks.Modal, {
-        screen: ModalStackScreens.SelfScreener,
+        screen: ModalStackScreens.SelfScreenerFromExposureDetails,
       })
     })
   })

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -29,7 +29,7 @@ const ExposureActions: FunctionComponent = () => {
 
   const handleOnPressPersonalizeMyGuidance = () => {
     navigation.navigate(Stacks.Modal, {
-      screen: ModalStackScreens.SelfScreener,
+      screen: ModalStackScreens.SelfScreenerFromExposureDetails,
     })
   }
 

--- a/src/MyHealth/AtRiskRecommendation.tsx
+++ b/src/MyHealth/AtRiskRecommendation.tsx
@@ -86,7 +86,7 @@ const AtRiskRecommendationScreen: FunctionComponent = () => {
             {t("symptom_checker.get_tested")}
           </GlobalText>
         </View>
-        {findATestCenterUrl && (
+        {Boolean(findATestCenterUrl) && (
           <Button
             label={t("symptom_checker.find_a_test_center_nearby")}
             onPress={handleOnPressFindTestCenter}

--- a/src/MyHealth/SymptomLogContext.tsx
+++ b/src/MyHealth/SymptomLogContext.tsx
@@ -158,6 +158,7 @@ export const SymptomLogProvider: FunctionComponent = ({ children }) => {
     try {
       await deleteCheckIns()
       await getCheckIns()
+      setTodaysCheckIn(initialState.todaysCheckIn)
       return SUCCESS_RESPONSE
     } catch (e) {
       return failureResponse(e.message)

--- a/src/MyHealth/Today.spec.tsx
+++ b/src/MyHealth/Today.spec.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, waitFor } from "@testing-library/react-native"
 import { useNavigation } from "@react-navigation/native"
 import { showMessage } from "react-native-flash-message"
 
-import { MyHealthStackScreens } from "../navigation"
+import { ModalStackScreens, MyHealthStackScreens, Stacks } from "../navigation"
 
 import Today from "./Today"
 import { SymptomLogContext } from "./SymptomLogContext"
@@ -151,9 +151,9 @@ describe("Today", () => {
 
         fireEvent.press(getByLabelText("Not well"))
         await waitFor(() => {
-          expect(navigateSpy).toHaveBeenCalledWith(
-            MyHealthStackScreens.SelectSymptoms,
-          )
+          expect(navigateSpy).toHaveBeenCalledWith(Stacks.Modal, {
+            screen: ModalStackScreens.SelfScreenerFromMyHealth,
+          })
           expect(addTodaysCheckInSpy).toHaveBeenCalledWith(
             CheckInStatus.FeelingNotWell,
           )

--- a/src/MyHealth/Today.tsx
+++ b/src/MyHealth/Today.tsx
@@ -15,7 +15,7 @@ import { showMessage } from "react-native-flash-message"
 
 import { GlobalText, Button } from "../components"
 import { CheckInStatus } from "./symptoms"
-import { MyHealthStackScreens } from "../navigation"
+import { ModalStackScreens, MyHealthStackScreens, Stacks } from "../navigation"
 
 import {
   Outlines,
@@ -56,7 +56,9 @@ const Today: FunctionComponent = () => {
         ...Affordances.errorFlashMessageOptions,
       })
     } else {
-      navigation.navigate(MyHealthStackScreens.SelectSymptoms)
+      navigation.navigate(Stacks.Modal, {
+        screen: ModalStackScreens.SelfScreenerFromMyHealth,
+      })
     }
   }
 
@@ -183,7 +185,7 @@ const FeelingNotWellContent: FunctionComponent = () => {
       <GlobalText style={style.healthAssessmentText}>
         {t("symptom_checker.get_tested")}
       </GlobalText>
-      {findATestCenterUrl && (
+      {Boolean(findATestCenterUrl) && (
         <Button
           label={t("symptom_checker.find_a_test_center")}
           onPress={handleOnPressFindTestCenter}

--- a/src/navigation/ModalStack.tsx
+++ b/src/navigation/ModalStack.tsx
@@ -55,12 +55,35 @@ const ModalStack: FunctionComponent = () => {
         }}
       />
       <Stack.Screen
-        name={Stacks.SelfScreener}
-        component={SelfScreenerStack}
+        name={Stacks.SelfScreenerFromExposureDetails}
         options={{
           headerShown: false,
         }}
-      />
+      >
+        {(props) => {
+          return (
+            <SelfScreenerStack
+              {...props}
+              destinationOnCancel={Stacks.ExposureHistoryFlow}
+            />
+          )
+        }}
+      </Stack.Screen>
+      <Stack.Screen
+        name={Stacks.SelfScreenerFromMyHealth}
+        options={{
+          headerShown: false,
+        }}
+      >
+        {(props) => {
+          return (
+            <SelfScreenerStack
+              {...props}
+              destinationOnCancel={Stacks.MyHealth}
+            />
+          )
+        }}
+      </Stack.Screen>
     </Stack.Navigator>
   )
 }

--- a/src/navigation/SelfScreenerStack.tsx
+++ b/src/navigation/SelfScreenerStack.tsx
@@ -10,7 +10,7 @@ import {
 import { SvgXml } from "react-native-svg"
 
 import { SelfScreenerProvider } from "../SelfScreenerContext"
-import { SelfScreenerStackScreens, Stacks } from "./index"
+import { SelfScreenerStackScreens, Stack as AllStacks } from "./index"
 
 import SelfScreenerIntro from "../SelfScreener/SelfScreenerIntro"
 import EmergencySymptomsQuestions from "../SelfScreener/EmergencySymptomsQuestions"
@@ -51,44 +51,48 @@ const BackButton = () => {
   )
 }
 
-const cancelButton = () => <CancelButton />
-const CancelButton = () => {
-  const { t } = useTranslation()
-  const navigation = useNavigation()
+type SelfScreenerStackProps = {
+  destinationOnCancel: AllStacks
+}
 
-  return (
-    <TouchableOpacity
-      onPress={() => navigation.navigate(Stacks.ExposureHistoryFlow)}
-      accessible
-      accessibilityLabel={t("export.code_input_button_cancel")}
-    >
-      <View style={style.navigationButton}>
-        <SvgXml
-          xml={Icons.X}
-          fill={Colors.black}
-          width={Iconography.xxSmall}
-          height={Iconography.xxSmall}
-        />
-      </View>
-    </TouchableOpacity>
+const SelfScreenerStack: FunctionComponent<SelfScreenerStackProps> = ({
+  destinationOnCancel,
+}) => {
+  const cancelButton = () => (
+    <CancelButton destinationOnCancel={destinationOnCancel} />
   )
-}
+  const CancelButton: FunctionComponent<SelfScreenerStackProps> = ({
+    destinationOnCancel,
+  }) => {
+    const { t } = useTranslation()
+    const navigation = useNavigation()
 
-const style = StyleSheet.create({
-  navigationButton: {
-    padding: Spacing.medium,
-  },
-})
+    return (
+      <TouchableOpacity
+        onPress={() => navigation.navigate(destinationOnCancel)}
+        accessible
+        accessibilityLabel={t("export.code_input_button_cancel")}
+      >
+        <View style={style.navigationButton}>
+          <SvgXml
+            xml={Icons.X}
+            fill={Colors.black}
+            width={Iconography.xxSmall}
+            height={Iconography.xxSmall}
+          />
+        </View>
+      </TouchableOpacity>
+    )
+  }
 
-const navigationBarOptions: StackNavigationOptions = {
-  title: "",
-  headerStyle: { backgroundColor: Colors.secondary10 },
-  headerLeft: backButton,
-  headerRight: cancelButton,
-  headerStyleInterpolator: HeaderStyleInterpolators.forNoAnimation,
-}
+  const navigationBarOptions: StackNavigationOptions = {
+    title: "",
+    headerStyle: { backgroundColor: Colors.secondary10 },
+    headerLeft: backButton,
+    headerRight: cancelButton,
+    headerStyleInterpolator: HeaderStyleInterpolators.forNoAnimation,
+  }
 
-const SelfAssessmentStack: FunctionComponent = () => {
   return (
     <SelfScreenerProvider>
       <Stack.Navigator screenOptions={navigationBarOptions}>
@@ -140,4 +144,10 @@ const SelfAssessmentStack: FunctionComponent = () => {
   )
 }
 
-export default SelfAssessmentStack
+const style = StyleSheet.create({
+  navigationButton: {
+    padding: Spacing.medium,
+  },
+})
+
+export default SelfScreenerStack

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -107,7 +107,8 @@ export type ModalStackScreen =
   | "HowItWorksReviewFromConnect"
   | "AnonymizedDataConsent"
   | "AtRiskRecommendation"
-  | "SelfScreener"
+  | "SelfScreenerFromExposureDetails"
+  | "SelfScreenerFromMyHealth"
 
 export const ModalStackScreens: {
   [key in ModalStackScreen]: ModalStackScreen
@@ -119,7 +120,8 @@ export const ModalStackScreens: {
   HowItWorksReviewFromConnect: "HowItWorksReviewFromConnect",
   AnonymizedDataConsent: "AnonymizedDataConsent",
   AtRiskRecommendation: "AtRiskRecommendation",
-  SelfScreener: "SelfScreener",
+  SelfScreenerFromExposureDetails: "SelfScreenerFromExposureDetails",
+  SelfScreenerFromMyHealth: "SelfScreenerFromMyHealth",
 }
 
 export type SettingsStackScreen =
@@ -203,6 +205,7 @@ export const SelfScreenerStackScreens: {
   Summary: "Summary",
   Guidance: "Guidance",
 }
+
 export type Stack =
   | "Activation"
   | "AffectedUserStack"
@@ -216,7 +219,8 @@ export type Stack =
   | "Settings"
   | "Home"
   | "MyHealth"
-  | "SelfScreener"
+  | "SelfScreenerFromExposureDetails"
+  | "SelfScreenerFromMyHealth"
 
 export const Stacks: { [key in Stack]: Stack } = {
   Activation: "Activation",
@@ -231,7 +235,8 @@ export const Stacks: { [key in Stack]: Stack } = {
   Settings: "Settings",
   Home: "Home",
   MyHealth: "MyHealth",
-  SelfScreener: "SelfScreener",
+  SelfScreenerFromExposureDetails: "SelfScreenerFromExposureDetails",
+  SelfScreenerFromMyHealth: "SelfScreenerFromMyHealth",
 }
 
 export const useStatusBarEffect = (


### PR DESCRIPTION
Why:
When a user taps 'Unwell' on the my health screen, we would like for
them to start the self screener flow.

This commit:
Adds the logic to navigate to the self screener from the my health tab.
Note that given the way that the modal navigation is factored, we need
to mount two instances of the component with a prop to determine where
to go back to after closing the modal. A future commit might want to
refactor this such that we dont need to have many mounted instances of
the same component.

Co-Authored-By: alejandro dustet <alejandro@thoughtbot.com>
