### PR TITLE
Fix Display Bug in Debug Menu TEK List

### DIFF
--- a/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
+++ b/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
@@ -12,7 +12,6 @@ extension ENTemporaryExposureKey {
 
   var asDictionary : [String: Any] {
     return [
-      "id": UUID().uuidString,
       "key": keyData.base64EncodedString(),
       "rollingPeriod": rollingPeriod,
       "rollingStartNumber": rollingStartNumber,

--- a/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
+++ b/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
@@ -12,6 +12,7 @@ extension ENTemporaryExposureKey {
 
   var asDictionary : [String: Any] {
     return [
+      "id": UUID().uuidString,
       "key": keyData.base64EncodedString(),
       "rollingPeriod": rollingPeriod,
       "rollingStartNumber": rollingStartNumber,

--- a/src/Settings/ENLocalDiagnosisKeyScreen.tsx
+++ b/src/Settings/ENLocalDiagnosisKeyScreen.tsx
@@ -64,10 +64,12 @@ const ENLocalDiagnosisKeyScreen: FunctionComponent<ENLocalDiagnosisKeyScreenProp
 
   return (
     <ScrollView>
-      {diagnosisKeys.map((_key: ENDiagnosisKey, index: number) => {
+      {diagnosisKeys.map((key: ENDiagnosisKey, index: number) => {
         return (
           <View key={index.toString()} style={style.flatlistRowView}>
-            <Text style={style.itemText}>{index}</Text>
+            <Text
+              style={style.itemText}
+            >{`${index}:${key.rollingStartNumber}`}</Text>
           </View>
         )
       })}

--- a/src/Settings/ENLocalDiagnosisKeyScreen.tsx
+++ b/src/Settings/ENLocalDiagnosisKeyScreen.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useEffect, useState } from "react"
-import { Alert, BackHandler, FlatList, StyleSheet, View } from "react-native"
+import { Alert, BackHandler, ScrollView, StyleSheet, View } from "react-native"
 
 import { NavigationProp } from "../navigation"
 import { NativeModule } from "../gaen"
@@ -63,17 +63,15 @@ const ENLocalDiagnosisKeyScreen: FunctionComponent<ENLocalDiagnosisKeyScreenProp
   }
 
   return (
-    <FlatList
-      data={diagnosisKeys}
-      keyExtractor={(item) => {
-        return item.id
-      }}
-      renderItem={(item) => (
-        <View style={style.flatlistRowView}>
-          <Text style={style.itemText}>{item.item.id}</Text>
-        </View>
-      )}
-    />
+    <ScrollView>
+      {diagnosisKeys.map((_key: ENDiagnosisKey, index: number) => {
+        return (
+          <View key={index.toString()} style={style.flatlistRowView}>
+            <Text style={style.itemText}>{index}</Text>
+          </View>
+        )
+      })}
+    </ScrollView>
   )
 }
 

--- a/src/Settings/ENLocalDiagnosisKeyScreen.tsx
+++ b/src/Settings/ENLocalDiagnosisKeyScreen.tsx
@@ -65,12 +65,12 @@ const ENLocalDiagnosisKeyScreen: FunctionComponent<ENLocalDiagnosisKeyScreenProp
   return (
     <FlatList
       data={diagnosisKeys}
-      keyExtractor={(item) => item.id}
+      keyExtractor={(item) => {
+        return item.id
+      }}
       renderItem={(item) => (
         <View style={style.flatlistRowView}>
-          <Text style={style.itemText}>
-            Rolling start number: {item.item.rollingStartNumber}
-          </Text>
+          <Text style={style.itemText}>{item.item.id}</Text>
         </View>
       )}
     />


### PR DESCRIPTION
### Why
We'd like the `TEK` list (inside the debug menu) to display all keys fetched from the native layer

### This commit
This commit ads a unique id to the `ExposureKey` model in the iOS codebase such that it the collection can be displayed in a list
![IMG_EEAB9602BA40-1](https://user-images.githubusercontent.com/2637355/95503683-ae022100-0979-11eb-8f8f-1336117326c7.jpeg)

