### PR TITLE
Bugfix for COVID Data JSON Response Parsing

### DIFF
--- a/src/CovidDataDashboard/covidDataAPI.ts
+++ b/src/CovidDataDashboard/covidDataAPI.ts
@@ -17,13 +17,13 @@ export type CovidData = {
   peopleDeathNewCt: number
 }
 
-const toCovidData = ( jsonResponse: Record<string, string>[] ): CovidData[] => { 
-  return jsonResponse.map( ( json ) => {
+const toCovidData = (jsonResponse: Record<string, string>[]): CovidData[] => {
+  return jsonResponse.map((json) => {
     return {
-      peoplePositiveNewCasesCt: parseInt( json["peoplePositiveNewCasesCt"] ),
-      peoplePositiveCasesCt: parseInt( json["peoplePositiveCasesCt"] ),
-      peopleDeathNewCt: parseInt( json["peopleDeathNewCt"] ),
-      peopleDeathCt: parseInt( json["peopleDeathCt"] ),
+      peoplePositiveNewCasesCt: parseInt(json["peoplePositiveNewCasesCt"]),
+      peoplePositiveCasesCt: parseInt(json["peoplePositiveCasesCt"]),
+      peopleDeathNewCt: parseInt(json["peopleDeathNewCt"]),
+      peopleDeathCt: parseInt(json["peopleDeathCt"]),
     }
   })
 }

--- a/src/CovidDataDashboard/covidDataAPI.ts
+++ b/src/CovidDataDashboard/covidDataAPI.ts
@@ -17,6 +17,17 @@ export type CovidData = {
   peopleDeathNewCt: number
 }
 
+const toCovidData = ( jsonResponse: Record<string, string>[] ): CovidData[] => { 
+  return jsonResponse.map( ( json ) => {
+    return {
+      peoplePositiveNewCasesCt: parseInt( json["peoplePositiveNewCasesCt"] ),
+      peoplePositiveCasesCt: parseInt( json["peoplePositiveCasesCt"] ),
+      peopleDeathNewCt: parseInt( json["peopleDeathNewCt"] ),
+      peopleDeathCt: parseInt( json["peopleDeathCt"] ),
+    }
+  })
+}
+
 export interface RequestSuccess {
   kind: "success"
   lastWeekCovidData: CovidData[]
@@ -33,12 +44,12 @@ export interface RequestFailure {
   nature: FailureNature
 }
 
-const isValidCovidDataResponse = (jsonResponse: Record<string, number>) => {
+const isValidCovidDataResponse = (jsonResponse: Record<string, string>) => {
   return (
-    jsonResponse["peoplePositiveNewCasesCt"] >= 0 &&
-    jsonResponse["peoplePositiveCasesCt"] >= 0 &&
-    jsonResponse["peopleDeathNewCt"] >= 0 &&
-    jsonResponse["peopleDeathCt"] >= 0
+    parseInt(jsonResponse["peoplePositiveNewCasesCt"]) >= 0 &&
+    parseInt(jsonResponse["peoplePositiveCasesCt"]) >= 0 &&
+    parseInt(jsonResponse["peopleDeathNewCt"]) >= 0 &&
+    parseInt(jsonResponse["peopleDeathCt"]) >= 0
   )
 }
 
@@ -58,7 +69,7 @@ export const fetchCovidDataForState = async (
     if (historicData.every(isValidCovidDataResponse)) {
       return {
         kind: "success",
-        lastWeekCovidData: jsonResponse[DATA_KEY],
+        lastWeekCovidData: toCovidData(jsonResponse[DATA_KEY]),
       }
     } else {
       Logger.error("Invalid response for covid data", {


### PR DESCRIPTION
### Why
We'd like the app to parse COVID stats data such that it displays as expected on the home screen

### This Commit
This commit addresses a bug whereby the client side code was expecting numerical data from the API to be returned with the `number` type, however it was coming back as the `string` type

### Before
![Simulator Screen Shot - iPhone 11 Pro - 2020-10-10 at 21 09 27](https://user-images.githubusercontent.com/2637355/95668301-3af6d700-0b40-11eb-8ef0-15d04dfb192c.png)


### After
![Simulator Screen Shot - iPhone 11 Pro - 2020-10-10 at 21 28 52](https://user-images.githubusercontent.com/2637355/95668302-3e8a5e00-0b40-11eb-9c5b-17a020dd2a58.png)
