### PR TITLE
Support metric system units

### DIFF
--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent, createContext, useContext } from "react"
 import { Platform } from "react-native"
 import env from "react-native-config"
 
+type MeasurementSystem = "Imperial" | "Metric"
+
 export interface Configuration {
   appDownloadLink: string
   appPackageName: string
@@ -20,6 +22,7 @@ export interface Configuration {
   healthAuthoritySupportsAnalytics: boolean
   healthAuthorityAnalyticsUrl: string | null
   healthAuthorityAnalyticsSiteId: number | null
+  measurementSystem: MeasurementSystem
   regionCodes: string[]
 }
 
@@ -41,6 +44,7 @@ const initialState = {
   healthAuthoritySupportsAnalytics: false,
   healthAuthorityAnalyticsUrl: null,
   healthAuthorityAnalyticsSiteId: null,
+  measurementSystem: "Imperial" as const,
   regionCodes: [],
 }
 
@@ -49,22 +53,28 @@ const ConfigurationContext = createContext<Configuration>(initialState)
 const ConfigurationProvider: FunctionComponent = ({ children }) => {
   const {
     AUTHORITY_ADVICE_URL: healthAuthorityAdviceUrl,
-    FIND_A_TEST_CENTER_URL: findATestCenterUrl,
     EMERGENCY_PHONE_NUMBER: emergencyPhoneNumber,
     EULA_URL: eulaUrl,
+    FIND_A_TEST_CENTER_URL: findATestCenterUrl,
     GAEN_AUTHORITY_NAME: healthAuthorityName,
     LEARN_MORE_URL: healthAuthorityLearnMoreUrl,
     LEGAL_PRIVACY_POLICY_URL: legalPrivacyPolicyUrl,
     PRIVACY_POLICY_URL: healthAuthorityPrivacyPolicyUrl,
   } = env
+
   const displayAcceptTermsOfService =
     env.DISPLAY_ACCEPT_TERMS_OF_SERVICE === "true"
   const displayCallbackForm = env.DISPLAY_CALLBACK_FORM === "true"
   const displayMyHealth = env.DISPLAY_SYMPTOM_CHECKER === "true"
   const displaySelfScreener = env.DISPLAY_SELF_SCREENER === "true"
+
+  const measurementSystem =
+    env.MEASUREMENT_SYSTEM === "metric" ? "Metric" : "Imperial"
+
   const healthAuthoritySupportsAnalytics = Boolean(env.MATOMO_URL)
   const healthAuthorityAnalyticsUrl = env.MATOMO_URL || null
   const healthAuthorityAnalyticsSiteId = parseInt(env.MATOMO_SITE_ID) || null
+
   const appDownloadLink = env.SHARE_APP_LINK
   const appPackageName = Platform.select({
     ios: env.IOS_BUNDLE_ID,
@@ -92,6 +102,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         healthAuthoritySupportsAnalytics,
         healthAuthorityAnalyticsUrl,
         healthAuthorityAnalyticsSiteId,
+        measurementSystem,
         regionCodes,
       }}
     >

--- a/src/ExposureHistory/History/NoExposures.tsx
+++ b/src/ExposureHistory/History/NoExposures.tsx
@@ -30,11 +30,17 @@ const HealthGuidelines: FunctionComponent = () => {
   const {
     healthAuthorityName,
     healthAuthorityLearnMoreUrl,
+    measurementSystem,
   } = useConfigurationContext()
 
   const handleOnPressHALink = () => {
     Linking.openURL(healthAuthorityLearnMoreUrl)
   }
+
+  const stayApartRecommendationText =
+    measurementSystem === "Imperial"
+      ? t("exposure_history.health_guidelines.six_feet_apart")
+      : t("exposure_history.health_guidelines.two_meters_apart")
 
   return (
     <View style={style.card}>
@@ -80,7 +86,7 @@ const HealthGuidelines: FunctionComponent = () => {
       />
       <HealthGuidelineItem
         icon={Icons.StayApart}
-        text={t("exposure_history.health_guidelines.six_feet_apart")}
+        text={stayApartRecommendationText}
       />
     </View>
   )

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -21,6 +21,7 @@ const ExposureActions: FunctionComponent = () => {
     displaySelfScreener,
     healthAuthorityName,
     healthAuthorityAdviceUrl,
+    measurementSystem,
   } = useConfigurationContext()
 
   const handleOnPressNextStep = () => {
@@ -35,6 +36,11 @@ const ExposureActions: FunctionComponent = () => {
 
   const displayNextStepsLink =
     !displaySelfScreener && healthAuthorityAdviceUrl !== ""
+
+  const stayApartRecommendationText =
+    measurementSystem === "Imperial"
+      ? t("exposure_history.exposure_detail.6ft_apart")
+      : t("exposure_history.exposure_detail.2m_apart")
 
   return (
     <>
@@ -61,7 +67,7 @@ const ExposureActions: FunctionComponent = () => {
           />
           <RecommendationBubble
             icon={Icons.StayApart}
-            text={t("exposure_history.exposure_detail.6ft_apart")}
+            text={stayApartRecommendationText}
           />
           <RecommendationBubble
             icon={Icons.WashHands}

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -19,5 +19,6 @@ export default Factory.define<Configuration>(() => ({
   healthAuthoritySupportsAnalytics: false,
   healthAuthorityAnalyticsUrl: null,
   healthAuthorityAnalyticsSiteId: null,
+  measurementSystem: "Imperial",
   regionCodes: ["REGION"],
 }))

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,6 +81,7 @@
   "exposure_history": {
     "check_for_exposures": "Check for exposures",
     "exposure_detail": {
+      "2m_apart": "2m apart",
       "6ft_apart": "6ft apart",
       "general_guidance": "General Guidance",
       "ha_guidance_header": "What should I do?",
@@ -102,6 +103,7 @@
       "six_feet_apart": "Stay 6 feet apart",
       "stay_home": "Stay home when sick",
       "title": "Health Guidelines",
+      "two_meters_apart": "Stay 2 meters apart",
       "wash_your_hands": "Wash your hands often",
       "wear_a_mask": "Wear a mask"
     },


### PR DESCRIPTION
Why:
Currently we only have support for units using the imperial system. We
would like for the app to be able to support metric units.

This commit:
Adds a configuration based of an environment variable for setting the
measurement system to either metric or imperial. If metric is not
provided, we default to imperial.
