### PR TITLE
Add first draft of covid data dashboard

### DIFF
--- a/src/COVIDDataDashboard/COVIDDataDashboard.tsx
+++ b/src/COVIDDataDashboard/COVIDDataDashboard.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from "react"
+import { StyleSheet, View } from "react-native"
+
+import StateData from "./StateData"
+import { useConfigurationContext } from "../ConfigurationContext"
+
+import { Affordances, Spacing } from "../styles"
+
+const COVIDDataDashboard: FunctionComponent = () => {
+  const { stateAbbreviation } = useConfigurationContext()
+
+  if (stateAbbreviation === null) {
+    return null
+  }
+
+  return (
+    <View style={style.dataContainer}>
+      <StateData stateAbbreviation={stateAbbreviation} />
+    </View>
+  )
+}
+
+const style = StyleSheet.create({
+  dataContainer: {
+    ...Affordances.floatingContainer,
+    marginTop: Spacing.large,
+    marginHorizontal: Spacing.small,
+    padding: 0,
+  },
+})
+
+export default COVIDDataDashboard

--- a/src/COVIDDataDashboard/StateData.tsx
+++ b/src/COVIDDataDashboard/StateData.tsx
@@ -1,0 +1,93 @@
+import React, {
+  FunctionComponent,
+  useEffect,
+  useState,
+  useCallback,
+} from "react"
+import { useTranslation } from "react-i18next"
+import { StyleSheet, View } from "react-native"
+
+import { Text } from "../components"
+import { CovidData, fetchCovidDataForState } from "./covidDataAPI"
+import { beginningOfDay } from "../utils/dateTime"
+
+import { Typography, Colors, Outlines, Spacing } from "../styles"
+
+type StateDataProps = {
+  stateAbbreviation: string
+}
+
+const StateData: FunctionComponent<StateDataProps> = ({
+  stateAbbreviation,
+}) => {
+  const { t } = useTranslation()
+  const [todayCovidData, setTodayCovidData] = useState<CovidData | null>(null)
+
+  const getTodayCovidData = useCallback(async () => {
+    const todayDate = beginningOfDay(Date.now())
+    const todayCovidDataRequestResponse = await fetchCovidDataForState(
+      stateAbbreviation,
+      todayDate,
+    )
+    if (todayCovidDataRequestResponse.kind === "success") {
+      setTodayCovidData(todayCovidDataRequestResponse.covidData)
+    }
+  }, [stateAbbreviation])
+
+  useEffect(() => {
+    getTodayCovidData()
+  }, [getTodayCovidData])
+
+  if (todayCovidData === null) {
+    return null
+  }
+
+  return (
+    <View>
+      <View style={style.headerContainer}>
+        <Text style={style.headerText}>{t("covid_data.covid_data")}</Text>
+        <Text style={style.headerText}>{stateAbbreviation.toUpperCase()}</Text>
+      </View>
+      <View style={style.labelAndDataContainer}>
+        <Text style={style.dataText}>{t("covid_data.cases_today")}</Text>
+        <Text style={style.dataText}>{todayCovidData.positiveIncrease}</Text>
+      </View>
+      <View style={style.labelAndDataContainer}>
+        <Text style={style.dataText}>{t("covid_data.deaths_today")}</Text>
+        <Text style={style.dataText}>{todayCovidData.deathIncrease}</Text>
+      </View>
+      <View style={style.labelAndDataContainer}>
+        <Text style={style.dataText}>{t("covid_data.total_cases")}</Text>
+        <Text style={style.dataText}>{todayCovidData.positive}</Text>
+      </View>
+      <View style={style.labelAndDataContainer}>
+        <Text style={style.dataText}>{t("covid_data.total_deaths")}</Text>
+        <Text style={style.dataText}>{todayCovidData.death}</Text>
+      </View>
+    </View>
+  )
+}
+
+const style = StyleSheet.create({
+  headerContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    borderBottomWidth: Outlines.hairline,
+    borderBottomColor: Colors.neutral30,
+  },
+  headerText: {
+    ...Typography.header4,
+    ...Typography.bold,
+    paddingBottom: Spacing.xSmall,
+  },
+  labelAndDataContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingTop: Spacing.xxSmall,
+  },
+  dataText: {
+    ...Typography.body1,
+  },
+})
+
+export default StateData

