### PR TITLE
Improve Home screen UI

### DIFF
--- a/src/AffectedUserFlow/Start.tsx
+++ b/src/AffectedUserFlow/Start.tsx
@@ -1,24 +1,13 @@
 import React, { FunctionComponent } from "react"
-import {
-  StyleSheet,
-  TouchableOpacity,
-  View,
-  Image,
-  ScrollView,
-} from "react-native"
+import { StyleSheet, View, Image, ScrollView } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
-import { SvgXml } from "react-native-svg"
 
-import { StatusBar, Text, Button } from "../components"
-import {
-  useStatusBarEffect,
-  AffectedUserFlowStackScreens,
-  Stacks,
-} from "../navigation"
+import { Text, Button } from "../components"
+import { useStatusBarEffect, AffectedUserFlowStackScreens } from "../navigation"
 
-import { Layout, Spacing, Colors, Iconography, Typography } from "../styles"
-import { Images, Icons } from "../assets"
+import { Spacing, Colors, Typography } from "../styles"
+import { Images } from "../assets"
 
 export const ExportIntro: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
@@ -29,52 +18,29 @@ export const ExportIntro: FunctionComponent = () => {
     navigation.navigate(AffectedUserFlowStackScreens.AffectedUserCodeInput)
   }
 
-  const handleOnPressCancel = () => {
-    navigation.navigate(Stacks.Home)
-  }
-
   return (
-    <>
-      <StatusBar backgroundColor={Colors.primaryLightBackground} />
-      <ScrollView
-        style={style.container}
-        contentContainerStyle={style.contentContainer}
-        alwaysBounceVertical={false}
-      >
-        <View style={style.cancelButtonContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressCancel}
-            accessible
-            accessibilityLabel={t("export.code_input_button_cancel")}
-          >
-            <View style={style.cancelButtonInnerContainer}>
-              <SvgXml
-                xml={Icons.X}
-                fill={Colors.black}
-                width={Iconography.xxSmall}
-                height={Iconography.xxSmall}
-              />
-            </View>
-          </TouchableOpacity>
-        </View>
-        <View>
-          <Image
-            source={Images.HowItWorksValueProposition}
-            style={style.image}
-            accessible
-            accessibilityLabel={t("export.person_and_health_expert")}
-          />
-          <Text style={style.header}>{t("export.start_header_bluetooth")}</Text>
-        </View>
-        <View style={style.buttonContainer}>
-          <Button
-            label={t("common.start")}
-            onPress={handleOnPressNext}
-            hasRightArrow
-          />
-        </View>
-      </ScrollView>
-    </>
+    <ScrollView
+      style={style.container}
+      contentContainerStyle={style.contentContainer}
+      alwaysBounceVertical={false}
+    >
+      <View>
+        <Image
+          source={Images.HowItWorksValueProposition}
+          style={style.image}
+          accessible
+          accessibilityLabel={t("export.person_and_health_expert")}
+        />
+        <Text style={style.header}>{t("export.start_header_bluetooth")}</Text>
+      </View>
+      <View style={style.buttonContainer}>
+        <Button
+          label={t("common.start")}
+          onPress={handleOnPressNext}
+          hasRightArrow
+        />
+      </View>
+    </ScrollView>
   )
 }
 
