### PR TITLE
Display information about the logs timeline

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/SymptomLogEntryModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/SymptomLogEntryModule.java
@@ -64,8 +64,8 @@ public class SymptomLogEntryModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void deleteStaleSymptomLogs(Promise promise) {
-    RealmSecureStorageBte.INSTANCE.deleteStaleSymptomLogs();
+  public void deleteSymptomLogsOlderThan(Integer days, final Promise promise) {
+    RealmSecureStorageBte.INSTANCE.deleteSymptomLogsOlderThan(days);
     promise.resolve(null);
   }
 }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
@@ -170,7 +170,7 @@ object RealmSecureStorageBte {
         getRealmInstance().use {
             it.executeTransaction { db ->
                 db.where(CheckIn::class.java)
-                    .lessThan("date", fourteenDaysAgo())
+                    .lessThan("date", daysAgo(14))
                     .findAll()
                     ?.deleteAllFromRealm()
             }
@@ -204,11 +204,11 @@ object RealmSecureStorageBte {
         }
     }
 
-    fun deleteStaleSymptomLogs() {
+    fun deleteSymptomLogsOlderThan(days: Long) {
         getRealmInstance().use {
             it.executeTransaction { db ->
                 db.where(SymptomLogEntry::class.java)
-                    .lessThan("date", fourteenDaysAgo())
+                    .lessThan("date", daysAgo(days))
                     .findAll()
                     ?.deleteAllFromRealm()
             }
@@ -226,7 +226,7 @@ object RealmSecureStorageBte {
         return Realm.getInstance(realmConfig)
     }
 
-    private fun fourteenDaysAgo(): Long {
-        return Instant.now().plus(-14, ChronoUnit.DAYS).toEpochMilli()
+    private fun daysAgo(days: Long): Long {
+        return Instant.now().plus(-1 * days, ChronoUnit.DAYS).toEpochMilli()
     }
 }

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -169,8 +169,8 @@ final class ExposureManager: NSObject {
     return btSecureStorage.symptomLogEntries.map { $0.asDictionary }
   }
 
-  @objc func deleteStaleLogEntries() {
-    btSecureStorage.deleteFourteenDaysOldSymptomLogEntries()
+  @objc func deleteSymptomLogsOlderThan(_ days: Int) {
+    btSecureStorage.deleteSymptomLogsOlderThan(days)
   }
 
   /// Persists SymptomLogEntry in Realm

--- a/ios/BT/Extensions/Foundation/Date+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Date+Extensions.swift
@@ -6,7 +6,7 @@ extension Date {
   static func hourDifference(from startDate: Date, to endDate: Date) -> Int {
     Calendar.current.dateComponents([.hour], from: startDate, to: endDate).hour ?? 0
   }
-  
+
   static func daysAgoInPosix(_ days: Int) -> Int {
     return Calendar.current.date(byAdding: DateComponents(day: -1 * days), to: Date())!.posixRepresentation
   }

--- a/ios/BT/Storage/BTSecureStorage.swift
+++ b/ios/BT/Storage/BTSecureStorage.swift
@@ -101,10 +101,10 @@ class BTSecureStorage: SafePathsSecureStorage {
     }
   }
 
-  func deleteFourteenDaysOldSymptomLogEntries() {
+  func deleteSymptomLogsOlderThan(_ days: Int) {
     let realm = try! Realm(configuration: realmConfig)
     try! realm.write {
-      let staleObjects = realm.objects(SymptomLogEntry.self).filter("date <= %@", Date.daysAgoInPosix(14))
+      let staleObjects = realm.objects(SymptomLogEntry.self).filter("date <= %@", Date.daysAgoInPosix(days))
       realm.delete(staleObjects)
     }
   }

--- a/ios/BT/bridge/SymptomLogEntryModule.m
+++ b/ios/BT/bridge/SymptomLogEntryModule.m
@@ -56,11 +56,12 @@ RCT_REMAP_METHOD(deleteSymptomLogs,
   resolve(nil);
 }
 
-RCT_REMAP_METHOD(deleteStaleSymptomLogs,
-                 deleteStaleSymptomLogsWithResolver:(RCTPromiseResolveBlock)resolve
+RCT_REMAP_METHOD(deleteSymptomLogsOlderThan,
+                 days:(NSInteger)days
+                 resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-  [[ExposureManager shared] deleteStaleLogEntries];
+  [[ExposureManager shared] deleteSymptomLogsOlderThan:days];
   resolve(nil);
 }
 

--- a/src/MyHealth/SymptomLogContext.spec.tsx
+++ b/src/MyHealth/SymptomLogContext.spec.tsx
@@ -6,7 +6,7 @@ import { useSymptomLogContext, SymptomLogProvider } from "./SymptomLogContext"
 import {
   getLogEntries,
   createLogEntry,
-  deleteStaleSymptomLogs,
+  deleteSymptomLogsOlderThan,
 } from "./nativeModule"
 import { Symptom } from "./symptoms"
 import Logger from "../logger"
@@ -116,7 +116,7 @@ describe("SymptomLogProvider", () => {
     })
 
     it("deletes all the stale data on load", async () => {
-      const deleteStaleSymptomLogsSpy = deleteStaleSymptomLogs as jest.Mock
+      const deleteSymptomLogsOlderThanSpy = deleteSymptomLogsOlderThan as jest.Mock
 
       render(
         <SymptomLogProvider>
@@ -125,7 +125,7 @@ describe("SymptomLogProvider", () => {
       )
 
       await waitFor(() => {
-        expect(deleteStaleSymptomLogsSpy).toHaveBeenCalled()
+        expect(deleteSymptomLogsOlderThanSpy).toHaveBeenCalledWith(14)
       })
     })
   })

--- a/src/MyHealth/SymptomLogContext.tsx
+++ b/src/MyHealth/SymptomLogContext.tsx
@@ -13,7 +13,7 @@ import {
   modifyLogEntry,
   deleteLogEntry as removeLogEntry,
   deleteAllSymptomLogs as deleteLogs,
-  deleteStaleSymptomLogs,
+  deleteSymptomLogsOlderThan,
 } from "./nativeModule"
 import {
   failureResponse,
@@ -47,6 +47,8 @@ const initialState: SymptomLogState = {
 
 export const SymptomLogContext = createContext<SymptomLogState>(initialState)
 
+export const DAYS_AFTER_LOG_IS_CONSIDERED_STALE = 14
+
 export const SymptomLogProvider: FunctionComponent = ({ children }) => {
   const [symptomLogEntries, setSymptomLogEntries] = useState<SymptomLogEntry[]>(
     [],
@@ -59,7 +61,7 @@ export const SymptomLogProvider: FunctionComponent = ({ children }) => {
   }
 
   const cleanupStaleData = async () => {
-    await deleteStaleSymptomLogs()
+    await deleteSymptomLogsOlderThan(DAYS_AFTER_LOG_IS_CONSIDERED_STALE)
   }
 
   useEffect(() => {

--- a/src/MyHealth/index.tsx
+++ b/src/MyHealth/index.tsx
@@ -3,7 +3,10 @@ import { ScrollView, StyleSheet, View } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
-import { useSymptomLogContext } from "./SymptomLogContext"
+import {
+  DAYS_AFTER_LOG_IS_CONSIDERED_STALE,
+  useSymptomLogContext,
+} from "./SymptomLogContext"
 import { SymptomLogEntry } from "./symptoms"
 import { Text, StatusBar, Button } from "../components"
 import { useStatusBarEffect, MyHealthStackScreens } from "../navigation"
@@ -50,6 +53,12 @@ const SymptomLog: FunctionComponent = () => {
         alwaysBounceVertical={false}
       >
         <Text style={style.headerText}>{t("symptom_checker.symptom_log")}</Text>
+        <Text style={style.subHeaderText}>
+          {t("symptom_checker.to_protect_your_privacy", {
+            days: DAYS_AFTER_LOG_IS_CONSIDERED_STALE,
+          })}
+        </Text>
+
         {hasSymptomHistory ? <SymptomHistory /> : <NoSymptomHistory />}
       </ScrollView>
       <View style={style.bottomActionsContainer}>
@@ -80,6 +89,10 @@ const style = StyleSheet.create({
   headerText: {
     ...Typography.header1,
     ...Typography.bold,
+    marginBottom: Spacing.xxxSmall,
+  },
+  subHeaderText: {
+    ...Typography.body3,
     marginBottom: Spacing.large,
   },
   noSymptomHistoryText: {

--- a/src/MyHealth/nativeModule.ts
+++ b/src/MyHealth/nativeModule.ts
@@ -30,6 +30,8 @@ export const deleteAllSymptomLogs = async (): Promise<void> => {
   return symptomLogEntryModule.deleteSymptomLogs()
 }
 
-export const deleteStaleSymptomLogs = async (): Promise<void> => {
-  return symptomLogEntryModule.deleteStaleSymptomLogs()
+export const deleteSymptomLogsOlderThan = async (
+  days: number,
+): Promise<void> => {
+  return symptomLogEntryModule.deleteSymptomLogsOlderThan(days)
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -365,6 +365,7 @@
     "get_tested": "We recommend you get tested for COVID-19.",
     "guidance": "Guidance",
     "log_symptoms": "Log symptoms",
+    "to_protect_your_privacy": "To protect your privacy, logs more than {{days}} days old are deleted",
     "no_symptom_history": "No symptom history…",
     "person_finding_location_label": "A person on their phone searching for a location.",
     "sorry_not_feeling_well": "Sorry you're not feeling well.",


### PR DESCRIPTION
Why:
----

The application will delete stale logs, currently 14 days automatically. Users should be aware of this information.

This Commit:
----

- Change android delete stale entries to receive a number of days
- Change ios delete stale logs to receive a number of days
- Change stale symptom deletion to send a number of days
- Display info for users of the data that will be kept on the device

<img width="584" alt="Screen Shot 2020-10-06 at 12 57 30 PM" src="https://user-images.githubusercontent.com/2413802/95235672-e1a34680-07d3-11eb-93ed-cef11834557b.png">