--- a/src/COVIDDataDashboard/covidDataAPI.ts
+++ b/src/COVIDDataDashboard/covidDataAPI.ts
@@ -1,0 +1,93 @@
+import { Posix, posixToDayjs } from "../utils/dateTime"
+import Logger from "../logger"
+
+const COVID_DATA_ENDPOINT = "https://api.covidtracking.com/v1/states/"
+const DATE_ARGUMENT_FORMAT = "YYYYDDMM"
+const ENDPOINT_FORMAT = "json"
+
+const requestHeaders = {
+  "content-type": "application/json",
+  accept: "application/json",
+}
+
+export type CovidData = {
+  positive: number
+  totalTestResults: number
+  hospitalizedCurrently: number
+  inIcuCurrently: number
+  death: number
+  positiveIncrease: number
+  totalTestResultsIncrease: number
+  deathIncrease: number
+}
+
+export interface RequestSuccess {
+  kind: "success"
+  covidData: CovidData
+}
+
+type FailureNature =
+  | "InternalError"
+  | "RequestFailed"
+  | "NetworkConnection"
+  | "Unknown"
+
+export interface RequestFailure {
+  kind: "failure"
+  nature: FailureNature
+}
+
+const isValidCovidDataResponse = (jsonResponse: Record<string, number>) => {
+  return jsonResponse["positive"] >= 0 && jsonResponse["totalTestResults"] >= 0
+}
+
+export const fetchCovidDataForState = async (
+  state: string,
+  date?: Posix,
+): Promise<RequestSuccess | RequestFailure> => {
+  const dateForTheData = date || Date.now()
+  const dayJsDate = posixToDayjs(dateForTheData)
+  if (dayJsDate === null) {
+    return {
+      kind: "failure",
+      nature: "InternalError",
+    }
+  }
+
+  const dateString = dayJsDate.local().format(DATE_ARGUMENT_FORMAT)
+
+  const endpointURL = `${COVID_DATA_ENDPOINT}/${state}/${dateString}.${ENDPOINT_FORMAT}`
+  try {
+    const response = await fetch(endpointURL, {
+      method: "GET",
+      headers: requestHeaders,
+    })
+
+    const jsonResponse = await response.json()
+
+    if (isValidCovidDataResponse(jsonResponse)) {
+      return {
+        kind: "success",
+        covidData: jsonResponse as CovidData,
+      }
+    } else {
+      Logger.error("Invalid response for covid data", {
+        jsonResponse,
+        state,
+        dateString,
+      })
+      return { kind: "failure", nature: "RequestFailed" }
+    }
+  } catch (e) {
+    Logger.error("Exception retrieving covid data", {
+      message: e.message,
+      state,
+      dateString,
+    })
+    if (e.message === "Network request failed") {
+      return { kind: "failure", nature: "NetworkConnection" }
+    } else {
+      return { kind: "failure", nature: "Unknown" }
+    }
+  }
+}

--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -9,43 +9,47 @@ export interface Configuration {
   appPackageName: string
   displayAcceptTermsOfService: boolean
   displayCallbackForm: boolean
+  displayCovidData: boolean
   displayMyHealth: boolean
   displaySelfScreener: boolean
   emergencyPhoneNumber: string
   findATestCenterUrl: string | null
   healthAuthorityAdviceUrl: string
-  healthAuthorityLearnMoreUrl: string
+  healthAuthorityAnalyticsSiteId: number | null
+  healthAuthorityAnalyticsUrl: string | null
   healthAuthorityEulaUrl: string | null
+  healthAuthorityLearnMoreUrl: string
+  healthAuthorityLegalPrivacyPolicyUrl: string | null
   healthAuthorityName: string
   healthAuthorityPrivacyPolicyUrl: string
-  healthAuthorityLegalPrivacyPolicyUrl: string | null
   healthAuthoritySupportsAnalytics: boolean
-  healthAuthorityAnalyticsUrl: string | null
-  healthAuthorityAnalyticsSiteId: number | null
   measurementSystem: MeasurementSystem
   regionCodes: string[]
+  stateAbbreviation: string | null
 }
 
-const initialState = {
+const initialState: Configuration = {
   appDownloadLink: "",
   appPackageName: "",
   displayAcceptTermsOfService: false,
   displayCallbackForm: false,
+  displayCovidData: false,
   displayMyHealth: false,
   displaySelfScreener: false,
   emergencyPhoneNumber: "",
   findATestCenterUrl: null,
   healthAuthorityAdviceUrl: "",
-  healthAuthorityLearnMoreUrl: "",
+  healthAuthorityAnalyticsSiteId: null,
+  healthAuthorityAnalyticsUrl: null,
   healthAuthorityEulaUrl: null,
+  healthAuthorityLearnMoreUrl: "",
+  healthAuthorityLegalPrivacyPolicyUrl: "",
   healthAuthorityName: "",
   healthAuthorityPrivacyPolicyUrl: "",
-  healthAuthorityLegalPrivacyPolicyUrl: "",
   healthAuthoritySupportsAnalytics: false,
-  healthAuthorityAnalyticsUrl: null,
-  healthAuthorityAnalyticsSiteId: null,
   measurementSystem: "Imperial" as const,
   regionCodes: [],
+  stateAbbreviation: "",
 }
 
 const ConfigurationContext = createContext<Configuration>(initialState)
@@ -65,6 +69,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
   const displayAcceptTermsOfService =
     env.DISPLAY_ACCEPT_TERMS_OF_SERVICE === "true"
   const displayCallbackForm = env.DISPLAY_CALLBACK_FORM === "true"
+  const displayCovidData = env.DISPLAY_COVID_DATA === "true"
   const displayMyHealth = env.DISPLAY_SYMPTOM_CHECKER === "true"
   const displaySelfScreener = env.DISPLAY_SELF_SCREENER === "true"
 
@@ -82,6 +87,9 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
   }) as string
   const regionCodes = env.REGION_CODES.split(",")
 
