### PR TITLE
Calculate trend from full day of data

### DIFF
--- a/src/CovidDataContext.spec.tsx
+++ b/src/CovidDataContext.spec.tsx
@@ -1,0 +1,197 @@
+import React, { FunctionComponent } from "react"
+import { Text } from "react-native"
+
+import {
+  useCovidDataContext,
+  CovidDataContextProvider,
+  CovidDataRequestStatus,
+} from "./CovidDataContext"
+import { factories } from "./factories"
+import { fetchCovidDataForState } from "./CovidDataDashboard/covidDataAPI"
+import { render, waitFor } from "@testing-library/react-native"
+import { ConfigurationContext } from "./ConfigurationContext"
+
+jest.mock("./CovidDataDashboard/covidDataAPI.ts")
+describe("CovidDataContextProvider", () => {
+  it("doesn't start the request if it should not be requested", async () => {
+    const configurationContext = factories.configurationContext.build({
+      displayCovidData: false,
+      stateAbbreviation: "state",
+    })
+
+    const { getByTestId } = render(
+      <ConfigurationContext.Provider value={configurationContext}>
+        <CovidDataContextProvider>
+          <CovidDataContextSpoof />
+        </CovidDataContextProvider>
+      </ConfigurationContext.Provider>,
+    )
+
+    await waitFor(() => {
+      expect(getByTestId("status").children).toEqual([
+        CovidDataRequestStatus.MISSING_INFO.toString(),
+      ])
+    })
+  })
+
+  it("doesn't start the request if required data is missing", async () => {
+    const configurationContext = factories.configurationContext.build({
+      displayCovidData: true,
+      stateAbbreviation: null,
+    })
+
+    const { getByTestId } = render(
+      <ConfigurationContext.Provider value={configurationContext}>
+        <CovidDataContextProvider>
+          <CovidDataContextSpoof />
+        </CovidDataContextProvider>
+      </ConfigurationContext.Provider>,
+    )
+
+    await waitFor(() => {
+      expect(getByTestId("status").children).toEqual([
+        CovidDataRequestStatus.MISSING_INFO.toString(),
+      ])
+    })
+  })
+
+  it("fetches the data if required arguments are present", async () => {
+    const configurationContext = factories.configurationContext.build({
+      displayCovidData: true,
+      stateAbbreviation: "state",
+    })
+
+    const todayData = factories.covidData.build({ peoplePositiveCasesCt: 4 })
+    const trendReferenceData = factories.covidData.build({
+      peoplePositiveCasesCt: 3,
+    })
+    const collectionForTrend = [
+      trendReferenceData,
+      factories.covidData.build({ peoplePositiveCasesCt: 2 }),
+      factories.covidData.build({ peoplePositiveCasesCt: 1 }),
+    ]
+
+    const lastWeekCovidData = [...collectionForTrend, todayData]
+
+    ;(fetchCovidDataForState as jest.Mock).mockResolvedValueOnce({
+      kind: "success",
+      lastWeekCovidData,
+    })
+
+    const { getByTestId } = render(
+      <ConfigurationContext.Provider value={configurationContext}>
+        <CovidDataContextProvider>
+          <CovidDataContextSpoof />
+        </CovidDataContextProvider>
+      </ConfigurationContext.Provider>,
+    )
+
+    expect(getByTestId("status").children).toEqual([
+      CovidDataRequestStatus.LOADING.toString(),
+    ])
+
+    await waitFor(() => {
+      expect(getByTestId("status").children).toEqual([
+        CovidDataRequestStatus.SUCCESS.toString(),
+      ])
+      expect(getByTestId("todayData").children).toEqual([
+        JSON.stringify(todayData),
+      ])
+      expect(getByTestId("trendReferenceData").children).toEqual([
+        JSON.stringify(trendReferenceData),
+      ])
+      expect(getByTestId("collectionForTrend").children).toEqual([
+        JSON.stringify(collectionForTrend),
+      ])
+    })
+  })
+
+  describe("when the response is incomplete", () => {
+    it("sets the status as missing information", async () => {
+      const configurationContext = factories.configurationContext.build({
+        displayCovidData: true,
+        stateAbbreviation: "state",
+      })
+
+      const lastWeekCovidData = [
+        factories.covidData.build({ peoplePositiveCasesCt: 1 }),
+      ]
+
+      ;(fetchCovidDataForState as jest.Mock).mockResolvedValueOnce({
+        kind: "success",
+        lastWeekCovidData,
+      })
+
+      const { getByTestId } = render(
+        <ConfigurationContext.Provider value={configurationContext}>
+          <CovidDataContextProvider>
+            <CovidDataContextSpoof />
+          </CovidDataContextProvider>
+        </ConfigurationContext.Provider>,
+      )
+
+      expect(getByTestId("status").children).toEqual([
+        CovidDataRequestStatus.LOADING.toString(),
+      ])
+
+      await waitFor(() => {
+        expect(getByTestId("status").children).toEqual([
+          CovidDataRequestStatus.MISSING_INFO.toString(),
+        ])
+      })
+    })
+  })
+
+  it("sets the status as an error when the request fails", async () => {
+    const configurationContext = factories.configurationContext.build({
+      displayCovidData: true,
+      stateAbbreviation: "state",
+    })
+
+    ;(fetchCovidDataForState as jest.Mock).mockResolvedValueOnce({
+      kind: "failure",
+    })
+
+    const { getByTestId } = render(
+      <ConfigurationContext.Provider value={configurationContext}>
+        <CovidDataContextProvider>
+          <CovidDataContextSpoof />
+        </CovidDataContextProvider>
+      </ConfigurationContext.Provider>,
+    )
+
+    expect(getByTestId("status").children).toEqual([
+      CovidDataRequestStatus.LOADING.toString(),
+    ])
+
+    await waitFor(() => {
+      expect(getByTestId("status").children).toEqual([
+        CovidDataRequestStatus.ERROR.toString(),
+      ])
+    })
+  })
+})
+
+const CovidDataContextSpoof: FunctionComponent = () => {
+  const {
+    covidDataRequest: {
+      status,
+      todayData,
+      trendReferenceData,
+      collectionForTrend,
+    },
+  } = useCovidDataContext()
+
+  return (
+    <>
+      <Text testID="status">{status}</Text>
+      <Text testID="todayData">{JSON.stringify(todayData)}</Text>
+      <Text testID="trendReferenceData">
+        {JSON.stringify(trendReferenceData)}
+      </Text>
+      <Text testID="collectionForTrend">
+        {JSON.stringify(collectionForTrend)}
+      </Text>
+    </>
+  )
+}

