### PR TITLE
Set Infectiousness value of 1 for keys with unknown symptom onset date

### DIFF
--- a/ios/BT/API/Model/DailySummariesConfiguration.swift
+++ b/ios/BT/API/Model/DailySummariesConfiguration.swift
@@ -11,12 +11,13 @@ struct DailySummariesConfiguration: ExposureConfiguration {
   let reportTypeWeights: [Double]
   let reportTypeWhenMissing: Int
   let infectiousnessWeights: [Double]
-  let daysSinceOnsetToInfectiousness: [NSNumber:NSNumber]
   let infectiousnessWhenDaysSinceOnsetMissing: Int
   let triggerThresholdWeightedDuration: Int
+  var daysSinceOnsetToInfectiousness: [NSNumber:NSNumber]
 
   static var placeholder: DailySummariesConfiguration = {
-    let daysSinceOnsetToInfectiousness: [NSNumber:NSNumber] = [-2:1,
+    let daysSinceOnsetToInfectiousness: [NSNumber:NSNumber] = [NSNumber(value: ENDaysSinceOnsetOfSymptomsUnknown): infectiousnessValueUnknownDaysSinceOnsetOfSymptoms,
+                                                               -2:1,
                                                                -1:1,
                                                                0:1,
                                                                1:1,
@@ -34,13 +35,13 @@ struct DailySummariesConfiguration: ExposureConfiguration {
                                                                13:1,
                                                                14:1]
     return DailySummariesConfiguration(attenuationDurationThresholds: [40, 53, 60],
-                                   attenuationBucketWeights: [1, 1, 0.5, 0],
-                                   reportTypeWeights: [1, 0, 0, 0],
-                                   reportTypeWhenMissing: 1,
-                                   infectiousnessWeights: [1, 1],
-                                   daysSinceOnsetToInfectiousness: daysSinceOnsetToInfectiousness,
-                                   infectiousnessWhenDaysSinceOnsetMissing: 1,
-                                   triggerThresholdWeightedDuration: 15)
+                                       attenuationBucketWeights: [1, 1, 0.5, 0],
+                                       reportTypeWeights: [1, 0, 0, 0],
+                                       reportTypeWhenMissing: 1,
+                                       infectiousnessWeights: [1, 1],
+                                       infectiousnessWhenDaysSinceOnsetMissing: 1,
+                                       triggerThresholdWeightedDuration: 15,
+                                       daysSinceOnsetToInfectiousness: daysSinceOnsetToInfectiousness)
   }()
 
   var asENExposureConfiguration: ENExposureConfiguration {
@@ -60,6 +61,8 @@ struct DailySummariesConfiguration: ExposureConfiguration {
     config.reportTypeNoneMap = ENDiagnosisReportType.confirmedTest
     return config
   }
+
+  private static let infectiousnessValueUnknownDaysSinceOnsetOfSymptoms: NSNumber = 1
 }
 
 @available(iOS 13.7, *)
@@ -73,6 +76,7 @@ extension DailySummariesConfiguration: DownloadableFile {
     var dailySummariesConfiguration: DailySummariesConfiguration
     do {
       dailySummariesConfiguration = try parse(data: data)
+      dailySummariesConfiguration.daysSinceOnsetToInfectiousness[NSNumber(value: ENDaysSinceOnsetOfSymptomsUnknown)] = infectiousnessValueUnknownDaysSinceOnsetOfSymptoms
       try data.write(to: saveLocalPath)
     } catch {
       do {
@@ -104,8 +108,9 @@ extension DailySummariesConfiguration: DownloadableFile {
                                        reportTypeWeights: reportTypeWeights,
                                        reportTypeWhenMissing: reportTypeWhenMissing,
                                        infectiousnessWeights: infectiousnessWeights,
-                                       daysSinceOnsetToInfectiousness: daysSinceOnsetToInfectiousness,
                                        infectiousnessWhenDaysSinceOnsetMissing: infectiousnessWhenDaysSinceOnsetMissing,
-                                       triggerThresholdWeightedDuration: triggerThresholdWeightedDuration)
+                                       triggerThresholdWeightedDuration: triggerThresholdWeightedDuration,
+                                       daysSinceOnsetToInfectiousness: daysSinceOnsetToInfectiousness)
   }
+
 }

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -1445,7 +1445,6 @@ class ExposureManagerTests: XCTestCase {
       switch result {
       case .success(let files):
         XCTAssertEqual(files, 1)
-        storeExposureExpectation.fulfill()
       default: XCTFail()
       }
     }
@@ -1454,49 +1453,33 @@ class ExposureManagerTests: XCTestCase {
 
   @available(iOS 13.7, *)
   func testValidDailySummariesConfiguration() {
-    let configMissingENDaysSinceOnsetOfSymptomsUnknown: DailySummariesConfiguration = {
-      let daysSinceOnsetToInfectiousness: [NSNumber:NSNumber] = [-2:1,
-                                                                 -1:1,
-                                                                 0:1,
-                                                                 1:1,
-                                                                 2:1,
-                                                                 3:1,
-                                                                 4:1,
-                                                                 5:1,
-                                                                 6:1,
-                                                                 7:1,
-                                                                 8:1,
-                                                                 9:1,
-                                                                 10:1,
-                                                                 11:1,
-                                                                 12:1,
-                                                                 13:1,
-                                                                 14:1]
-      return DailySummariesConfiguration(attenuationDurationThresholds: [40, 53, 60],
-                                         attenuationBucketWeights: [1, 1, 0.5, 0],
-                                         reportTypeWeights: [1, 0, 0, 0],
-                                         reportTypeWhenMissing: 1,
-                                         infectiousnessWeights: [1, 1],
-                                         infectiousnessWhenDaysSinceOnsetMissing: 1,
-                                         triggerThresholdWeightedDuration: 15,
-                                         daysSinceOnsetToInfectiousness: daysSinceOnsetToInfectiousness)
-    }()
-    let enManagerMock = ENManagerMock()
-    let apiClientMock = APIClientMock { (request, requestType) -> (AnyObject) in
-      return Result<String>.success("indexFilePath") as AnyObject
-    }
-
-    apiClientMock.downloadRequestHander = { (request, requestType) in
-      return Result<DailySummariesConfiguration>.success(configMissingENDaysSinceOnsetOfSymptomsUnknown)
-    }
-    let exposureManager = ExposureManager(exposureNotificationManager: enManagerMock,
-                                          apiClient: apiClientMock)
-    do {
-      let config = try await(exposureManager.getExposureConfigurationV2())
-      XCTAssertEqual(config.daysSinceOnsetToInfectiousness[NSNumber(value: ENDaysSinceOnsetOfSymptomsUnknown)], 1)
-    } catch {
-      XCTFail()
-    }
+    let dict: [String: Any] = ["DailySummariesConfig": ["attenuationDurationThresholds": [40,53,60],
+                                                        "attenuationBucketWeights": [1,1,0.5,0],
+                                                        "reportTypeWeights": [1,0,0,0],
+                                                        "reportTypeWhenMissing": 1,
+                                                        "infectiousnessWeights": [1,1],
+                                                        "infectiousnessWhenDaysSinceOnsetMissing": 1,
+                                                        "daysSinceOnsetToInfectiousness": [[-2,1],
+                                                                                           [-1,1],
+                                                                                           [0,1],
+                                                                                           [1,1],
+                                                                                           [2,1],
+                                                                                           [3,1],
+                                                                                           [4,1],
+                                                                                           [5,1],
+                                                                                           [6,1],
+                                                                                           [7,1],
+                                                                                           [8,1],
+                                                                                           [9,1],
+                                                                                           [10,1],
+                                                                                           [11,1],
+                                                                                           [12,1],
+                                                                                           [13,1],
+                                                                                           [14,1]]],
+                               "triggerThresholdWeightedDuration": 15]
+    let jsonData = try! JSONSerialization.data(withJSONObject: dict)
+    let config = DailySummariesConfiguration.create(from: jsonData)!
+    XCTAssertEqual(config.daysSinceOnsetToInfectiousness[NSNumber(value: ENDaysSinceOnsetOfSymptomsUnknown)], 1)
   }
 
   @available(iOS 13.7, *)

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -1445,12 +1445,59 @@ class ExposureManagerTests: XCTestCase {
       switch result {
       case .success(let files):
         XCTAssertEqual(files, 1)
+        storeExposureExpectation.fulfill()
       default: XCTFail()
       }
     }
     wait(for: [storeExposureExpectation], timeout:2)
   }
 
+  @available(iOS 13.7, *)
+  func testValidDailySummariesConfiguration() {
+    let configMissingENDaysSinceOnsetOfSymptomsUnknown: DailySummariesConfiguration = {
+      let daysSinceOnsetToInfectiousness: [NSNumber:NSNumber] = [-2:1,
+                                                                 -1:1,
+                                                                 0:1,
+                                                                 1:1,
+                                                                 2:1,
+                                                                 3:1,
+                                                                 4:1,
+                                                                 5:1,
+                                                                 6:1,
+                                                                 7:1,
+                                                                 8:1,
+                                                                 9:1,
+                                                                 10:1,
+                                                                 11:1,
+                                                                 12:1,
+                                                                 13:1,
+                                                                 14:1]
+      return DailySummariesConfiguration(attenuationDurationThresholds: [40, 53, 60],
+                                         attenuationBucketWeights: [1, 1, 0.5, 0],
+                                         reportTypeWeights: [1, 0, 0, 0],
+                                         reportTypeWhenMissing: 1,
+                                         infectiousnessWeights: [1, 1],
+                                         infectiousnessWhenDaysSinceOnsetMissing: 1,
+                                         triggerThresholdWeightedDuration: 15,
+                                         daysSinceOnsetToInfectiousness: daysSinceOnsetToInfectiousness)
+    }()
+    let enManagerMock = ENManagerMock()
+    let apiClientMock = APIClientMock { (request, requestType) -> (AnyObject) in
+      return Result<String>.success("indexFilePath") as AnyObject
+    }
+
+    apiClientMock.downloadRequestHander = { (request, requestType) in
+      return Result<DailySummariesConfiguration>.success(configMissingENDaysSinceOnsetOfSymptomsUnknown)
+    }
+    let exposureManager = ExposureManager(exposureNotificationManager: enManagerMock,
+                                          apiClient: apiClientMock)
+    do {
+      let config = try await(exposureManager.getExposureConfigurationV2())
+      XCTAssertEqual(config.daysSinceOnsetToInfectiousness[NSNumber(value: ENDaysSinceOnsetOfSymptomsUnknown)], 1)
+    } catch {
+      XCTFail()
+    }
+  }
 
   @available(iOS 13.7, *)
   func testDetectExposuresV2SuccessScoreBelow() {


### PR DESCRIPTION
### Why
We'd like keys representing positively diagnosed individuals with an unknown symptom onset data to have an infectiousness value of `1`

### This Commit
This commit implements the above and adds a corresponding unit test