### PR TITLE
Sort symptom logs by time

### DIFF
--- a/src/MyHealth/SymptomLogContext.spec.tsx
+++ b/src/MyHealth/SymptomLogContext.spec.tsx
@@ -134,5 +134,5 @@ describe("SymptomLogProvider", () => {
 const SymptomLogConsumer = () => {
   const { symptomLogEntries } = useSymptomLogContext()
 
-  return <Text>{JSON.stringify(symptomLogEntries)}</Text>
+  return <Text testID="symptom-logs">{JSON.stringify(symptomLogEntries)}</Text>
 }

--- a/src/MyHealth/SymptomLogContext.tsx
+++ b/src/MyHealth/SymptomLogContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react"
 
-import { SymptomLogEntry, Symptom } from "./symptoms"
+import { SymptomLogEntry, Symptom, sortSymptomEntries } from "./symptoms"
 import {
   getLogEntries,
   createLogEntry,
@@ -54,7 +54,8 @@ export const SymptomLogProvider: FunctionComponent = ({ children }) => {
 
   const fetchLogEntries = async () => {
     const entries = await getLogEntries()
-    setSymptomLogEntries(entries)
+    const sortedEntries = sortSymptomEntries(entries)
+    setSymptomLogEntries(sortedEntries)
   }
 
   const cleanupStaleData = async () => {

--- a/src/MyHealth/symptoms.spec.ts
+++ b/src/MyHealth/symptoms.spec.ts
@@ -1,0 +1,43 @@
+import { SymptomLogEntry, sortSymptomEntries } from "./symptoms"
+
+describe("sortSymptomEntries", () => {
+  it("returns a list log entries sorted by time descending", () => {
+    const log1DateTime = Date.parse("10-1-2020 10:00")
+    const log2DateTime = Date.parse("10-2-2020 10:00")
+    const log3DateTime = Date.parse("10-2-2020 10:05")
+    const log4DateTime = Date.parse("10-2-2020 10:10")
+    const log5DateTime = Date.parse("10-3-2020 10:00")
+
+    const log1: SymptomLogEntry = {
+      id: "1",
+      symptoms: ["fever", "cough"],
+      date: log1DateTime,
+    }
+    const log2: SymptomLogEntry = {
+      id: "2",
+      symptoms: ["fever", "cough"],
+      date: log2DateTime,
+    }
+    const log3: SymptomLogEntry = {
+      id: "3",
+      symptoms: ["fever", "cough"],
+      date: log3DateTime,
+    }
+    const log4: SymptomLogEntry = {
+      id: "4",
+      symptoms: ["fever", "cough"],
+      date: log4DateTime,
+    }
+    const log5: SymptomLogEntry = {
+      id: "5",
+      symptoms: ["fever", "cough"],
+      date: log5DateTime,
+    }
+    const unsortedEntries = [log3, log1, log4, log2, log5]
+
+    const result = sortSymptomEntries(unsortedEntries)
+
+    const expected = [log5, log4, log3, log2, log1]
+    expect(result).toEqual(expected)
+  })
+})

--- a/src/MyHealth/symptoms.ts
+++ b/src/MyHealth/symptoms.ts
@@ -23,3 +23,16 @@ export type SymptomLogEntry = {
 }
 
 export type SymptomLogEntryAttributes = Omit<SymptomLogEntry, "id">
+
+export const sortSymptomEntries = (
+  entries: SymptomLogEntry[],
+): SymptomLogEntry[] => {
+  const compareEntries = (
+    entryA: SymptomLogEntry,
+    entryB: SymptomLogEntry,
+  ): number => {
+    return Math.sign(entryB.date - entryA.date)
+  }
+
+  return entries.sort(compareEntries)
+}


### PR DESCRIPTION
Why:
We would like symptom logs to be sorted by time descending

Co-Authored-By: alejandro dustet <alejandro@thoughtbot.com>
Co-Authored-By: devin jameson <devin@thoughtbot.com>