### PR TITLE
Add copy for self screener start

### DIFF
--- a/src/SelfScreener/CallEmergencyServices.tsx
+++ b/src/SelfScreener/CallEmergencyServices.tsx
@@ -57,7 +57,7 @@ const CallEmergencyServices: FunctionComponent = () => {
       <TouchableOpacity
         onPress={handleOnPressCallEmergencyServices}
         accessibilityLabel={t(
-          "self_screen.call_emergency_services.call_emergency_services",
+          "self_screener.call_emergency_services.call_emergency_services",
         )}
         accessibilityRole="button"
         style={style.buttonContainer}

--- a/src/SelfScreener/SelfScreenerIntro.tsx
+++ b/src/SelfScreener/SelfScreenerIntro.tsx
@@ -12,6 +12,7 @@ import { SvgXml } from "react-native-svg"
 
 import { SelfScreenerStackScreens, useStatusBarEffect } from "../navigation"
 import { Button, GlobalText, StatusBar } from "../components"
+import { useConfigurationContext } from "../ConfigurationContext"
 
 import {
   Colors,
@@ -27,6 +28,10 @@ const SelfScreenerIntro: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const { t } = useTranslation()
   const navigation = useNavigation()
+  const {
+    emergencyPhoneNumber,
+    healthAuthorityName,
+  } = useConfigurationContext()
 
   const handleOnPressStartScreener = () => {
     navigation.navigate(SelfScreenerStackScreens.EmergencySymptomsQuestions)
@@ -81,7 +86,9 @@ const SelfScreenerIntro: FunctionComponent = () => {
               <View style={style.bullet} />
             </View>
             <GlobalText style={style.bulletText}>
-              {t("self_screener.intro.you_are_a_resident")}
+              {t("self_screener.intro.you_are_a_resident", {
+                healthAuthorityName,
+              })}
             </GlobalText>
           </View>
           <View style={style.bulletRow}>
@@ -102,7 +109,7 @@ const SelfScreenerIntro: FunctionComponent = () => {
               />
             </View>
             <GlobalText style={style.bulletText}>
-              {t("self_screener.intro.if_this_is")}
+              {t("self_screener.intro.if_this_is", { emergencyPhoneNumber })}
             </GlobalText>
           </View>
         </View>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -272,6 +272,7 @@
       "urgent_medical_attention_needed": "Urgent medical attention may be needed. Please call 911 or go to the Emergency Department"
     },
     "emergency_symptoms": {
+      "are_you_experiencing": "Are you experiencing any of these emergency symptoms?",
       "chest_pain": "Severe, constant chest pain or pressure",
       "difficulty_breathing": "Extreme difficulty breathing",
       "disorientation": "Serious disorientation or unresponsiveness",
@@ -322,7 +323,12 @@
     },
     "intro": {
       "agree_and_start_screener": "Agree and start screener",
-      "covid19_self_screener": "COVID-19 Self Screener"
+      "covid19_self_screener": "COVID-19 Self Screener",
+      "find_out_how_to_care": "Find out how to care for yourself and others after close contact with someone positive for COVID-19",
+      "if_this_is": "If this is an emergency, please call {{emergencyPhoneNumber}}",
+      "this_is_based_on": "This is based on the latest guidance from the CDC and may be updated over time as we learn move about how the virus spreads and the illness it causes",
+      "this_is_not_intended": "This is not intended for diagnosis or treatment",
+      "you_are_a_resident": "You are a resident of the community supported by {{ healthAuthorityName }}"
     },
     "no_emergency_symptoms": {
       "glad_to_hear": "Thanks, glad you're no experiencing emergency symptoms.",


### PR DESCRIPTION
Why:
Currently we arent providing copy for the self screener intro screen,
which is causing CI to fail for any commit that updates the translations
file.

This commit:
Adds the copy to the self screener intro screen.


<img width="584" alt="Screen Shot 2020-10-02 at 9 16 34 AM" src="https://user-images.githubusercontent.com/16049495/94927521-661e5e00-0490-11eb-9ee4-48520fb2c98f.png">
