### PR TITLE
(Android) Simulate exposures

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/dto/RNExposureInformation.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/dto/RNExposureInformation.java
@@ -6,11 +6,9 @@ import java.util.UUID;
 public class RNExposureInformation {
   private String id;
   private long date; // Milliseconds
-  private double duration; // Minutes
 
-  public RNExposureInformation(long date, double duration) {
+  public RNExposureInformation(long date) {
     this.id = UUID.randomUUID().toString();
     this.date = date;
-    this.duration = duration;
   }
 }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
@@ -9,6 +9,7 @@ import com.facebook.react.module.annotations.ReactModule;
 import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -18,7 +19,9 @@ import org.pathcheck.covidsafepaths.exposurenotifications.common.AppExecutors;
 import org.pathcheck.covidsafepaths.exposurenotifications.common.NotificationHelper;
 import org.pathcheck.covidsafepaths.exposurenotifications.dto.RNDiagnosisKey;
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.RealmSecureStorageBte;
+import org.pathcheck.covidsafepaths.exposurenotifications.storage.objects.ExposureEntity;
 import org.pathcheck.covidsafepaths.exposurenotifications.utils.Util;
+import org.threeten.bp.Instant;
 
 @SuppressWarnings("unused")
 @ReactModule(name = DebugMenuModule.MODULE_NAME)
@@ -72,8 +75,22 @@ public class DebugMenuModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void simulateExposure(Promise promise) {
+    RealmSecureStorageBte.INSTANCE.insertExposure(
+        ExposureEntity.create(getRandomExposureDate(), Instant.now().toEpochMilli())
+    );
     NotificationHelper.showPossibleExposureNotification(getReactApplicationContext());
     promise.resolve(null);
+  }
+
+  /**
+   * Get a random date between the last 14 days and now.
+   * @return random exposure date
+   */
+  private Long getRandomExposureDate() {
+    SecureRandom random = new SecureRandom();
+    int randomDayMillis = random.nextInt(13) * 24 * 60 * 60 * 1000;
+
+    return Instant.now().toEpochMilli() - randomDayMillis;
   }
 
   @ReactMethod

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
@@ -130,6 +130,20 @@ object RealmSecureStorageBte {
         return somethingAdded
     }
 
+    fun insertExposure(exposure: ExposureEntity) {
+        getRealmInstance().use {
+            it.executeTransaction { db ->
+                db.insert(exposure)
+            }
+        }
+    }
+
+    fun getExposures(): List<ExposureEntity> {
+        return getRealmInstance().use {
+            it.copyFromRealm(it.where(ExposureEntity::class.java).findAll())
+        }
+    }
+
     fun resetExposures() {
         getRealmInstance().use {
             it.executeTransaction { db ->


### PR DESCRIPTION
#### Why:

<!-- Provide context to the reader as to why this PR is useful or needed. -->
We need a way to test the exposure history flow without having to wait 24 hours until a real exposure is detected.

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->
Reads exposures from Realm instead of calling the API.
In that way we can created mocked exposures from the "Simulate Exposure" button.