### PR TITLE
Jts find a test center

### DIFF
--- a/src/Connect/index.tsx
+++ b/src/Connect/index.tsx
@@ -37,7 +37,6 @@ const ConnectScreen: FunctionComponent = () => {
   const { applicationName, versionInfo } = useApplicationInfo()
   const {
     healthAuthorityName,
-    displayCallbackForm,
     emergencyPhoneNumber,
   } = useConfigurationContext()
 
@@ -83,15 +82,6 @@ const ConnectScreen: FunctionComponent = () => {
   }
 
   listItems.push(howTheAppWorks)
-
-  if (displayCallbackForm) {
-    const callbackForm: ConnectListItem = {
-      label: t("screen_titles.callback"),
-      onPress: () => navigation.navigate(ModalStackScreens.CallbackStack),
-      icon: Icons.Headset,
-    }
-    listItems.push(callbackForm)
-  }
 
   return (
     <>

--- a/src/SelfAssessment/Guidance.tsx
+++ b/src/SelfAssessment/Guidance.tsx
@@ -1,10 +1,11 @@
 import React, { FunctionComponent } from "react"
-import { Image, ScrollView, StyleSheet, View } from "react-native"
+import { Linking, Image, ScrollView, StyleSheet, View } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
 import { Button, Text } from "../components"
 import { useSelfAssessmentContext } from "../SelfAssessmentContext"
+import { useConfigurationContext } from "../ConfigurationContext"
 import { SymptomGroup } from "./selfAssessment"
 import { Stack, Stacks } from "../navigation"
 
@@ -21,6 +22,7 @@ const Guidance: FunctionComponent<GuidanceProps> = ({
   const { t } = useTranslation()
   const navigation = useNavigation()
   const { symptomGroup } = useSelfAssessmentContext()
+  const { findATestCenterUrl } = useConfigurationContext()
 
   if (symptomGroup === null) {
     return null
@@ -181,6 +183,14 @@ const Guidance: FunctionComponent<GuidanceProps> = ({
     }
   }
 
+  const displayFindATestCenter = Boolean(findATestCenterUrl)
+
+  const handleOnPressFindTestCenter = () => {
+    if (findATestCenterUrl) {
+      Linking.openURL(findATestCenterUrl)
+    }
+  }
+
   return (
     <ScrollView
       style={style.container}
@@ -200,12 +210,22 @@ const Guidance: FunctionComponent<GuidanceProps> = ({
       <View style={style.bulletListContainer}>
         {instructionsForSymptomGroup(symptomGroup)}
       </View>
-      <Button
-        onPress={handleOnPressDone}
-        label={t("common.done")}
-        customButtonStyle={style.button}
-        customButtonInnerStyle={style.buttonInner}
-      />
+      {displayFindATestCenter ? (
+        <Button
+          label={t("self_assessment.guidance.find_a_test_center_nearby")}
+          onPress={handleOnPressFindTestCenter}
+          customButtonStyle={style.button}
+          customButtonInnerStyle={style.buttonInner}
+          hasRightArrow
+        />
+      ) : (
+        <Button
+          onPress={handleOnPressDone}
+          label={t("common.done")}
+          customButtonStyle={style.button}
+          customButtonInnerStyle={style.buttonInner}
+        />
+      )}
     </ScrollView>
   )
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -309,6 +309,7 @@
       "dont_use_public_transport": "Do not use public transportation or ride sharing.",
       "drink_water": "Drink plenty of water and other clear liquids to prevent fluid loss (dehydration).",
       "feeling_fine": "Good to hear you’re feeling fine. You shuold monitor your symptoms and stay at home.",
+      "find_a_test_center_nearby": "Find a test center nearby",
       "find_telehealth": "Find telehealth services",
       "follow_cdc_guidance": "If you develop symptoms, follow CDC guidance.",
       "guidance": "Your Guidance",


### PR DESCRIPTION
Commit1:

Why:
A previous commit removed the find a test center functionality. We would
like to reintroduce it.

This commit:
Adds a button to find a test center to the self assessment guidance
screen if the findATestCenterUrl is present

Commit2:
Why:
A previous commit removed the display callback form from the connect
screen navigation stack, but did not remove the button from the connect
screen.

This commit.
Removes the callback form navigation button from the connect screen

Co-Authored-By: alejandro dustet <alejandro@thoughtbot.com>
Co-Authored-By: devin jameson <devin@thoughtbot.com>
Co-Authored-By: matt buckley <mattbuckley@nicethings.io>