--- a/src/CovidDataContext.tsx
+++ b/src/CovidDataContext.tsx
@@ -17,22 +17,38 @@ export enum CovidDataRequestStatus {
   SUCCESS,
   LOADING,
   ERROR,
-  NOT_STARTED,
+  MISSING_INFO,
 }
 
-type CovidDataRequest = {
+type RequestDataPortion = {
+  todayData: CovidData
+  trendReferenceData: CovidData
+  collectionForTrend: CovidData[]
+}
+
+type CovidDataRequest = RequestDataPortion & {
   status: CovidDataRequestStatus
-  data: CovidData[]
 }
 
 export type CovidDataContextState = {
+  stateAbbreviation: string
   covidDataRequest: CovidDataRequest
 }
 
+const placeHolderData: CovidData = {
+  peoplePositiveCasesCt: 0,
+  peopleDeathCt: 0,
+  peoplePositiveNewCasesCt: 0,
+  peopleDeathNewCt: 0,
+}
+
 const initialState: CovidDataContextState = {
+  stateAbbreviation: "",
   covidDataRequest: {
-    status: CovidDataRequestStatus.NOT_STARTED,
-    data: [],
+    status: CovidDataRequestStatus.MISSING_INFO,
+    todayData: placeHolderData,
+    trendReferenceData: placeHolderData,
+    collectionForTrend: [],
   },
 }
 
@@ -41,37 +57,76 @@ export const CovidDataContext = createContext<CovidDataContextState>(
 )
 
 export const CovidDataContextProvider: FunctionComponent = ({ children }) => {
-  const { stateAbbreviation } = useConfigurationContext()
+  const { stateAbbreviation, displayCovidData } = useConfigurationContext()
   const [covidDataRequest, setCovidDataRequest] = useState(
     initialState.covidDataRequest,
   )
 
+  const parseLastWeekCovidData = (
+    lastWeekData: CovidData[],
+  ): RequestDataPortion => {
+    const sortedData = lastWeekData.sort((leftCovidData, rightCovidData) => {
+      return Math.sign(
+        rightCovidData.peoplePositiveCasesCt -
+          leftCovidData.peoplePositiveCasesCt,
+      )
+    })
+
+    const [todayData, ...collectionForTrend] = sortedData
+    const [trendReferenceData] = collectionForTrend
+    return {
+      todayData,
+      trendReferenceData,
+      collectionForTrend,
+    }
+  }
+
   const fetchCovidData = useCallback(async (stateCode: string) => {
     setCovidDataRequest({
+      ...initialState.covidDataRequest,
       status: CovidDataRequestStatus.LOADING,
-      data: [],
     })
 
     const covidDataResponse = await fetchCovidDataForState(stateCode)
+
     if (covidDataResponse.kind === "success") {
-      setCovidDataRequest({
-        status: CovidDataRequestStatus.SUCCESS,
-        data: covidDataResponse.lastWeekCovidData,
-      })
+      const {
+        todayData,
+        trendReferenceData,
+        collectionForTrend,
+      } = parseLastWeekCovidData(covidDataResponse.lastWeekCovidData)
+
+      if (trendReferenceData && todayData) {
+        setCovidDataRequest({
+          status: CovidDataRequestStatus.SUCCESS,
+          todayData,
+          trendReferenceData,
+          collectionForTrend,
+        })
+      } else {
+        setCovidDataRequest({
+          ...initialState.covidDataRequest,
+          status: CovidDataRequestStatus.MISSING_INFO,
+        })
+      }
     } else {
       setCovidDataRequest({
+        ...initialState.covidDataRequest,
         status: CovidDataRequestStatus.ERROR,
-        data: [],
       })
     }
   }, [])
 
   useEffect(() => {
-    stateAbbreviation && fetchCovidData(stateAbbreviation)
-  }, [stateAbbreviation, fetchCovidData])
+    if (displayCovidData && stateAbbreviation !== null) {
+      fetchCovidData(stateAbbreviation)
+    }
+  }, [displayCovidData, stateAbbreviation, fetchCovidData])
 
   return (
-    <CovidDataContext.Provider value={{ covidDataRequest }}>
+    <CovidDataContext.Provider
+      value={{ covidDataRequest, stateAbbreviation: stateAbbreviation || "" }}
+    >
       {children}
     </CovidDataContext.Provider>
   )

