### PR TITLE
Use full week of covid data and show cases trend

### DIFF
--- a/src/COVIDDataDashboard/COVIDDataDashboard.tsx
+++ b/src/COVIDDataDashboard/COVIDDataDashboard.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react"
 import { StyleSheet, View } from "react-native"
 
-import StateData from "./StateData"
+import COVIDDataStateTrend from "./COVIDDataStateTrend"
 import { useConfigurationContext } from "../ConfigurationContext"
 
 import { Affordances, Spacing } from "../styles"
@@ -15,7 +15,7 @@ const COVIDDataDashboard: FunctionComponent = () => {
 
   return (
     <View style={style.dataContainer}>
-      <StateData stateAbbreviation={stateAbbreviation} />
+      <COVIDDataStateTrend stateAbbreviation={stateAbbreviation} />
     </View>
   )
 }

--- a/src/COVIDDataDashboard/COVIDDataStateTrend.tsx
+++ b/src/COVIDDataDashboard/COVIDDataStateTrend.tsx
@@ -1,0 +1,118 @@
+import React, {
+  FunctionComponent,
+  useEffect,
+  useState,
+  useCallback,
+} from "react"
+import { useTranslation } from "react-i18next"
+import { SvgXml } from "react-native-svg"
+import { StyleSheet, View } from "react-native"
+
+import { fetchCovidDataForState } from "./covidDataAPI"
+import { calculateCasesPercentageTrend } from "./covidData"
+
+import { Text } from "../components"
+import { Icons } from "../assets"
+
+import { Colors, Typography, Spacing, Outlines } from "../styles"
+
+type COVIDDataStateTrendProps = {
+  stateAbbreviation: string
+}
+
+const COVIDDataStateTrend: FunctionComponent<COVIDDataStateTrendProps> = ({
+  stateAbbreviation,
+}) => {
+  const { t } = useTranslation()
+  const [casesPercentageTrend, setCasesPercentageTrend] = useState<
+    number | null
+  >(null)
+
+  const determineCasesPercentageTrend = useCallback(async () => {
+    const covidDataResponse = await fetchCovidDataForState(stateAbbreviation)
+    if (covidDataResponse.kind === "success") {
+      setCasesPercentageTrend(
+        calculateCasesPercentageTrend(covidDataResponse.lastWeekCovidData),
+      )
+    }
+  }, [stateAbbreviation])
+
+  useEffect(() => {
+    determineCasesPercentageTrend()
+  }, [determineCasesPercentageTrend])
+
+  if (casesPercentageTrend === null) {
+    return null
+  }
+
+  const trendPercentageValue = `${Math.abs(casesPercentageTrend)}%`
+
+  const trendInfo =
+    casesPercentageTrend > 0
+      ? {
+          text: t("covid_data.cases_are_up"),
+          indicator: <SvgXml xml={Icons.ChevronUp} fill={Colors.white} />,
+        }
+      : {
+          text: t("covid_data.cases_are_down"),
+          indicator: (
+            <SvgXml
+              xml={Icons.ChevronUp}
+              fill={Colors.white}
+              style={style.downwardTrendChevron}
+            />
+          ),
+        }
+
+  return (
+    <View style={style.container}>
+      <View style={style.percentageContainer}>
+        <View style={style.trendArrowContainer}>{trendInfo.indicator}</View>
+        <Text style={style.percentageText}>{trendPercentageValue}</Text>
+      </View>
+      <View style={style.infoContainer}>
+        <Text style={style.headerText}>{stateAbbreviation.toUpperCase()}</Text>
+        <Text style={style.subHeaderText}>{trendInfo.text}</Text>
+      </View>
+    </View>
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  headerText: {
+    ...Typography.header4,
+    ...Typography.bold,
+  },
+  subHeaderText: {
+    ...Typography.body3,
+  },
+  percentageContainer: {
+    ...Outlines.ovalBorder,
+    borderWidth: 0,
+    backgroundColor: Colors.primary110,
+    paddingHorizontal: Spacing.medium,
+    paddingVertical: Spacing.xSmall,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  percentageText: {
+    ...Typography.body1,
+    color: Colors.white,
+  },
+  infoContainer: {
+    ...Typography.body1,
+  },
+  trendArrowContainer: {
+    paddingRight: Spacing.xxSmall,
+  },
+  downwardTrendChevron: {
+    transform: [{ rotate: "180deg" }],
+  },
+})
+
+export default COVIDDataStateTrend

--- a/src/COVIDDataDashboard/StateData.tsx
+++ b/src/COVIDDataDashboard/StateData.tsx
@@ -1,46 +1,22 @@
-import React, {
-  FunctionComponent,
-  useEffect,
-  useState,
-  useCallback,
-} from "react"
+import React, { FunctionComponent } from "react"
 import { useTranslation } from "react-i18next"
 import { StyleSheet, View } from "react-native"
 
 import { Text } from "../components"
-import { CovidData, fetchCovidDataForState } from "./covidDataAPI"
-import { beginningOfDay } from "../utils/dateTime"
+import { CovidData } from "./covidDataAPI"
 
 import { Typography, Colors, Outlines, Spacing } from "../styles"
 
 type StateDataProps = {
+  todayCovidData: CovidData
   stateAbbreviation: string
 }
 
 const StateData: FunctionComponent<StateDataProps> = ({
+  todayCovidData,
   stateAbbreviation,
 }) => {
   const { t } = useTranslation()
-  const [todayCovidData, setTodayCovidData] = useState<CovidData | null>(null)
-
-  const getTodayCovidData = useCallback(async () => {
-    const todayDate = beginningOfDay(Date.now())
-    const todayCovidDataRequestResponse = await fetchCovidDataForState(
-      stateAbbreviation,
-      todayDate,
-    )
-    if (todayCovidDataRequestResponse.kind === "success") {
-      setTodayCovidData(todayCovidDataRequestResponse.covidData)
-    }
-  }, [stateAbbreviation])
-
-  useEffect(() => {
-    getTodayCovidData()
-  }, [getTodayCovidData])
-
-  if (todayCovidData === null) {
-    return null
-  }
 
   return (
     <View>
@@ -50,19 +26,23 @@ const StateData: FunctionComponent<StateDataProps> = ({
       </View>
       <View style={style.labelAndDataContainer}>
         <Text style={style.dataText}>{t("covid_data.cases_today")}</Text>
-        <Text style={style.dataText}>{todayCovidData.positiveIncrease}</Text>
+        <Text style={style.dataText}>
+          {todayCovidData.peoplePositiveNewCasesCt}
+        </Text>
       </View>
       <View style={style.labelAndDataContainer}>
         <Text style={style.dataText}>{t("covid_data.deaths_today")}</Text>
-        <Text style={style.dataText}>{todayCovidData.deathIncrease}</Text>
+        <Text style={style.dataText}>{todayCovidData.peopleDeathNewCt}</Text>
       </View>
       <View style={style.labelAndDataContainer}>
         <Text style={style.dataText}>{t("covid_data.total_cases")}</Text>
-        <Text style={style.dataText}>{todayCovidData.positive}</Text>
+        <Text style={style.dataText}>
+          {todayCovidData.peoplePositiveCasesCt}
+        </Text>
       </View>
       <View style={style.labelAndDataContainer}>
         <Text style={style.dataText}>{t("covid_data.total_deaths")}</Text>
-        <Text style={style.dataText}>{todayCovidData.death}</Text>
+        <Text style={style.dataText}>{todayCovidData.peopleDeathCt}</Text>
       </View>
     </View>
   )

--- a/src/COVIDDataDashboard/covidData.spec.ts
+++ b/src/COVIDDataDashboard/covidData.spec.ts
@@ -1,0 +1,40 @@
+import { factories } from "../factories"
+import { calculateCasesPercentageTrend } from "./covidData"
+
+describe("calculateCasesPercentageTrend", () => {
+  it("returns a positive percentage trend when the cases are growing", () => {
+    const todayData = factories.covidData.build({
+      peoplePositiveNewCasesCt: 10,
+    })
+    const pastData = [
+      factories.covidData.build({
+        peoplePositiveNewCasesCt: 6,
+      }),
+      factories.covidData.build({
+        peoplePositiveNewCasesCt: 6,
+      }),
+    ]
+
+    const cumulativeData = [todayData, ...pastData]
+
+    expect(calculateCasesPercentageTrend(cumulativeData)).toEqual(40)
+  })
+
+  it("returns a negative percentage trend when the cases are shrinking", () => {
+    const todayData = factories.covidData.build({
+      peoplePositiveNewCasesCt: 6,
+    })
+    const pastData = [
+      factories.covidData.build({
+        peoplePositiveNewCasesCt: 10,
+      }),
+      factories.covidData.build({
+        peoplePositiveNewCasesCt: 10,
+      }),
+    ]
+
+    const cumulativeData = [todayData, ...pastData]
+
+    expect(calculateCasesPercentageTrend(cumulativeData)).toEqual(-67)
+  })
+})

--- a/src/COVIDDataDashboard/covidData.ts
+++ b/src/COVIDDataDashboard/covidData.ts
@@ -1,0 +1,22 @@
+import { CovidData } from "./covidDataAPI"
+
+const percentageChange = (average: number, todayCases: number) => {
+  return Math.round((1 - average / todayCases) * 100)
+}
+
+export const calculateCasesPercentageTrend = (
+  cumulativeCovidData: CovidData[],
+): number => {
+  if (cumulativeCovidData.length === 0) {
+    return 0
+  }
+  const [todayData, ...pastDaysData] = cumulativeCovidData
+  const sumOfNewCases = pastDaysData.reduce((sum, covidData) => {
+    return sum + covidData.peoplePositiveNewCasesCt
+  }, 0)
+  const averageOfNewCases = sumOfNewCases / pastDaysData.length
+
+  const newCasesToday = todayData.peoplePositiveNewCasesCt
+
+  return percentageChange(averageOfNewCases, newCasesToday)
+}

--- a/src/factories/covidData.ts
+++ b/src/factories/covidData.ts
@@ -1,0 +1,9 @@
+import { Factory } from "fishery"
+import { CovidData } from "../COVIDDataDashboard/covidDataAPI"
+
+export default Factory.define<CovidData>(() => ({
+  peopleDeathCt: 0,
+  peopleDeathNewCt: 0,
+  peoplePositiveCasesCt: 0,
+  peoplePositiveNewCasesCt: 0,
+}))

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -8,10 +8,12 @@ import symptomLogContext from "./symptomLogContext"
 import selfScreenerContext from "./selfScreenerContext"
 import selfScreenerAnswers from "./selfScreenerAnswers"
 import rawExposure from "./rawExposure"
+import covidData from "./covidData"
 
 export const factories = register({
   analyticsContext,
   configurationContext,
+  covidData,
   exposureContext,
   exposureDatum,
   gaenStrategy,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,8 +36,10 @@
     "submit": "Submit"
   },
   "covid_data": {
-    "covid_data": "COVID Data",
+    "cases_are_up": "Cases are up from last week",
+    "cases_are_down": "Cases are down from last week",
     "cases_today": "Cases today",
+    "covid_data": "COVID Data",
     "deaths_today": "Deaths today",
     "total_cases": "Total cases",
     "total_deaths": "Total deaths"


### PR DESCRIPTION
Why:
----

The info shown to users should be of a more actionable nature. This could be achieved by showing a trend of the cases instead of just the cold numbers.

This Commit:
----
- Switch endpoint to pull full week's worth of data. Now the endpoint uses the same data set but it is aggregated for a week worth of data.
- Calculate trend from last week compared to today cases
- Switch the component on the home screen to a trend data clip. Instead of showing all 4 values, we derive the trend from today's cases count and last week average.

Reviewers:
----

Currently, the `StateData` component is not being used, the plan is to include it on the following commit as a details screen for the data.

Co-authored-by: John Schoeman <johnschoeman1617@gmail.com>
Co-authored-by: Devin Jameson <devin@toughtbot.com>
Co-authored-by: Samuel Zimmerman <zimmerman.samuel@gmail.com>

<img width="584" alt="Screen Shot 2020-10-08 at 9 29 02 AM" src="https://user-images.githubusercontent.com/2413802/95465121-bd1cab00-0948-11eb-8d0b-10066978389c.png">

