### PR TITLE
Update tab icon color to use the brand

### DIFF
--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -35,7 +35,7 @@ const MainTabNavigator: FunctionComponent = () => {
     return (
       <SvgXml
         xml={icon}
-        fill={focused ? Colors.black : Colors.neutral50}
+        fill={focused ? Colors.primary100 : Colors.neutral50}
         accessible
         accessibilityLabel={label}
         width={size}


### PR DESCRIPTION
Why:
We would like to use the brand colors for the nav icons

Co-Authored-By: alejandro dustet <alejandro@thoughtbot.com>
Co-Authored-By: devin jameson <devin@thoughtbot.com>
Co-Authored-By: matt buckley <matt@nicethings.io>
