### PR TITLE
Navbar Updates

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
@@ -26,19 +26,6 @@ describe("CodeInputForm", () => {
     expect(getByTestId("code-input")).toHaveTextContent("")
   })
 
-  it("navigates to the home screen when user cancels the process", () => {
-    const navigateSpy = jest.fn()
-    ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
-    const { getByLabelText } = render(
-      <AffectedUserProvider>
-        <CodeInputForm />
-      </AffectedUserProvider>,
-    )
-
-    fireEvent.press(getByLabelText("Cancel"))
-    expect(navigateSpy).toHaveBeenCalledWith("Home")
-  })
-
   describe("on a successful code verification", () => {
     it("navigates to the affected user publish consent", async () => {
       const navigateSpy = jest.fn()

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -3,7 +3,6 @@ import {
   ActivityIndicator,
   Alert,
   StyleSheet,
-  TouchableOpacity,
   TextInput,
   View,
   Keyboard,
@@ -11,7 +10,6 @@ import {
 } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
-import { SvgXml } from "react-native-svg"
 
 import { Text, Button, StatusBar } from "../../components"
 import { useAffectedUserContext } from "../AffectedUserContext"
@@ -19,12 +17,10 @@ import * as API from "../verificationAPI"
 import { calculateHmac } from "../hmac"
 import { useExposureContext } from "../../ExposureContext"
 import {
-  Stacks,
   useStatusBarEffect,
   AffectedUserFlowStackScreens,
 } from "../../navigation"
 
-import { Icons } from "../../assets"
 import {
   Spacing,
   Layout,
@@ -32,7 +28,6 @@ import {
   Colors,
   Outlines,
   Typography,
-  Iconography,
 } from "../../styles"
 import Logger from "../../logger"
 
@@ -68,14 +63,6 @@ const CodeInputForm: FunctionComponent = () => {
 
   const handleOnToggleFocus = () => {
     setIsFocused(!isFocused)
-  }
-
-  const handleOnPressBack = () => {
-    navigation.goBack()
-  }
-
-  const handleOnPressCancel = () => {
-    navigation.navigate(Stacks.Home)
   }
 
   const handleOnPressSubmit = async () => {
@@ -172,38 +159,6 @@ const CodeInputForm: FunctionComponent = () => {
         contentContainerStyle={style.contentContainer}
         testID={"affected-user-code-input-form"}
       >
-        <View style={style.backButtonContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressBack}
-            accessible
-            accessibilityLabel={t("export.code_input_button_back")}
-          >
-            <View style={style.backButtonInnerContainer}>
-              <SvgXml
-                xml={Icons.ArrowLeft}
-                fill={Colors.black}
-                width={Iconography.xxSmall}
-                height={Iconography.xxSmall}
-              />
-            </View>
-          </TouchableOpacity>
-        </View>
-        <View style={style.cancelButtonContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressCancel}
-            accessible
-            accessibilityLabel={t("export.code_input_button_cancel")}
-          >
-            <View style={style.cancelButtonInnerContainer}>
-              <SvgXml
-                xml={Icons.X}
-                fill={Colors.black}
-                width={Iconography.xxSmall}
-                height={Iconography.xxSmall}
-              />
-            </View>
-          </TouchableOpacity>
-        </View>
         <View style={style.headerContainer}>
           <Text style={style.header}>
             {t("export.code_input_title_bluetooth")}
@@ -261,25 +216,8 @@ const indicatorWidth = 120
 const style = StyleSheet.create({
   contentContainer: {
     backgroundColor: Colors.primaryLightBackground,
-    paddingTop: 110,
     paddingBottom: Spacing.xxxHuge,
     paddingHorizontal: Spacing.medium,
-  },
-  backButtonContainer: {
-    position: "absolute",
-    top: Layout.oneTwentiethHeight,
-    left: 0,
-  },
-  backButtonInnerContainer: {
-    padding: Spacing.medium,
-  },
-  cancelButtonContainer: {
-    position: "absolute",
-    top: Layout.oneTwentiethHeight,
-    right: 0,
-  },
-  cancelButtonInnerContainer: {
-    padding: Spacing.medium,
   },
   headerContainer: {
     marginBottom: Spacing.xxLarge,

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.spec.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { openAppSettings } from "../../gaen/nativeModule"
 import { render, fireEvent } from "@testing-library/react-native"
-import { useNavigation } from "@react-navigation/native"
 
 import EnableExposureNotifications from "./EnableExposureNotifications"
 
@@ -17,16 +16,6 @@ describe("EnableExposureNotifications", () => {
     ).toBeDefined()
     expect(getByText("Enable exposure notifications to continue")).toBeDefined()
   })
-
-  it("navigates to the home screen if users cancels", () => {
-    const navigateSpy = jest.fn()
-    ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
-    const { getByLabelText } = render(<EnableExposureNotifications />)
-
-    fireEvent.press(getByLabelText("Cancel"))
-    expect(navigateSpy).toHaveBeenCalledWith("Home")
-  })
-
   it("takes user to system settings if decide to activate notifications", () => {
     const { getByLabelText } = render(<EnableExposureNotifications />)
 

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
@@ -1,26 +1,18 @@
 import React, { FunctionComponent } from "react"
-import { ScrollView, TouchableOpacity, View, StyleSheet } from "react-native"
+import { ScrollView, View, StyleSheet } from "react-native"
 import { useTranslation } from "react-i18next"
-import { useNavigation } from "@react-navigation/native"
-import { SvgXml } from "react-native-svg"
 
 import { Text, Button, StatusBar } from "../../components"
-import { useStatusBarEffect, Stacks } from "../../navigation"
-import { Spacing, Iconography, Colors, Typography, Layout } from "../../styles"
-import { Icons } from "../../assets"
+import { useStatusBarEffect } from "../../navigation"
+import { Spacing, Colors, Typography } from "../../styles"
 import { openAppSettings } from "../../gaen/nativeModule"
 
 const EnableExposureNotifications: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.primaryLightBackground)
   const { t } = useTranslation()
-  const navigation = useNavigation()
 
   const handleOnPressOpenSettings = () => {
     openAppSettings()
-  }
-
-  const handleOnPressCancel = () => {
-    navigation.navigate(Stacks.Home)
   }
 
   return (
@@ -31,22 +23,6 @@ const EnableExposureNotifications: FunctionComponent = () => {
         testID={"affected-user-enable-exposure-notifications-screen"}
         alwaysBounceVertical={false}
       >
-        <View style={style.cancelButtonContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressCancel}
-            accessible
-            accessibilityLabel={t("export.code_input_button_cancel")}
-          >
-            <View style={style.cancelButtonInnerContainer}>
-              <SvgXml
-                xml={Icons.X}
-                fill={Colors.black}
-                width={Iconography.xxSmall}
-                height={Iconography.xxSmall}
-              />
-            </View>
-          </TouchableOpacity>
-        </View>
         <View style={style.headerContainer}>
           <Text style={style.header}>
             {t("export.enable_exposure_notifications_title")}
@@ -71,18 +47,8 @@ const style = StyleSheet.create({
     flexGrow: 1,
     justifyContent: "space-between",
     paddingHorizontal: Spacing.large,
-    paddingTop: Layout.oneEighthHeight,
     paddingBottom: Spacing.massive,
     backgroundColor: Colors.primaryLightBackground,
-  },
-  cancelButtonContainer: {
-    position: "absolute",
-    top: Spacing.medium,
-    right: Spacing.medium,
-    zIndex: Layout.zLevel1,
-  },
-  cancelButtonInnerContainer: {
-    padding: Spacing.medium,
   },
   headerContainer: {
     marginBottom: Spacing.huge,

--- a/src/AffectedUserFlow/index.tsx
+++ b/src/AffectedUserFlow/index.tsx
@@ -35,10 +35,18 @@ const AffectedUserStack: FunctionComponent = () => {
         <Stack.Screen
           name={AffectedUserFlowStackScreens.AffectedUserCodeInput}
           component={CodeInput}
+          options={{
+            ...Headers.headerMinimalOptions,
+            headerLeft: () => applyHeaderLeftBackButton(),
+          }}
         />
         <Stack.Screen
           name={AffectedUserFlowStackScreens.AffectedUserPublishConsent}
           component={PublishConsent}
+          options={{
+            ...Headers.headerMinimalOptions,
+            headerLeft: () => applyHeaderLeftBackButton(),
+          }}
         />
         <Stack.Screen
           name={AffectedUserFlowStackScreens.AffectedUserComplete}

--- a/src/AffectedUserFlow/index.tsx
+++ b/src/AffectedUserFlow/index.tsx
@@ -37,7 +37,7 @@ const AffectedUserStack: FunctionComponent = () => {
           component={CodeInput}
           options={{
             ...Headers.headerMinimalOptions,
-            headerLeft: () => applyHeaderLeftBackButton(),
+            headerLeft: applyHeaderLeftBackButton(),
           }}
         />
         <Stack.Screen
@@ -45,7 +45,7 @@ const AffectedUserStack: FunctionComponent = () => {
           component={PublishConsent}
           options={{
             ...Headers.headerMinimalOptions,
-            headerLeft: () => applyHeaderLeftBackButton(),
+            headerLeft: applyHeaderLeftBackButton(),
           }}
         />
         <Stack.Screen

--- a/src/SelfAssessment/SelfAssessmentIntro.tsx
+++ b/src/SelfAssessment/SelfAssessmentIntro.tsx
@@ -67,9 +67,8 @@ const style = StyleSheet.create({
   contentContainer: {
     flexGrow: 1,
     alignItems: "flex-start",
-    justifyContent: "center",
     paddingHorizontal: Spacing.xLarge,
-    paddingVertical: Spacing.xxxLarge,
+    paddingVertical: Spacing.large,
   },
   headerText: {
     ...Typography.header1,

--- a/src/navigation/HeaderLeftBackButton.tsx
+++ b/src/navigation/HeaderLeftBackButton.tsx
@@ -18,7 +18,6 @@ const HeaderLeftBackButton = () => {
     <HeaderBackButton
       tintColor={Colors.primary150}
       onPress={() => navigation.goBack()}
-      labelVisible={false}
     />
   )
 }


### PR DESCRIPTION
#### Why:
Several screens which are "pushed" to the nav stack rather than "presented" modally needed to be updated to display the navbar with a `back` button rather than hide the navbar and display an `X` icon

#### This commit:
This commit updates the relevant screens, and also displays the default `Back` label on iOS (to increase the tappable area of this button, which can be difficult to reach on larger iOS devices)

![Oct-11-2020 11-29-48](https://user-images.githubusercontent.com/2637355/95682769-243e9780-0bb5-11eb-9b5f-e25f44415cc2.gif)