+  const stateAbbreviation =
+    env.STATE_ABBREVIATION?.length > 0 ? env.STATE_ABBREVIATION : null
+
   return (
     <ConfigurationContext.Provider
       value={{
@@ -89,21 +97,23 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         appPackageName,
         displayAcceptTermsOfService,
         displayCallbackForm,
+        displayCovidData,
         displayMyHealth,
         displaySelfScreener,
         emergencyPhoneNumber,
         findATestCenterUrl,
         healthAuthorityAdviceUrl,
-        healthAuthorityLearnMoreUrl,
+        healthAuthorityAnalyticsSiteId,
+        healthAuthorityAnalyticsUrl,
         healthAuthorityEulaUrl: eulaUrl || null,
-        healthAuthorityName,
+        healthAuthorityLearnMoreUrl,
         healthAuthorityLegalPrivacyPolicyUrl: legalPrivacyPolicyUrl || null,
+        healthAuthorityName,
         healthAuthorityPrivacyPolicyUrl,
         healthAuthoritySupportsAnalytics,
-        healthAuthorityAnalyticsUrl,
-        healthAuthorityAnalyticsSiteId,
         measurementSystem,
         regionCodes,
+        stateAbbreviation,
       }}
     >
       {children}

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -31,6 +31,7 @@ import { StatusBar, Text, Button, GradientBackground } from "../components"
 import { BluetoothActivationStatus } from "./BluetoothActivationStatus"
 import { ProximityTracingActivationStatus } from "./ProximityTracingActivationStatus"
 import { LocationActivationStatus } from "./LocationActivationStatus"
+import COVIDDataDashboard from "../COVIDDataDashboard/COVIDDataDashboard"
 import { ShareLink } from "./ShareLink"
 
 import { Icons } from "../assets"
@@ -50,7 +51,7 @@ const Home: FunctionComponent = () => {
   useStatusBarEffect("light-content", Colors.gradient100Light)
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const { displaySelfScreener } = useConfigurationContext()
+  const { displaySelfScreener, displayCovidData } = useConfigurationContext()
 
   const { applicationName } = useApplicationName()
 
@@ -156,6 +157,7 @@ const Home: FunctionComponent = () => {
             <BluetoothActivationStatus />
             <ProximityTracingActivationStatus />
             <LocationActivationStatus />
+            {displayCovidData && <COVIDDataDashboard />}
           </View>
           <View style={style.ctaContainer}>
             <Button

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -6,6 +6,7 @@ export default Factory.define<Configuration>(() => ({
   appPackageName: "appPackageName",
   displayAcceptTermsOfService: false,
   displayCallbackForm: false,
+  displayCovidData: false,
   displayMyHealth: false,
   displaySelfScreener: false,
   emergencyPhoneNumber: "emergencyPhoneNumber",
@@ -21,4 +22,5 @@ export default Factory.define<Configuration>(() => ({
   healthAuthorityAnalyticsSiteId: null,
   measurementSystem: "Imperial",
   regionCodes: ["REGION"],
+  stateAbbreviation: null,
 }))

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,6 +35,13 @@
     "start": "Start",
     "submit": "Submit"
   },
+  "covid_data": {
+    "covid_data": "COVID Data",
+    "cases_today": "Cases today",
+    "deaths_today": "Deaths today",
+    "total_cases": "Total cases",
+    "total_deaths": "Total deaths"
+  },
   "errors": {
     "description": "An error has occurred. Please reload the app.",
     "reload": "Reload",


### PR DESCRIPTION
Why:
----

We believe that insight on the data for the virus is a valuable asset for our users.

This Commit:
----

- Introduces a covid data component that will pull the data from a specific API and display the results on the home screen when the module for it is active from the configuration. It needs a valid state abbreviation to get the correct data for a given jurisdiction.

Co-authored-by: John Schoeman <johnschoeman1617@gmail.com>

<img width="584" alt="Screen Shot 2020-10-07 at 2 30 13 PM" src="https://user-images.githubusercontent.com/2413802/95372691-e63a2e80-08a9-11eb-8668-6ee8bb7547f7.png">