--- a/src/CovidDataDashboard/CovidDataClip.tsx
+++ b/src/CovidDataDashboard/CovidDataClip.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next"
 
 import CovidDataStateTrend from "./CovidDataStateTrend"
 import { Text } from "../components"
-import { useConfigurationContext } from "../ConfigurationContext"
 import {
   CovidDataRequestStatus,
   useCovidDataContext,
@@ -32,15 +31,11 @@ const LoadingIndicator = () => {
 }
 
 const CovidDataClip: FunctionComponent = () => {
-  const { stateAbbreviation } = useConfigurationContext()
   const { t } = useTranslation()
   const {
-    covidDataRequest: { data, status },
+    stateAbbreviation,
+    covidDataRequest: { trendReferenceData, collectionForTrend, status },
   } = useCovidDataContext()
-
-  if (stateAbbreviation === null) {
-    return null
-  }
 
   const dataClipContent = () => {
     switch (status) {
@@ -57,14 +52,15 @@ const CovidDataClip: FunctionComponent = () => {
       case CovidDataRequestStatus.SUCCESS:
         return (
           <CovidDataStateTrend
-            lastWeekData={data}
+            trendReferenceData={trendReferenceData}
+            collectionForTrend={collectionForTrend}
             stateAbbreviation={stateAbbreviation}
           />
         )
-      case CovidDataRequestStatus.NOT_STARTED:
+      case CovidDataRequestStatus.MISSING_INFO:
         return (
           <Text style={style.errorMessageText}>
-            {t("covid_data.error_getting_data", { stateAbbreviation })}
+            {t("covid_data.apologies_data_unavailable")}
           </Text>
         )
     }

--- a/src/CovidDataDashboard/CovidDataDashboard.tsx
+++ b/src/CovidDataDashboard/CovidDataDashboard.tsx
@@ -1,23 +1,23 @@
 import React, { FunctionComponent } from "react"
 import { ScrollView, StyleSheet } from "react-native"
 
-import { useConfigurationContext } from "../ConfigurationContext"
-import { useCovidDataContext } from "../CovidDataContext"
+import {
+  CovidDataRequestStatus,
+  useCovidDataContext,
+} from "../CovidDataContext"
 import StateData from "./StateData"
 
 import { Colors, Spacing } from "../styles"
 
 const CovidDataDashboard: FunctionComponent = () => {
-  const { stateAbbreviation } = useConfigurationContext()
   const {
-    covidDataRequest: { data },
+    stateAbbreviation,
+    covidDataRequest: { status, todayData },
   } = useCovidDataContext()
 
-  if (stateAbbreviation === null || data.length <= 0) {
+  if (status === CovidDataRequestStatus.MISSING_INFO) {
     return null
   }
-
-  const [todayCovidData] = data
 
   return (
     <ScrollView
@@ -25,7 +25,7 @@ const CovidDataDashboard: FunctionComponent = () => {
       contentContainerStyle={style.contentContainer}
     >
       <StateData
-        todayCovidData={todayCovidData}
+        todayCovidData={todayData}
         stateAbbreviation={stateAbbreviation}
       />
     </ScrollView>

--- a/src/CovidDataDashboard/CovidDataStateTrend.tsx
+++ b/src/CovidDataDashboard/CovidDataStateTrend.tsx
@@ -14,12 +14,14 @@ import { Icons } from "../assets"
 import { Colors, Typography, Spacing, Outlines, Iconography } from "../styles"
 
 type CovidDataStateTrendProps = {
-  lastWeekData: CovidData[]
+  trendReferenceData: CovidData
+  collectionForTrend: CovidData[]
   stateAbbreviation: string
 }
 
 const CovidDataStateTrend: FunctionComponent<CovidDataStateTrendProps> = ({
-  lastWeekData,
+  trendReferenceData,
+  collectionForTrend,
   stateAbbreviation,
 }) => {
   const { t } = useTranslation()
@@ -33,8 +35,10 @@ const CovidDataStateTrend: FunctionComponent<CovidDataStateTrendProps> = ({
   }
 
   useEffect(() => {
-    setCasesPercentageTrend(calculateCasesPercentageTrend(lastWeekData))
-  }, [lastWeekData])
+    setCasesPercentageTrend(
+      calculateCasesPercentageTrend(trendReferenceData, collectionForTrend),
+    )
+  }, [trendReferenceData, collectionForTrend])
 
   if (casesPercentageTrend === null) {
     return null

--- a/src/CovidDataDashboard/covidData.spec.ts
+++ b/src/CovidDataDashboard/covidData.spec.ts
@@ -3,10 +3,10 @@ import { calculateCasesPercentageTrend } from "./covidData"
 
 describe("calculateCasesPercentageTrend", () => {
   it("returns a positive percentage trend when the cases are growing", () => {
-    const todayData = factories.covidData.build({
+    const trendReferenceData = factories.covidData.build({
       peoplePositiveNewCasesCt: 10,
     })
-    const pastData = [
+    const collectionForTrend = [
       factories.covidData.build({
         peoplePositiveNewCasesCt: 6,
       }),
@@ -15,16 +15,16 @@ describe("calculateCasesPercentageTrend", () => {
       }),
     ]
 
-    const cumulativeData = [todayData, ...pastData]
-
-    expect(calculateCasesPercentageTrend(cumulativeData)).toEqual(40)
+    expect(
+      calculateCasesPercentageTrend(trendReferenceData, collectionForTrend),
+    ).toEqual(40)
   })
 
   it("returns a negative percentage trend when the cases are shrinking", () => {
-    const todayData = factories.covidData.build({
+    const trendReferenceData = factories.covidData.build({
       peoplePositiveNewCasesCt: 6,
     })
-    const pastData = [
+    const collectionForTrend = [
       factories.covidData.build({
         peoplePositiveNewCasesCt: 10,
       }),
@@ -33,8 +33,8 @@ describe("calculateCasesPercentageTrend", () => {
       }),
     ]
 
-    const cumulativeData = [todayData, ...pastData]
-
-    expect(calculateCasesPercentageTrend(cumulativeData)).toEqual(-67)
+    expect(
+      calculateCasesPercentageTrend(trendReferenceData, collectionForTrend),
+    ).toEqual(-67)
   })
 })

--- a/src/CovidDataDashboard/covidData.ts
+++ b/src/CovidDataDashboard/covidData.ts
@@ -5,18 +5,18 @@ const percentageChange = (average: number, todayCases: number) => {
 }
 
 export const calculateCasesPercentageTrend = (
-  cumulativeCovidData: CovidData[],
+  trendReferenceData: CovidData,
+  collectionForTrend: CovidData[],
 ): number => {
-  if (cumulativeCovidData.length === 0) {
+  if (collectionForTrend.length === 0) {
     return 0
   }
-  const [todayData, ...pastDaysData] = cumulativeCovidData
-  const sumOfNewCases = pastDaysData.reduce((sum, covidData) => {
+  const sumOfNewCases = collectionForTrend.reduce((sum, covidData) => {
     return sum + covidData.peoplePositiveNewCasesCt
   }, 0)
-  const averageOfNewCases = sumOfNewCases / pastDaysData.length
+  const averageOfNewCases = sumOfNewCases / collectionForTrend.length
 
-  const newCasesToday = todayData.peoplePositiveNewCasesCt
+  const newCasesToday = trendReferenceData.peoplePositiveNewCasesCt
 
   return percentageChange(averageOfNewCases, newCasesToday)
 }

--- a/src/factories/covidDataContext.ts
+++ b/src/factories/covidDataContext.ts
@@ -3,7 +3,14 @@ import {
   CovidDataContextState,
   CovidDataRequestStatus,
 } from "../CovidDataContext"
+import covidData from "./covidData"
 
 export default Factory.define<CovidDataContextState>(() => ({
-  covidDataRequest: { status: CovidDataRequestStatus.NOT_STARTED, data: [] },
+  stateAbbreviation: "state",
+  covidDataRequest: {
+    status: CovidDataRequestStatus.MISSING_INFO,
+    todayData: covidData.build(),
+    trendReferenceData: covidData.build(),
+    collectionForTrend: [],
+  },
 }))

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,6 +42,7 @@
     "down_from_last_week": "Down from last week",
     "error_getting_data": "Sorry, we could not fetch the latest COVID cases data for {{location}}.",
     "new_cases": "New Cases",
+    "apologies_data_unavailable": "Apologies, COVID data is unavailable.",
     "see_more": "See more",
     "total_cases": "Total cases",
     "total_deaths": "Total deaths",


### PR DESCRIPTION
Why:
----

The trend was being calculated from the latest data entry which was on occasion an incomplete day worth of data.

This Commit:
----

- Move necessary configuration checks to the data context to avoid repeating the checks across the visual components.
- Add data checks to the COVID data context. This is needed since the data source is external and we need at least some data in existence to do the calculations.
- Use new data context state down the views hierarchy
