### PR TITLE
Update styling to make screens use similar patterns

### DIFF
--- a/src/Connect/index.tsx
+++ b/src/Connect/index.tsx
@@ -145,7 +145,8 @@ const style = StyleSheet.create({
     marginBottom: Spacing.large,
   },
   headerText: {
-    ...Typography.header2,
+    ...Typography.header1,
+    ...Typography.bold,
     marginBottom: Spacing.small,
   },
   aboutContent: {

--- a/src/ExposureHistory/History/ExposureListItem.tsx
+++ b/src/ExposureHistory/History/ExposureListItem.tsx
@@ -14,7 +14,7 @@ import {
   Colors,
   Spacing,
   Typography,
-  Outlines,
+  Affordances,
 } from "../../styles"
 
 interface ExposureListItemProps {
@@ -78,12 +78,8 @@ const ExposureListItem: FunctionComponent<ExposureListItemProps> = ({
 
 const style = StyleSheet.create({
   container: {
-    flex: 1,
-    backgroundColor: Colors.primaryLightBackground,
+    ...Affordances.floatingContainer,
     marginBottom: Spacing.medium,
-    paddingHorizontal: Spacing.medium,
-    paddingVertical: Spacing.xSmall,
-    borderRadius: Outlines.borderRadiusLarge,
   },
   innerContainer: {
     flexDirection: "row",

--- a/src/ExposureHistory/History/NoExposures.tsx
+++ b/src/ExposureHistory/History/NoExposures.tsx
@@ -4,7 +4,7 @@ import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
 
 import { Text } from "../../components"
-import { Colors, Typography, Spacing, Outlines } from "../../styles"
+import { Colors, Typography, Spacing, Affordances } from "../../styles"
 import { Icons } from "../../assets"
 import { useConfigurationContext } from "../../ConfigurationContext"
 
@@ -112,10 +112,11 @@ const HealthGuidelineItem: FunctionComponent<HealthGuidelineItemProps> = ({
 
 const style = StyleSheet.create({
   noExposureCard: {
+    ...Affordances.floatingContainer,
     backgroundColor: Colors.primary125,
-    ...Outlines.roundedBorder,
     borderColor: Colors.primary125,
     padding: Spacing.large,
+    marginBottom: Spacing.small,
   },
   headerText: {
     ...Typography.header5,
@@ -127,11 +128,7 @@ const style = StyleSheet.create({
     color: Colors.secondary10,
   },
   card: {
-    backgroundColor: Colors.primaryLightBackground,
-    ...Outlines.roundedBorder,
-    borderColor: Colors.white,
-    padding: Spacing.large,
-    marginTop: Spacing.large,
+    ...Affordances.floatingContainer,
   },
   cardHeaderText: {
     ...Typography.header3,

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -15,7 +15,7 @@ import NoExposures from "./NoExposures"
 
 import { Icons } from "../../assets"
 import { ExposureHistoryStackScreens } from "../../navigation"
-import { Buttons, Spacing, Typography, Colors } from "../../styles"
+import { Buttons, Spacing, Typography, Colors, Outlines } from "../../styles"
 
 type Posix = number
 
@@ -29,7 +29,7 @@ const History: FunctionComponent<HistoryProps> = ({
   exposures,
 }) => {
   useIsFocused()
-  useStatusBarEffect("dark-content", Colors.secondary10)
+  useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const { t } = useTranslation()
   const navigation = useNavigation()
   const { checkForNewExposures } = useExposureContext()
@@ -52,7 +52,7 @@ const History: FunctionComponent<HistoryProps> = ({
 
   return (
     <>
-      <StatusBar backgroundColor={Colors.secondary10} />
+      <StatusBar backgroundColor={Colors.primaryLightBackground} />
       <ScrollView
         contentContainerStyle={style.contentContainer}
         style={style.container}
@@ -86,6 +86,8 @@ const History: FunctionComponent<HistoryProps> = ({
             <NoExposures />
           )}
         </View>
+      </ScrollView>
+      <View style={style.bottomActionsContainer}>
         <Button
           label={t("exposure_history.check_for_exposures")}
           onPress={handleOnPressCheckForExposures}
@@ -93,7 +95,7 @@ const History: FunctionComponent<HistoryProps> = ({
           customButtonStyle={style.button}
           customButtonInnerStyle={style.buttonInner}
         />
-      </ScrollView>
+      </View>
     </>
   )
 }
@@ -104,9 +106,9 @@ const style = StyleSheet.create({
     paddingBottom: Spacing.xxHuge,
   },
   container: {
-    paddingHorizontal: Spacing.medium,
+    paddingHorizontal: Spacing.large,
     paddingBottom: Spacing.medium,
-    backgroundColor: Colors.secondary10,
+    backgroundColor: Colors.primaryLightBackground,
   },
   headerRow: {
     flexDirection: "row",
@@ -134,6 +136,15 @@ const style = StyleSheet.create({
   listContainer: {
     marginTop: Spacing.xxLarge,
     marginBottom: Spacing.large,
+  },
+  bottomActionsContainer: {
+    alignItems: "center",
+    borderTopWidth: Outlines.hairline,
+    borderColor: Colors.neutral10,
+    backgroundColor: Colors.secondary10,
+    paddingTop: Spacing.small,
+    paddingBottom: Spacing.medium,
+    paddingHorizontal: Spacing.small,
   },
   button: {
     width: "100%",

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -198,7 +198,7 @@ const style = StyleSheet.create({
   },
   contentContainer: {
     flexGrow: 1,
-    paddingBottom: Spacing.large,
+    paddingBottom: Spacing.medium,
     backgroundColor: Colors.primaryLightBackground,
   },
   topContainer: {

--- a/src/MyHealth/SymptomLogListItem.tsx
+++ b/src/MyHealth/SymptomLogListItem.tsx
@@ -58,7 +58,6 @@ const SymptomLogListItem: FunctionComponent<SymptomLogListItemProps> = ({
           <Text style={style.datetimeText}>{dateText}</Text>
           <Text style={style.datetimeText}>{timeText}</Text>
         </View>
-
         <View style={style.symptomsContainer}>
           {symptoms.map(toSymptomText)}
         </View>
@@ -69,18 +68,23 @@ const SymptomLogListItem: FunctionComponent<SymptomLogListItemProps> = ({
 
 const style = StyleSheet.create({
   symptomLogContainer: {
-    marginBottom: Spacing.xLarge,
     ...Affordances.floatingContainer,
-    paddingBottom: Spacing.medium,
+    paddingTop: 0,
+    paddingBottom: Spacing.small,
+    paddingHorizontal: 0,
+    marginBottom: Spacing.xLarge,
   },
   timeContainer: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "flex-end",
-    paddingBottom: Spacing.xxxSmall,
+    paddingTop: Spacing.xSmall + 1,
+    paddingBottom: Spacing.xSmall,
+    paddingHorizontal: Spacing.medium,
     marginBottom: Spacing.small,
-    borderBottomWidth: Outlines.hairline,
-    borderBottomColor: Colors.neutral75,
+    backgroundColor: Colors.neutral5,
+    borderTopLeftRadius: Outlines.borderRadiusLarge,
+    borderTopRightRadius: Outlines.borderRadiusLarge,
   },
   datetimeText: {
     ...Typography.monospace,
@@ -88,6 +92,7 @@ const style = StyleSheet.create({
   },
   symptomsContainer: {
     flexDirection: "column",
+    paddingHorizontal: Spacing.medium,
   },
   symptomTextContainer: {
     marginBottom: Spacing.xxxSmall,

--- a/src/MyHealth/index.tsx
+++ b/src/MyHealth/index.tsx
@@ -42,19 +42,16 @@ const SymptomLog: FunctionComponent = () => {
   }
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={style.outerContainer}>
       <StatusBar backgroundColor={Colors.primaryLightBackground} />
-
       <ScrollView
         style={style.container}
         contentContainerStyle={style.contentContainer}
         alwaysBounceVertical={false}
       >
         <Text style={style.headerText}>{t("symptom_checker.symptom_log")}</Text>
-
         {hasSymptomHistory ? <SymptomHistory /> : <NoSymptomHistory />}
       </ScrollView>
-
       <View style={style.bottomActionsContainer}>
         <Button
           onPress={handleOnPressLogSymptoms}
@@ -69,6 +66,9 @@ const SymptomLog: FunctionComponent = () => {
 }
 
 const style = StyleSheet.create({
+  outerContainer: {
+    flex: 1,
+  },
   container: {
     flex: 1,
     backgroundColor: Colors.primaryLightBackground,
@@ -85,21 +85,21 @@ const style = StyleSheet.create({
   noSymptomHistoryText: {
     ...Typography.body1,
   },
-  button: {
-    width: "100%",
-  },
-  buttonInner: {
-    ...Buttons.medium,
-    width: "100%",
-  },
   bottomActionsContainer: {
     alignItems: "center",
     borderTopWidth: Outlines.hairline,
     borderColor: Colors.neutral10,
     backgroundColor: Colors.secondary10,
     paddingTop: Spacing.small,
-    paddingBottom: Spacing.small,
-    paddingHorizontal: Spacing.large,
+    paddingBottom: Spacing.medium,
+    paddingHorizontal: Spacing.small,
+  },
+  button: {
+    width: "100%",
+  },
+  buttonInner: {
+    ...Buttons.medium,
+    width: "100%",
   },
 })
 

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -10,6 +10,7 @@ const applyOpacity = (hexColor: string, opacity: number): string => {
 
 // Neutrals
 export const white = "#ffffff"
+export const neutral5 = "#edeef3"
 export const neutral10 = "#e9eaf0"
 export const neutral25 = "#d8d8de"
 export const neutral30 = "#d6d6da"


### PR DESCRIPTION
Why:
----
We were using different design patterns on different screens, which made the app
feel disjointed and created a suboptimal user experience.

This commit:
----
Updates various screens to use the same design patterns. For example, showing
the primary action button in a similarly styled container that is stuck to the bottom
of each screen, using the same floating container styles throughout, and using
similar background colors.

![gif](https://user-images.githubusercontent.com/39350030/95227080-abfa5f80-07cb-11eb-893d-409d6992eee4.gif)