@@ -89,15 +55,6 @@ const style = StyleSheet.create({
     paddingTop: Spacing.huge,
     paddingBottom: Spacing.massive,
     backgroundColor: Colors.primaryLightBackground,
-  },
-  cancelButtonContainer: {
-    position: "absolute",
-    top: Spacing.medium,
-    right: Spacing.medium,
-    zIndex: Layout.zLevel1,
-  },
-  cancelButtonInnerContainer: {
-    padding: Spacing.medium,
   },
   image: {
     width: "100%",

--- a/src/AffectedUserFlow/index.tsx
+++ b/src/AffectedUserFlow/index.tsx
@@ -1,20 +1,38 @@
 import React, { FunctionComponent } from "react"
-import { createStackNavigator } from "@react-navigation/stack"
+import { createStackNavigator, HeaderBackButton } from "@react-navigation/stack"
+import { useNavigation } from "@react-navigation/native"
+import { useTranslation } from "react-i18next"
 
 import { AffectedUserProvider } from "./AffectedUserContext"
 import Start from "./Start"
 import CodeInput from "./CodeInput/CodeInputScreen"
 import Complete from "./Complete"
 import PublishConsent from "./PublishConsent/PublishConsentScreen"
-
 import {
   AffectedUserFlowStackScreen,
   AffectedUserFlowStackScreens,
 } from "../navigation"
 
+import { Colors, Headers } from "../styles"
+
 type AffectedUserFlowStackParams = {
   [key in AffectedUserFlowStackScreen]: undefined
 }
+
+const headerLeft = () => <HeaderLeft />
+const HeaderLeft = () => {
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+
+  return (
+    <HeaderBackButton
+      tintColor={Colors.primary150}
+      onPress={() => navigation.goBack()}
+      label={t("screen_titles.home")}
+    />
+  )
+}
+
 const Stack = createStackNavigator<AffectedUserFlowStackParams>()
 
 const AffectedUserStack: FunctionComponent = () => {
@@ -24,6 +42,7 @@ const AffectedUserStack: FunctionComponent = () => {
         <Stack.Screen
           name={AffectedUserFlowStackScreens.AffectedUserStart}
           component={Start}
+          options={{ ...Headers.headerMinimalOptions, headerLeft: headerLeft }}
         />
         <Stack.Screen
           name={AffectedUserFlowStackScreens.AffectedUserCodeInput}

--- a/src/Home/ActivationStatusView.tsx
+++ b/src/Home/ActivationStatusView.tsx
@@ -123,7 +123,7 @@ const ActivationStatusView: FunctionComponent<ActivationStatusProps> = ({
 const style = StyleSheet.create({
   outerContainer: {
     ...Affordances.floatingContainer,
-    borderWidth: Outlines.hairline,
+    borderWidth: Outlines.thin,
   },
   topContainer: {
     flexDirection: "row",

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -395,12 +395,12 @@ const ExpandingCircleAnimation: FunctionComponent = () => {
   )
 
   const animationTime = 1600
-  const delayTime = 800
+  const delayTime = 2000
   const initialCircleSize = 0
   const endingCircleSize = 600
   const initialTopValue = STATUS_ICON_SIZE / 2
   const endingTopValue = endingCircleSize * -0.46
-  const initialOpacity = 0.3
+  const initialOpacity = 0.2
   const endingOpacity = 0.0
 
   const sizeAnimatedValue = useRef(new Animated.Value(initialCircleSize))

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -14,6 +14,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   View,
+  Image,
 } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
@@ -32,7 +33,7 @@ import ShareLink from "./ShareLink"
 import COVIDDataDashboard from "../COVIDDataDashboard/COVIDDataDashboard"
 import { useExposureDetectionStatus } from "./useExposureDetectionStatus"
 
-import { Icons } from "../assets"
+import { Icons, Images } from "../assets"
 import {
   Layout,
   Spacing,
@@ -45,6 +46,7 @@ import {
 } from "../styles"
 
 const STATUS_ICON_SIZE = Iconography.small
+const IMAGE_HEIGHT = 170
 
 const Home: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
@@ -57,6 +59,19 @@ const Home: FunctionComponent = () => {
     displayCallbackForm,
     emergencyPhoneNumber,
   } = useConfigurationContext()
+
+  const ChevronRightIcon = () => {
+    return (
+      <View style={style.chevronRightIcon}>
+        <SvgXml
+          xml={Icons.ChevronRight}
+          width={Iconography.xxSmall}
+          height={Iconography.xxSmall}
+          fill={Colors.neutral75}
+        />
+      </View>
+    )
+  }
 
   const ExposureDetectionStatus: FunctionComponent = () => {
     const handleOnPressExposureDetectionStatus = () => {
@@ -132,21 +147,24 @@ const Home: FunctionComponent = () => {
     }
 
     return (
-      <View style={style.floatingContainer}>
+      <TouchableOpacity
+        onPress={handleOnPressTalkToContactTracer}
+        style={style.floatingContainer}
+      >
+        <ChevronRightIcon />
+        <Image
+          source={Images.HowItWorksValueProposition}
+          style={style.image}
+          width={200}
+          height={IMAGE_HEIGHT}
+        />
         <Text style={style.sectionHeaderText}>
           {t("home.did_you_test_positive")}
         </Text>
         <Text style={style.sectionBodyText}>
           {t("home.to_submit_your_test")}
         </Text>
-        <Button
-          onPress={handleOnPressTalkToContactTracer}
-          label={t("home.talk_to_a_contact")}
-          customButtonStyle={style.button}
-          customButtonInnerStyle={style.buttonInner}
-          hasRightArrow
-        />
-      </View>
+      </TouchableOpacity>
     )
   }
 
@@ -158,21 +176,24 @@ const Home: FunctionComponent = () => {
     }
 
     return (
-      <View style={style.floatingContainer}>
+      <TouchableOpacity
+        onPress={handleOnPressReportTestResult}
+        style={style.floatingContainer}
+      >
+        <ChevronRightIcon />
+        <Image
+          source={Images.ProtectPrivacySubmitKeys}
+          style={style.image}
+          width={130}
+          height={IMAGE_HEIGHT}
+        />
         <Text style={style.sectionHeaderText}>
           {t("home.have_a_positive_test")}
         </Text>
         <Text style={style.sectionBodyText}>
           {t("home.if_you_have_a_code")}
         </Text>
-        <Button
-          onPress={handleOnPressReportTestResult}
-          label={t("home.submit_test_result_code")}
-          customButtonStyle={style.button}
-          customButtonInnerStyle={style.buttonInner}
-          hasRightArrow
-        />
-      </View>
+      </TouchableOpacity>
     )
   }
 
@@ -184,18 +205,22 @@ const Home: FunctionComponent = () => {
     }
 
     return (
-      <View style={style.floatingContainer}>
+      <TouchableOpacity
+        onPress={handleOnPressTakeSelfAssessment}
+        style={style.floatingContainer}
+      >
+        <ChevronRightIcon />
+        <Image
+          source={Images.SelfAssessmentIntro}
+          style={style.image}
+          width={150}
+          height={IMAGE_HEIGHT}
+        />
         <Text style={style.sectionHeaderText}>{t("home.feeling_sick")}</Text>
         <Text style={style.sectionBodyText}>
           {t("home.check_if_your_symptoms")}
         </Text>
-        <Button
-          onPress={handleOnPressTakeSelfAssessment}
-          label={t("home.bluetooth.take_self_assessment")}
-          customButtonStyle={style.button}
-          customButtonInnerStyle={style.buttonInner}
-        />
-      </View>
+      </TouchableOpacity>
     )
   }
 
@@ -328,20 +353,25 @@ const style = StyleSheet.create({
   floatingContainer: {
     ...Affordances.floatingContainer,
   },
+  chevronRightIcon: {
+    position: "absolute",
+    top: Spacing.large,
+    right: Spacing.large,
+  },
+  image: {
+    resizeMode: "contain",
+    marginBottom: Spacing.xSmall,
+  },
   sectionHeaderText: {
     ...Typography.header3,
+    color: Colors.black,
     marginBottom: Spacing.xxSmall,
   },
   sectionBodyText: {
-    ...Typography.body1,
-    marginBottom: Spacing.medium,
-  },
-  button: {
-    width: "100%",
-  },
-  buttonInner: {
-    ...Buttons.medium,
-    width: "100%",
+    ...Typography.header4,
+    ...Typography.base,
+    color: Colors.neutral100,
+    marginBottom: Spacing.small,
   },
   emergencyButtonContainer: {
     ...Buttons.primary,

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -27,7 +27,7 @@ import {
   Stacks,
 } from "../navigation"
 import { useConfigurationContext } from "../ConfigurationContext"
-import { StatusBar, Text, Button } from "../components"
+import { StatusBar, Text } from "../components"
 
 import ShareLink from "./ShareLink"
 import COVIDDataDashboard from "../COVIDDataDashboard/COVIDDataDashboard"

--- a/src/SelfAssessment/SelfAssessmentIntro.tsx
+++ b/src/SelfAssessment/SelfAssessmentIntro.tsx
@@ -1,15 +1,13 @@
 import React, { FunctionComponent } from "react"
-import { ScrollView, StyleSheet, View, TouchableOpacity } from "react-native"
+import { ScrollView, StyleSheet, View } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
-import { SvgXml } from "react-native-svg"
 
 import { SelfAssessmentStackScreens, useStatusBarEffect } from "../navigation"
-import { Button, Text, StatusBar } from "../components"
+import { Button, Text } from "../components"
 import { useConfigurationContext } from "../ConfigurationContext"
 
-import { Colors, Iconography, Layout, Spacing, Typography } from "../styles"
-import { Icons } from "../assets"
+import { Colors, Spacing, Typography } from "../styles"
 
 const SelfAssessmentIntro: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
@@ -24,64 +22,41 @@ const SelfAssessmentIntro: FunctionComponent = () => {
     navigation.navigate(SelfAssessmentStackScreens.HowAreYouFeeling)
   }
 
-  const handleOnPressCancel = () => {
-    navigation.goBack()
-  }
-
   return (
-    <>
-      <StatusBar backgroundColor={Colors.primaryLightBackground} />
-      <ScrollView
-        style={style.container}
-        contentContainerStyle={style.contentContainer}
-        alwaysBounceVertical={false}
-      >
-        <View style={style.cancelButtonContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressCancel}
-            accessible
-            accessibilityLabel={t("export.code_input_button_cancel")}
-          >
-            <View style={style.cancelButtonInnerContainer}>
-              <SvgXml
-                xml={Icons.X}
-                fill={Colors.black}
-                width={Iconography.xxSmall}
-                height={Iconography.xxSmall}
-              />
-            </View>
-          </TouchableOpacity>
-        </View>
-        <Text style={style.headerText}>
-          {t("self_assessment.intro.covid19_self_assessment")}
+    <ScrollView
+      style={style.container}
+      contentContainerStyle={style.contentContainer}
+      alwaysBounceVertical={false}
+    >
+      <Text style={style.headerText}>
+        {t("self_assessment.intro.covid19_self_assessment")}
+      </Text>
+      <Text style={style.subheaderText}>
+        {t("self_assessment.intro.find_out_how_to_care")}
+      </Text>
+      <View style={style.bulletListContainer}>
+        <Text style={style.bulletText}>
+          {t("self_assessment.intro.this_is_not_intended")}
         </Text>
-        <Text style={style.subheaderText}>
-          {t("self_assessment.intro.find_out_how_to_care")}
+        <Text style={style.bulletText}>
+          {t("self_assessment.intro.you_are_a_resident", {
+            healthAuthorityName,
+          })}
         </Text>
-        <View style={style.bulletListContainer}>
-          <Text style={style.bulletText}>
-            {t("self_assessment.intro.this_is_not_intended")}
-          </Text>
-          <Text style={style.bulletText}>
-            {t("self_assessment.intro.you_are_a_resident", {
-              healthAuthorityName,
-            })}
-          </Text>
-          <Text style={style.bulletText}>
-            {t("self_assessment.intro.this_is_based_on")}
-          </Text>
-          <Text style={{ ...style.bulletText, ...style.emergencyText }}>
-            {t("self_assessment.intro.if_this_is", { emergencyPhoneNumber })}
-          </Text>
-        </View>
-        <Button
-          onPress={handleOnPressStartAssessment}
-          label={t("self_assessment.intro.agree_and_start_assessment")}
-          customButtonStyle={style.button}
-          customButtonInnerStyle={style.buttonInner}
-        />
-      </ScrollView>
-    </>
+        <Text style={style.bulletText}>
+          {t("self_assessment.intro.this_is_based_on")}
+        </Text>
+        <Text style={{ ...style.bulletText, ...style.emergencyText }}>
+          {t("self_assessment.intro.if_this_is", { emergencyPhoneNumber })}
+        </Text>
+      </View>
+      <Button
+        onPress={handleOnPressStartAssessment}
+        label={t("self_assessment.intro.agree_and_start_assessment")}
+        customButtonStyle={style.button}
+        customButtonInnerStyle={style.buttonInner}
+      />
+    </ScrollView>
   )
 }
 
@@ -95,15 +70,6 @@ const style = StyleSheet.create({
     justifyContent: "center",
     paddingHorizontal: Spacing.xLarge,
     paddingVertical: Spacing.xxxLarge,
-  },
-  cancelButtonContainer: {
-    position: "absolute",
-    top: Spacing.medium,
-    right: Spacing.medium,
-    zIndex: Layout.zLevel1,
-  },
-  cancelButtonInnerContainer: {
-    padding: Spacing.medium,
   },
   headerText: {
     ...Typography.header1,

--- a/src/configuration/copy.json
+++ b/src/configuration/copy.json
@@ -7,8 +7,5 @@
   },
   "legal": {
     "en": ""
-  },
-  "callback_success": {
-    "en": ""
   }
 }

--- a/src/configuration/copy.json
+++ b/src/configuration/copy.json
@@ -7,5 +7,8 @@
   },
   "legal": {
     "en": ""
+  },
+  "callback_success": {
+    "en": ""
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -194,7 +194,7 @@
     "connect": "Connect",
     "exposure": "Exposure",
     "exposure_history": "Exposure History",
-    "home": "Home",
+    "home": "Dashboard",
     "more_info": "More Info",
     "symptom_checker": "symptom_checker"
   },
@@ -267,7 +267,7 @@
     "exposure_history": "Exposure History",
     "exposure_scanning": "Exposure Detection",
     "exposures": "Exposures",
-    "home": "Home",
+    "home": "Dashboard",
     "how_the_app_works": "How the app works",
     "legal": "Legal"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,8 +36,8 @@
     "submit": "Submit"
   },
   "covid_data": {
-    "cases_are_up": "Cases are up from last week",
     "cases_are_down": "Cases are down from last week",
+    "cases_are_up": "Cases are up from last week",
     "cases_today": "Cases today",
     "covid_data": "COVID Data",
     "deaths_today": "Deaths today",
@@ -149,7 +149,6 @@
       "proximity_tracing_header": "Exposure Notifications",
       "share": "Share {{applicationName}}",
       "share_message": "Check out this app {{applicationName}}, which can help us contain COVID-19! {{appDownloadLink}}",
-      "take_self_assessment": "Take self assessment",
       "tracing_off_header": "Exposure Detection Off",
       "tracing_on_header": "Exposure Detection On"
     },
@@ -175,8 +174,6 @@
       "unauthorized_error_message_ios": "To enable Exposure Notifications, go to the Exposure Notification section in Settings and Share Exposure Information and set the Active Region to {{applicationName}}",
       "unauthorized_error_title": "Enable Exposure Notifications"
     },
-    "submit_test_result_code": "Submit test result code",
-    "talk_to_a_contact": "Talk to a contact tracer",
     "to_submit_your_test": "To get your test result code, you'll need to speak with a contact tracer."
   },
   "label": {

--- a/src/navigation/ModalStack.tsx
+++ b/src/navigation/ModalStack.tsx
@@ -20,7 +20,7 @@ import ExposureNotificationsInfo from "../Home/ExposureNotificationsInfo"
 import LocationInfo from "../Home/LocationInfo"
 import CallbackStack from "./CallbackStack"
 
-import { Colors } from "../styles"
+import { Headers, Colors } from "../styles"
 
 const headerLeft = () => <HeaderLeft />
 const HeaderLeft = () => {
@@ -54,7 +54,6 @@ const ModalStack: FunctionComponent = () => {
       <Stack.Screen
         name={Stacks.AffectedUserStack}
         component={AffectedUserStack}
-        options={TransitionPresets.ModalTransition}
       />
       <Stack.Screen name={ModalStackScreens.HowItWorksReviewFromSettings}>
         {(props) => (
@@ -83,10 +82,7 @@ const ModalStack: FunctionComponent = () => {
           )
         }}
       </Stack.Screen>
-      <Stack.Screen
-        name={ModalStackScreens.SelfAssessmentFromHome}
-        options={TransitionPresets.ModalTransition}
-      >
+      <Stack.Screen name={ModalStackScreens.SelfAssessmentFromHome}>
         {(props) => {
           return (
             <SelfAssessmentStack {...props} destinationOnCancel={Stacks.Home} />
@@ -97,10 +93,8 @@ const ModalStack: FunctionComponent = () => {
         name={HomeStackScreens.ExposureDetectionStatus}
         component={ExposureDetectionStatus}
         options={{
-          title: "",
-          headerShown: true,
+          ...Headers.headerMinimalOptions,
           headerLeft: headerLeft,
-          headerStyle: { shadowColor: Colors.transparent },
         }}
       />
       <Stack.Screen

--- a/src/navigation/SelfAssessmentStack.tsx
+++ b/src/navigation/SelfAssessmentStack.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import {
   createStackNavigator,
+  HeaderBackButton,
   HeaderStyleInterpolators,
   StackNavigationOptions,
 } from "@react-navigation/stack"
@@ -22,9 +23,23 @@ import AgeRangeQuestion from "../SelfAssessment/AgeRangeQuestion"
 import Guidance from "../SelfAssessment/Guidance"
 
 import { Icons } from "../assets"
-import { Colors, Iconography, Spacing } from "../styles"
+import { Headers, Colors, Iconography, Spacing } from "../styles"
 
 const Stack = createStackNavigator()
+
+const headerLeft = () => <HeaderLeft />
+const HeaderLeft = () => {
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+
+  return (
+    <HeaderBackButton
+      tintColor={Colors.primary150}
+      onPress={() => navigation.goBack()}
+      label={t("screen_titles.home")}
+    />
+  )
+}
 
 const backButton = () => <BackButton />
 const BackButton = () => {
@@ -97,7 +112,11 @@ const SelfAssessmentStack: FunctionComponent<SelfAssessmentStackProps> = ({
         <Stack.Screen
           name={SelfAssessmentStackScreens.SelfAssessmentIntro}
           component={SelfAssessmentIntro}
-          options={{ headerShown: false }}
+          options={{
+            ...Headers.headerMinimalOptions,
+            headerLeft: headerLeft,
+            headerRight: () => null,
+          }}
         />
         <Stack.Screen
           name={SelfAssessmentStackScreens.EmergencySymptomsQuestions}

--- a/src/styles/headers.ts
+++ b/src/styles/headers.ts
@@ -27,18 +27,8 @@ export const headerScreenOptions: StackNavigationOptions = {
   headerTitleAlign: "center",
 }
 
-export const headerLightOptions: StackNavigationOptions = {
-  headerStyle: {
-    backgroundColor: Colors.secondary10,
-    shadowColor: "transparent",
-    elevation: 0,
-  },
-  headerTitleStyle: {
-    ...Typography.mediumBold,
-    color: Colors.primaryText,
-    letterSpacing: Typography.largeLetterSpacing,
-    textTransform: "uppercase",
-  },
-  headerBackTitleVisible: false,
-  headerTitleAlign: "center",
+export const headerMinimalOptions: StackNavigationOptions = {
+  title: "",
+  headerShown: true,
+  headerStyle: { shadowColor: Colors.transparent },
 }

--- a/src/styles/outlines.ts
+++ b/src/styles/outlines.ts
@@ -35,7 +35,7 @@ export const baseShadow: ViewStyle = {
 export const lightShadow: ViewStyle = {
   ...baseShadow,
   shadowOpacity: 0.25,
-  shadowColor: Colors.neutral75,
+  shadowColor: Colors.neutral100,
 }
 
 export const separatorLine: ViewStyle = {


### PR DESCRIPTION
Why:
----
The Home screen was a wall of text, which made the UX suboptimal. We would like for this screen to feel welcoming. We also had some styling and navigation issues we opted not to fix in the previous home screen redesign PR.

This commit:
----
- Renames the `Home` screen to `Dashboard` for users. This name more clearly communicates the purpose of the screen.
- Updates the design of the modules to remove the button, add an image, and make the entire container the button
- Updates the navigational elements for the screens that are navigated to directly from the home screen so they make sense

![gif](https://user-images.githubusercontent.com/39350030/95602714-4ef8e680-0a23-11eb-85d8-d36475889085.gif)