### PR TITLE
Add bluetooth and location events to ios

### DIFF
--- a/ios/BT/bridge/ExposureEventEmitter.m
+++ b/ios/BT/bridge/ExposureEventEmitter.m
@@ -4,6 +4,8 @@
 // Notification/Event Names
 NSString *const onEnabledStatusUpdated = @"onEnabledStatusUpdated";
 NSString *const onExposuresChanged = @"onExposureRecordUpdated";
+NSString *const onBluetoothStatusUpdated = @"onBluetoothStatusUpdated";
+NSString *const onLocationStatusUpdated = @"onLocationStatusUpdated";
 
 @interface ExposureEventEmitter : RCTEventEmitter <RCTBridgeModule>
 @end
@@ -30,7 +32,9 @@ RCT_EXPORT_MODULE();
 - (NSArray<NSString *> *)supportedEvents {
   return @[
     onExposuresChanged,
-    onEnabledStatusUpdated
+    onEnabledStatusUpdated,
+    onBluetoothStatusUpdated,
+    onLocationStatusUpdated
   ];
 }
 


### PR DESCRIPTION
Why:
A previous commit added the `onBluetoothStatusUpdated` and
`onLocationStatusUpdated` events to for listening to required status
changes on the android side. This causes errors on the ios side when
initializing the app as these events are not registered in the native
module.

This commit:
Adds the events to the ios native layer. Note that these events are not
needed to be used on ios builds, but we still subscribe to them on the
js layer for sake of simplicity.