### PR TITLE
Add self assessment button Home, make minor styling updates

### DIFF
--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -31,6 +31,7 @@ import {
   Button,
   GradientBackground,
 } from "../components"
+import { useConfigurationContext } from "../ConfigurationContext"
 
 import { BluetoothActivationStatus } from "./BluetoothActivationStatus"
 import { ProximityTracingActivationStatus } from "./ProximityTracingActivationStatus"
@@ -54,6 +55,7 @@ const Home: FunctionComponent = () => {
   useStatusBarEffect("light-content", Colors.gradient100Light)
   const { t } = useTranslation()
   const navigation = useNavigation()
+  const { displaySelfScreener } = useConfigurationContext()
 
   const { applicationName } = useApplicationName()
 
@@ -75,6 +77,12 @@ const Home: FunctionComponent = () => {
   const handleOnPressReportTestResult = () => {
     navigation.navigate(Stacks.Modal, {
       screen: ModalStackScreens.AffectedUserStack,
+    })
+  }
+
+  const handleOnPressTakeSelfAssessment = () => {
+    navigation.navigate(Stacks.Modal, {
+      screen: ModalStackScreens.SelfScreenerFromHome,
     })
   }
 
@@ -154,7 +162,7 @@ const Home: FunctionComponent = () => {
             <ProximityTracingActivationStatus />
             <LocationActivationStatus />
           </View>
-          <View style={style.buttonContainer}>
+          <View style={style.ctaContainer}>
             <Button
               onPress={handleOnPressReportTestResult}
               label={t("home.bluetooth.report_positive_result")}
@@ -162,6 +170,18 @@ const Home: FunctionComponent = () => {
               customButtonInnerStyle={style.buttonInner}
               hasRightArrow
             />
+            {displaySelfScreener && (
+              <Button
+                onPress={handleOnPressTakeSelfAssessment}
+                label={t("home.bluetooth.take_self_assessment")}
+                customButtonStyle={{
+                  ...style.button,
+                  ...style.selfAssessmentButton,
+                }}
+                customButtonInnerStyle={style.buttonInner}
+                outlined
+              />
+            )}
           </View>
         </View>
       </ScrollView>
@@ -183,7 +203,7 @@ const style = StyleSheet.create({
   },
   contentContainer: {
     flexGrow: 1,
-    paddingBottom: Spacing.small,
+    paddingBottom: Spacing.large,
     backgroundColor: Colors.primaryLightBackground,
   },
   topContainer: {
@@ -228,12 +248,15 @@ const style = StyleSheet.create({
     justifyContent: "space-between",
     backgroundColor: Colors.primaryLightBackground,
   },
-  buttonContainer: {
+  ctaContainer: {
     marginTop: Spacing.medium,
     marginHorizontal: Spacing.small,
   },
   button: {
     width: "100%",
+  },
+  selfAssessmentButton: {
+    marginTop: Spacing.medium,
   },
   buttonInner: {
     ...Buttons.medium,

--- a/src/SelfScreener/Guidance.tsx
+++ b/src/SelfScreener/Guidance.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react"
-import { ScrollView, StyleSheet, View } from "react-native"
+import { Image, ScrollView, StyleSheet, View } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
@@ -9,6 +9,7 @@ import { SymptomGroup } from "./selfScreener"
 import { Stack, Stacks } from "../navigation"
 
 import { Outlines, Colors, Spacing, Typography } from "../styles"
+import { Images } from "../assets"
 
 interface GuidanceProps {
   destinationOnCancel?: Stack
@@ -188,6 +189,7 @@ const Guidance: FunctionComponent<GuidanceProps> = ({
     >
       <View style={style.topScrollViewBackground} />
       <View style={style.headerContainer}>
+        <Image source={Images.SelfScreenerIntro} style={style.image} />
         <GlobalText style={style.headerText}>
           {t("self_screener.guidance.guidance")}
         </GlobalText>
@@ -213,7 +215,7 @@ const style = StyleSheet.create({
     backgroundColor: Colors.primaryLightBackground,
   },
   contentContainer: {
-    paddingBottom: Spacing.huge,
+    paddingBottom: Spacing.xxxHuge,
   },
   topScrollViewBackground: {
     position: "absolute",
@@ -224,12 +226,16 @@ const style = StyleSheet.create({
     height: "100%",
   },
   headerContainer: {
-    paddingVertical: Spacing.xLarge,
+    paddingVertical: Spacing.huge,
     paddingHorizontal: Spacing.large,
     marginBottom: Spacing.large,
     backgroundColor: Colors.secondary10,
-    borderBottomWidth: Outlines.hairline,
-    borderBottomColor: Colors.secondary75,
+  },
+  image: {
+    width: 70,
+    height: 70,
+    resizeMode: "contain",
+    marginBottom: Spacing.xLarge,
   },
   headerText: {
     ...Typography.header1,

--- a/src/SelfScreener/SelfScreenerIntro.tsx
+++ b/src/SelfScreener/SelfScreenerIntro.tsx
@@ -8,7 +8,14 @@ import { SelfScreenerStackScreens, useStatusBarEffect } from "../navigation"
 import { Button, GlobalText, StatusBar } from "../components"
 import { useConfigurationContext } from "../ConfigurationContext"
 
-import { Colors, Iconography, Layout, Spacing, Typography } from "../styles"
+import {
+  Colors,
+  Iconography,
+  Layout,
+  Outlines,
+  Spacing,
+  Typography,
+} from "../styles"
 import { Icons } from "../assets"
 
 const SelfScreenerIntro: FunctionComponent = () => {
@@ -70,7 +77,7 @@ const SelfScreenerIntro: FunctionComponent = () => {
           <GlobalText style={style.bulletText}>
             {t("self_screener.intro.this_is_based_on")}
           </GlobalText>
-          <GlobalText style={style.bulletText}>
+          <GlobalText style={{ ...style.bulletText, ...style.emergencyText }}>
             {t("self_screener.intro.if_this_is", { emergencyPhoneNumber })}
           </GlobalText>
         </View>
@@ -121,6 +128,10 @@ const style = StyleSheet.create({
   bulletText: {
     ...Typography.body2,
     marginBottom: Spacing.medium,
+  },
+  emergencyText: {
+    ...Typography.mediumBold,
+    color: Colors.danger100,
   },
   button: {
     width: "100%",

--- a/src/SelfScreener/SelfScreenerIntro.tsx
+++ b/src/SelfScreener/SelfScreenerIntro.tsx
@@ -8,14 +8,7 @@ import { SelfScreenerStackScreens, useStatusBarEffect } from "../navigation"
 import { Button, GlobalText, StatusBar } from "../components"
 import { useConfigurationContext } from "../ConfigurationContext"
 
-import {
-  Colors,
-  Iconography,
-  Layout,
-  Outlines,
-  Spacing,
-  Typography,
-} from "../styles"
+import { Colors, Iconography, Layout, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
 
 const SelfScreenerIntro: FunctionComponent = () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,6 +136,7 @@
       "report_positive_result": "Report positive test result",
       "share": "Share the app and help protect yourself and others.",
       "share_message": "Check out this app {{applicationName}}, which can help us contain COVID-19! {{appDownloadLink}}",
+      "take_self_assessment": "Take self assessment",
       "tracing_off_header": "Inactive",
       "tracing_off_subheader": "Enable Bluetooth and Proximity Tracing to get info about possible exposures",
       "tracing_off_subheader_location": "Enable Bluetooth, Proximity Tracing, and Location to get info about possible exposures",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -291,7 +291,7 @@
       "feeling_fine": "Good to hear you’re feeling fine. You shuold monitor your symptoms and stay at home.",
       "find_telehealth": "Find telehealth services",
       "follow_cdc_guidance": "If you develop symptoms, follow CDC guidance.",
-      "guidance": "Guidance",
+      "guidance": "Your Guidance",
       "if_symptoms_develop": "If you develop any COVID-19 symptoms or if you start to feel worse, call your healthcare provider, clinician advice line, or telemedicine provider.",
       "may_help_you_feel_better": "Here are some steps that may help you feel better:",
       "monitor_your_symptoms": "Sorry you’re feeling ill. Stay at home and monitor your symptoms. Call your provider if you get worse symptoms, stay at home.",

--- a/src/navigation/ModalStack.tsx
+++ b/src/navigation/ModalStack.tsx
@@ -32,12 +32,12 @@ const ModalStack: FunctionComponent = () => {
         name={Stacks.AffectedUserStack}
         component={AffectedUserStack}
       />
-      <Stack.Screen name={Stacks.HowItWorksReviewFromSettings}>
+      <Stack.Screen name={ModalStackScreens.HowItWorksReviewFromSettings}>
         {(props) => (
           <HowItWorksStack {...props} destinationOnSkip={Stacks.Settings} />
         )}
       </Stack.Screen>
-      <Stack.Screen name={Stacks.HowItWorksReviewFromConnect}>
+      <Stack.Screen name={ModalStackScreens.HowItWorksReviewFromConnect}>
         {(props) => (
           <HowItWorksStack {...props} destinationOnSkip={Stacks.Connect} />
         )}
@@ -55,7 +55,7 @@ const ModalStack: FunctionComponent = () => {
         }}
       />
       <Stack.Screen
-        name={Stacks.SelfScreenerFromExposureDetails}
+        name={ModalStackScreens.SelfScreenerFromExposureDetails}
         options={{
           headerShown: false,
         }}
@@ -70,17 +70,14 @@ const ModalStack: FunctionComponent = () => {
         }}
       </Stack.Screen>
       <Stack.Screen
-        name={Stacks.SelfScreenerFromMyHealth}
+        name={ModalStackScreens.SelfScreenerFromHome}
         options={{
           headerShown: false,
         }}
       >
         {(props) => {
           return (
-            <SelfScreenerStack
-              {...props}
-              destinationOnCancel={Stacks.MyHealth}
-            />
+            <SelfScreenerStack {...props} destinationOnCancel={Stacks.Home} />
           )
         }}
       </Stack.Screen>

--- a/src/navigation/SelfScreenerStack.tsx
+++ b/src/navigation/SelfScreenerStack.tsx
@@ -84,7 +84,7 @@ const SelfScreenerStack: FunctionComponent<SelfScreenerStackProps> = ({
 
   const navigationBarOptions: StackNavigationOptions = {
     title: "",
-    headerStyle: { backgroundColor: Colors.secondary10 },
+    headerStyle: { backgroundColor: Colors.primaryLightBackground },
     headerLeft: backButton,
     headerRight: cancelButton,
     headerStyleInterpolator: HeaderStyleInterpolators.forNoAnimation,

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -108,7 +108,7 @@ export type ModalStackScreen =
   | "AnonymizedDataConsent"
   | "AtRiskRecommendation"
   | "SelfScreenerFromExposureDetails"
-  | "SelfScreenerFromMyHealth"
+  | "SelfScreenerFromHome"
 
 export const ModalStackScreens: {
   [key in ModalStackScreen]: ModalStackScreen
@@ -121,7 +121,7 @@ export const ModalStackScreens: {
   AnonymizedDataConsent: "AnonymizedDataConsent",
   AtRiskRecommendation: "AtRiskRecommendation",
   SelfScreenerFromExposureDetails: "SelfScreenerFromExposureDetails",
-  SelfScreenerFromMyHealth: "SelfScreenerFromMyHealth",
+  SelfScreenerFromHome: "SelfScreenerFromHome",
 }
 
 export type SettingsStackScreen =
@@ -208,13 +208,9 @@ export type Stack =
   | "ExposureHistoryFlow"
   | "Modal"
   | "HowItWorks"
-  | "HowItWorksReviewFromSettings"
-  | "HowItWorksReviewFromConnect"
   | "Settings"
   | "Home"
   | "MyHealth"
-  | "SelfScreenerFromExposureDetails"
-  | "SelfScreenerFromMyHealth"
 
 export const Stacks: { [key in Stack]: Stack } = {
   Activation: "Activation",
@@ -224,13 +220,9 @@ export const Stacks: { [key in Stack]: Stack } = {
   ExposureHistoryFlow: "ExposureHistoryFlow",
   Modal: "Modal",
   HowItWorks: "HowItWorks",
-  HowItWorksReviewFromSettings: "HowItWorksReviewFromSettings",
-  HowItWorksReviewFromConnect: "HowItWorksReviewFromConnect",
   Settings: "Settings",
   Home: "Home",
   MyHealth: "MyHealth",
-  SelfScreenerFromExposureDetails: "SelfScreenerFromExposureDetails",
-  SelfScreenerFromMyHealth: "SelfScreenerFromMyHealth",
 }
 
 export const useStatusBarEffect = (


### PR DESCRIPTION
Why:
We would like to separate the notion of the symptom log and the self screener features as these may be used independently.

This commit:
Moves the StartSelfScreener button from the MyHealthTab to the Home screen.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-05 at 14 46 58](https://user-images.githubusercontent.com/39350030/95119432-f3281800-0719-11eb-806f-a97c1c147199.png)
