### PR TITLE
Use display self assessment flag

### DIFF
--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -11,7 +11,7 @@ export interface Configuration {
   displayCallbackForm: boolean
   displayCovidData: boolean
   displayMyHealth: boolean
-  displaySelfScreener: boolean
+  displaySelfAssessment: boolean
   emergencyPhoneNumber: string
   findATestCenterUrl: string | null
   healthAuthorityAdviceUrl: string
@@ -35,7 +35,7 @@ const initialState: Configuration = {
   displayCallbackForm: false,
   displayCovidData: false,
   displayMyHealth: false,
-  displaySelfScreener: false,
+  displaySelfAssessment: false,
   emergencyPhoneNumber: "",
   findATestCenterUrl: null,
   healthAuthorityAdviceUrl: "",
@@ -71,7 +71,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
   const displayCallbackForm = env.DISPLAY_CALLBACK_FORM === "true"
   const displayCovidData = env.DISPLAY_COVID_DATA === "true"
   const displayMyHealth = env.DISPLAY_SYMPTOM_CHECKER === "true"
-  const displaySelfScreener = env.DISPLAY_SELF_SCREENER === "true"
+  const displaySelfAssessment = env.DISPLAY_SELF_ASSESSMENT === "true"
 
   const measurementSystem =
     env.MEASUREMENT_SYSTEM === "metric" ? "Metric" : "Imperial"
@@ -99,7 +99,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         displayCallbackForm,
         displayCovidData,
         displayMyHealth,
-        displaySelfScreener,
+        displaySelfAssessment,
         emergencyPhoneNumber,
         findATestCenterUrl,
         healthAuthorityAdviceUrl,

--- a/src/ExposureHistory/ExposureDetail.spec.tsx
+++ b/src/ExposureHistory/ExposureDetail.spec.tsx
@@ -142,7 +142,7 @@ describe("ExposureDetail", () => {
       const { getByLabelText } = render(
         <ConfigurationContext.Provider
           value={factories.configurationContext.build({
-            displaySelfScreener: true,
+            displaySelfAssessment: true,
           })}
         >
           <ExposureDetail />

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -18,7 +18,7 @@ const ExposureActions: FunctionComponent = () => {
   const navigation = useNavigation()
   const {
     displayCallbackForm,
-    displaySelfScreener,
+    displaySelfAssessment,
     healthAuthorityName,
     healthAuthorityAdviceUrl,
     measurementSystem,
@@ -35,7 +35,7 @@ const ExposureActions: FunctionComponent = () => {
   }
 
   const displayNextStepsLink =
-    !displaySelfScreener && healthAuthorityAdviceUrl !== ""
+    !displaySelfAssessment && healthAuthorityAdviceUrl !== ""
 
   const stayApartRecommendationText =
     measurementSystem === "Imperial"
@@ -74,7 +74,7 @@ const ExposureActions: FunctionComponent = () => {
             text={t("exposure_history.exposure_detail.wash_your_hands")}
           />
         </View>
-        {displaySelfScreener && (
+        {displaySelfAssessment && (
           <Button
             onPress={handleOnPressPersonalizeMyGuidance}
             label={t(

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -51,7 +51,7 @@ const Home: FunctionComponent = () => {
   useStatusBarEffect("light-content", Colors.gradient100Light)
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const { displaySelfScreener, displayCovidData } = useConfigurationContext()
+  const { displaySelfAssessment, displayCovidData } = useConfigurationContext()
 
   const { applicationName } = useApplicationName()
 
@@ -167,7 +167,7 @@ const Home: FunctionComponent = () => {
               customButtonInnerStyle={style.buttonInner}
               hasRightArrow
             />
-            {displaySelfScreener && (
+            {displaySelfAssessment && (
               <Button
                 onPress={handleOnPressTakeSelfAssessment}
                 label={t("home.bluetooth.take_self_assessment")}

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -8,7 +8,7 @@ export default Factory.define<Configuration>(() => ({
   displayCallbackForm: false,
   displayCovidData: false,
   displayMyHealth: false,
-  displaySelfScreener: false,
+  displaySelfAssessment: false,
   emergencyPhoneNumber: "emergencyPhoneNumber",
   findATestCenterUrl: "findATestCenterUrl",
   healthAuthorityAdviceUrl: "authorityAdviceUrl",


### PR DESCRIPTION
Why:
Currently we have both DISPLAY_SELF_ASSESSMENT and DISPLAY_SELF_SCREENER
as flags in the environment. We only need one. Currently we have
DISPLAY_SELF_ASSESSMENT in the remote config so we would like to change
DISPLAY_SELF_SCREENER to DISPLAY_SELF_ASSESSMENT in the codebase.

This commit:
Changes DISPLAY_SELF_SCREENER to DISPLAY_SELF_ASSESSMENT.

---

Im not 100% sure on this one. We are going back and forth between the the terms 'Self Assessment' and 'Self Screener'. I think it makes sense to pick on and use it consistently, and I feel that for what ever reason we are using 'Self Assessment' more naturally in conversation. So the code base should also use that term to match the business terms. But I wanted to double check before taking the time to rename all the components.