### PR TITLE
iOS Unit Test Cleanup

### DIFF
--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B52D88C0248F0FC00071ED51 /* SafePathsSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271881BF2461AF76001DE067 /* SafePathsSecureStorage.swift */; };
 		B52D88C4248F10FD0071ED51 /* BTSecureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52D88C3248F10FD0071ED51 /* BTSecureStorage.swift */; };
 		B54CBF32249A738500218477 /* IndexFileRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54CBF31249A738500218477 /* IndexFileRequests.swift */; };
+		B54FAEFF2536102100F09344 /* ExposureManagerUnitTests+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FAEFD2536102100F09344 /* ExposureManagerUnitTests+Extensions.swift */; };
 		B5525E5D2512B3D90093614A /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5525E5C2512B3D90093614A /* Int+Extensions.swift */; };
 		B5582D47249943E5001458A9 /* ExposureEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B5582D43249943DE001458A9 /* ExposureEventEmitter.m */; };
 		B576CC4324993F5200CDD9D9 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B576CC3D24993F4C00CDD9D9 /* Date+Extensions.swift */; };
@@ -232,6 +233,7 @@
 		B51D8D2624E43AE4001C28E1 /* KeySubmissionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySubmissionResponse.swift; sourceTree = "<group>"; };
 		B52D88C3248F10FD0071ED51 /* BTSecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSecureStorage.swift; sourceTree = "<group>"; };
 		B54CBF31249A738500218477 /* IndexFileRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexFileRequests.swift; sourceTree = "<group>"; };
+		B54FAEFD2536102100F09344 /* ExposureManagerUnitTests+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ExposureManagerUnitTests+Extensions.swift"; sourceTree = "<group>"; };
 		B5525E5C2512B3D90093614A /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
 		B5582D43249943DE001458A9 /* ExposureEventEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExposureEventEmitter.m; sourceTree = "<group>"; };
 		B576CC3D24993F4C00CDD9D9 /* Date+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				00E356F21AD99517003FC87E /* COVIDSafePathsTests.m */,
 				00E356F01AD99517003FC87E /* Supporting Files */,
 				B5A6FD6A24BC9E54007D328C /* ExposureManagerUnitTests.swift */,
+				B54FAEFD2536102100F09344 /* ExposureManagerUnitTests+Extensions.swift */,
 				A53F7B2124F21C3000C5E30A /* IntegrationTests.swift */,
 				A5CE5FC425005BE40045251A /* MiscUnitTests.swift */,
 			);
@@ -1044,6 +1047,7 @@
 				A5CE5FC525005BE40045251A /* MiscUnitTests.swift in Sources */,
 				C5AA24D824768FFF00BA0A99 /* COVIDSafePathsTests.m in Sources */,
 				A53F7B2224F21C3000C5E30A /* IntegrationTests.swift in Sources */,
+				B54FAEFF2536102100F09344 /* ExposureManagerUnitTests+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests+Extensions.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests+Extensions.swift
@@ -1,0 +1,199 @@
+import ExposureNotification
+import Foundation
+
+@testable import BT
+
+extension ExposureManagerTests {
+
+  func storageWithExposures() -> BTSecureStorageMock {
+    let btSecureStorageMock = BTSecureStorageMock(notificationCenter: NotificationCenter())
+    btSecureStorageMock.userStateHandler = {
+      let userState = UserState()
+      userState.exposures.append(Exposure(id: "1",
+                                          date: startOfDay.posixRepresentation))
+      return userState
+    }
+    return btSecureStorageMock
+  }
+
+  func defaultExposureManager(withKeys: Bool = true, enAPIVersion: ENAPIVersion,
+                              userState: UserState? = nil,
+                              forceRiskScore: RiskScore = .aboveThreshold,
+                              forceExposureDetectionError: Bool = false,
+                              forceDownloadKeyError: Bool = false,
+                              forceKeyUnpackingError: Bool = false,
+                              forceGetExposureInfoError: Bool = false,
+                              forceDownloadConfigurationError: Bool = false) -> ExposureManager {
+
+    let btSecureStorageMock = BTSecureStorageMock(notificationCenter: NotificationCenter.default)
+
+    var apiClientMock: APIClientMock!
+    var enManagerMock: ENManagerMock!
+
+
+    if enAPIVersion == .v2, #available(iOS 13.7, *) {
+      apiClientMock = apiClientV2(forceDownloadKeyError: forceDownloadKeyError,
+                                  forceKeyUnpackingError: forceKeyUnpackingError,
+                                  forceDownloadConfigurationError: forceDownloadConfigurationError)
+      enManagerMock = eNManagerMockV2(forceExposureDetectionError: forceExposureDetectionError,
+                                      forceRiskScore: forceRiskScore)
+    } else {
+      apiClientMock = apiClientV1(forceDownloadKeyError: forceDownloadKeyError,
+                                  forceKeyUnpackingError: forceKeyUnpackingError,
+                                  forceDownloadConfigurationError: forceDownloadConfigurationError)
+      enManagerMock = eNManagerMockV1(forceExposureDetectionError: forceExposureDetectionError,
+                                      forceGetExposureInfoError: forceGetExposureInfoError)
+    }
+
+    if let userState = userState {
+      btSecureStorageMock.userStateHandler = {
+        return userState
+      }
+    }
+
+    if withKeys {
+      enManagerMock.getDiagnosisKeysHandler = { callback in
+        callback([ENTemporaryExposureKey()], nil)
+      }
+    } else {
+      enManagerMock.getDiagnosisKeysHandler = { callback in
+        callback(nil, GenericError.unknown)
+      }
+    }
+
+    let exposureManager = ExposureManager(exposureNotificationManager: enManagerMock,
+                                          apiClient: apiClientMock,
+                                          btSecureStorage: btSecureStorageMock)
+    return exposureManager
+  }
+
+  func eNManagerMockV1(forceExposureDetectionError: Bool,
+                       forceGetExposureInfoError: Bool) -> ENManagerMock {
+    let enManagerMock = ENManagerMock()
+
+    enManagerMock.enDetectExposuresHandler = { configuration, diagnosisKeys, completionHandler in
+      let enExposureSummary = MockENExposureDetectionSummary()
+      enExposureSummary.matchedKeyCountHandler = {
+        return 1
+      }
+      enExposureSummary.attenuationDurationsHandler = {
+        return [900,0,0]
+      }
+
+      if forceExposureDetectionError {
+        completionHandler(nil, GenericError.unknown)
+      } else {
+        completionHandler(enExposureSummary, nil)
+      }
+      return Progress()
+    }
+
+    enManagerMock.setExposureNotificationEnabledHandler = { enabled, completionHandler in
+      completionHandler(nil)
+    }
+
+    enManagerMock.getExposureInfoHandler = { summary, useExplanation, completionHandler in
+      guard !forceGetExposureInfoError else {
+        completionHandler(nil, GenericError.unknown)
+        return Progress()
+      }
+      completionHandler([MockENExposureInfo()], nil)
+      return Progress()
+    }
+
+    return enManagerMock
+  }
+
+  @available(iOS 13.7, *)
+  func eNManagerMockV2(forceExposureDetectionError: Bool = false, forceRiskScore: RiskScore) -> ENManagerMock {
+    let enManagerMock = ENManagerMock()
+
+    let mockDaySummariesENExposureDetectionSummary = MockDaySummariesENExposureDetectionSummary()
+
+    let enExposureSummaryItemMock = MockENExposureSummaryItem()
+    enExposureSummaryItemMock.weightedDurationSumHandler = {
+      return forceRiskScore == .aboveThreshold ? 20 : 0
+    }
+
+    let enExposureDaySummaryMock = MockENExposureDaySummary()
+    enExposureDaySummaryMock.daySummaryHandler = {
+      return enExposureSummaryItemMock
+    }
+
+    mockDaySummariesENExposureDetectionSummary.daySummariesHandler = {
+      return [enExposureDaySummaryMock]
+    }
+
+    enManagerMock.setExposureNotificationEnabledHandler = { enabled, completionHandler in
+      completionHandler(nil)
+    }
+
+    enManagerMock.enDetectExposuresHandler = { configuration, diagnosisKeys, completionHandler in
+      if forceExposureDetectionError {
+        completionHandler(nil, GenericError.unknown)
+      } else {
+        completionHandler(mockDaySummariesENExposureDetectionSummary, nil)
+      }
+      return Progress()
+    }
+
+    return enManagerMock
+  }
+
+  func apiClientV1(forceDownloadKeyError: Bool,
+                   forceKeyUnpackingError: Bool,
+                   forceDownloadConfigurationError: Bool) -> APIClientMock {
+    let apiClientMock = APIClientMock { (request, requestType) -> (AnyObject) in
+      return Result<String>.success("indexFilePath") as AnyObject
+    }
+    let mockDownloadedPackage = MockDownloadedPackage { () -> URL in
+      guard !forceKeyUnpackingError else {
+        throw GenericError.unknown
+      }
+      return URL(fileURLWithPath: "url")
+    }
+    apiClientMock.downloadRequestHander = { (request, requestType) in
+      switch requestType {
+      case .downloadKeys:
+        return forceDownloadKeyError ? .failure(GenericError.unknown) : Result<DownloadedPackage>.success(mockDownloadedPackage)
+      default:
+        return forceDownloadConfigurationError ? .failure(GenericError.unknown) : Result<ExposureConfigurationV1>.success(ExposureConfigurationV1.placeholder)
+      }
+    }
+    return apiClientMock
+  }
+
+  @available(iOS 13.7, *)
+  func apiClientV2(forceDownloadKeyError: Bool,
+                   forceKeyUnpackingError: Bool,
+                   forceDownloadConfigurationError: Bool) -> APIClientMock {
+    let apiClientMock = APIClientMock { (request, requestType) -> (AnyObject) in
+      return Result<String>.success("indexFilePath") as AnyObject
+    }
+    let mockDownloadedPackage = MockDownloadedPackage { () -> URL in
+      guard !forceKeyUnpackingError else {
+        throw GenericError.unknown
+      }
+      return URL(fileURLWithPath: "url")
+    }
+    
+    apiClientMock.downloadRequestHander = { (request, requestType) in
+      switch requestType {
+      case .downloadKeys:
+        return forceDownloadKeyError ? .failure(GenericError.unknown) : Result<DownloadedPackage>.success(mockDownloadedPackage)
+      default:
+        return forceDownloadConfigurationError ? .failure(GenericError.unknown) : Result<DailySummariesConfiguration>.success(DailySummariesConfiguration.placeholder)
+      }
+    }
+    return apiClientMock
+  }
+
+}
+
+enum RiskScore {
+  case aboveThreshold, belowThreshold
+}
+
+enum ENAPIVersion {
+  case v1, v2
+}

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests+Extensions.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests+Extensions.swift
@@ -4,8 +4,8 @@ import Foundation
 @testable import BT
 
 extension ExposureManagerTests {
-
-  func storageWithExposures() -> BTSecureStorageMock {
+  
+  func defaultStorage() -> BTSecureStorageMock {
     let btSecureStorageMock = BTSecureStorageMock(notificationCenter: NotificationCenter())
     btSecureStorageMock.userStateHandler = {
       let userState = UserState()
@@ -15,7 +15,7 @@ extension ExposureManagerTests {
     }
     return btSecureStorageMock
   }
-
+  
   func defaultExposureManager(withKeys: Bool = true, enAPIVersion: ENAPIVersion,
                               userState: UserState? = nil,
                               forceRiskScore: RiskScore = .aboveThreshold,
@@ -24,13 +24,13 @@ extension ExposureManagerTests {
                               forceKeyUnpackingError: Bool = false,
                               forceGetExposureInfoError: Bool = false,
                               forceDownloadConfigurationError: Bool = false) -> ExposureManager {
-
+    
     let btSecureStorageMock = BTSecureStorageMock(notificationCenter: NotificationCenter.default)
-
+    
     var apiClientMock: APIClientMock!
     var enManagerMock: ENManagerMock!
-
-
+    
+    
     if enAPIVersion == .v2, #available(iOS 13.7, *) {
       apiClientMock = apiClientV2(forceDownloadKeyError: forceDownloadKeyError,
                                   forceKeyUnpackingError: forceKeyUnpackingError,
@@ -44,13 +44,13 @@ extension ExposureManagerTests {
       enManagerMock = eNManagerMockV1(forceExposureDetectionError: forceExposureDetectionError,
                                       forceGetExposureInfoError: forceGetExposureInfoError)
     }
-
+    
     if let userState = userState {
       btSecureStorageMock.userStateHandler = {
         return userState
       }
     }
-
+    
     if withKeys {
       enManagerMock.getDiagnosisKeysHandler = { callback in
         callback([ENTemporaryExposureKey()], nil)
@@ -60,17 +60,17 @@ extension ExposureManagerTests {
         callback(nil, GenericError.unknown)
       }
     }
-
+    
     let exposureManager = ExposureManager(exposureNotificationManager: enManagerMock,
                                           apiClient: apiClientMock,
                                           btSecureStorage: btSecureStorageMock)
     return exposureManager
   }
-
+  
   func eNManagerMockV1(forceExposureDetectionError: Bool,
                        forceGetExposureInfoError: Bool) -> ENManagerMock {
     let enManagerMock = ENManagerMock()
-
+    
     enManagerMock.enDetectExposuresHandler = { configuration, diagnosisKeys, completionHandler in
       let enExposureSummary = MockENExposureDetectionSummary()
       enExposureSummary.matchedKeyCountHandler = {
@@ -79,7 +79,7 @@ extension ExposureManagerTests {
       enExposureSummary.attenuationDurationsHandler = {
         return [900,0,0]
       }
-
+      
       if forceExposureDetectionError {
         completionHandler(nil, GenericError.unknown)
       } else {
@@ -87,11 +87,11 @@ extension ExposureManagerTests {
       }
       return Progress()
     }
-
+    
     enManagerMock.setExposureNotificationEnabledHandler = { enabled, completionHandler in
       completionHandler(nil)
     }
-
+    
     enManagerMock.getExposureInfoHandler = { summary, useExplanation, completionHandler in
       guard !forceGetExposureInfoError else {
         completionHandler(nil, GenericError.unknown)
@@ -100,34 +100,34 @@ extension ExposureManagerTests {
       completionHandler([MockENExposureInfo()], nil)
       return Progress()
     }
-
+    
     return enManagerMock
   }
-
+  
   @available(iOS 13.7, *)
   func eNManagerMockV2(forceExposureDetectionError: Bool = false, forceRiskScore: RiskScore) -> ENManagerMock {
     let enManagerMock = ENManagerMock()
-
+    
     let mockDaySummariesENExposureDetectionSummary = MockDaySummariesENExposureDetectionSummary()
-
+    
     let enExposureSummaryItemMock = MockENExposureSummaryItem()
     enExposureSummaryItemMock.weightedDurationSumHandler = {
       return forceRiskScore == .aboveThreshold ? 20 : 0
     }
-
+    
     let enExposureDaySummaryMock = MockENExposureDaySummary()
     enExposureDaySummaryMock.daySummaryHandler = {
       return enExposureSummaryItemMock
     }
-
+    
     mockDaySummariesENExposureDetectionSummary.daySummariesHandler = {
       return [enExposureDaySummaryMock]
     }
-
+    
     enManagerMock.setExposureNotificationEnabledHandler = { enabled, completionHandler in
       completionHandler(nil)
     }
-
+    
     enManagerMock.enDetectExposuresHandler = { configuration, diagnosisKeys, completionHandler in
       if forceExposureDetectionError {
         completionHandler(nil, GenericError.unknown)
@@ -136,10 +136,10 @@ extension ExposureManagerTests {
       }
       return Progress()
     }
-
+    
     return enManagerMock
   }
-
+  
   func apiClientV1(forceDownloadKeyError: Bool,
                    forceKeyUnpackingError: Bool,
                    forceDownloadConfigurationError: Bool) -> APIClientMock {
@@ -162,7 +162,7 @@ extension ExposureManagerTests {
     }
     return apiClientMock
   }
-
+  
   @available(iOS 13.7, *)
   func apiClientV2(forceDownloadKeyError: Bool,
                    forceKeyUnpackingError: Bool,
@@ -187,7 +187,7 @@ extension ExposureManagerTests {
     }
     return apiClientMock
   }
-
+  
 }
 
 enum RiskScore {

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -10,22 +10,22 @@ import XCTest
 // MARK: == Mocks ==
 
 class MockENExposureDetectionSummary: ENExposureDetectionSummary {
-
+  
   var matchedKeyCountHandler: (() -> UInt64)?
   var attenuationDurationsHandler: (() -> [NSNumber])?
-
+  
   override var matchedKeyCount: UInt64 {
     return matchedKeyCountHandler?() ?? 0
   }
-
+  
   override var attenuationDurations: [NSNumber] {
     return attenuationDurationsHandler?() ?? [0,0,0]
   }
-
+  
   override var riskScoreSumFullRange: Double {
     return 0
   }
-
+  
   @available(iOS 13.7, *)
   override var daySummaries: [ENExposureDaySummary] {
     let enExposureSummary = ENExposureDaySummary()
@@ -35,16 +35,16 @@ class MockENExposureDetectionSummary: ENExposureDetectionSummary {
 
 @available(iOS 13.7, *)
 class MockDaySummariesENExposureDetectionSummary: MockENExposureDetectionSummary {
-
+  
   var daySummariesHandler: (() -> [ENExposureDaySummary])?
-
+  
   override var daySummaries: [ENExposureDaySummary] {
     return daySummariesHandler?() ?? []
   }
 }
 
 class MockENExposureInfo: ENExposureInfo {
-
+  
   override var date: Date {
     return Date()
   }
@@ -52,11 +52,11 @@ class MockENExposureInfo: ENExposureInfo {
 
 @available(iOS 13.7, *)
 class MockENExposureDaySummary: ENExposureDaySummary {
-
+  
   override var date: Date {
     return halloween
   }
-
+  
   var daySummaryHandler: (() -> ENExposureSummaryItem)?
   override var daySummary: ENExposureSummaryItem {
     return daySummaryHandler?() ?? ENExposureSummaryItem()
@@ -65,9 +65,9 @@ class MockENExposureDaySummary: ENExposureDaySummary {
 
 @available(iOS 13.7, *)
 class MockENExposureSummaryItem: ENExposureSummaryItem {
-
+  
   var weightedDurationSumHandler: (() -> TimeInterval)?
-
+  
   override var weightedDurationSum: TimeInterval {
     return weightedDurationSumHandler?() ?? 0
   }
@@ -76,33 +76,33 @@ class MockENExposureSummaryItem: ENExposureSummaryItem {
 
 
 class MockDownloadedPackage: DownloadedPackage {
-
+  
   var handler: () throws -> URL
-
+  
   init(handler: @escaping () throws -> URL) {
     self.handler = handler
     super.init(keysBin: Data(), signature: Data())
   }
-
+  
   override func writeSignatureEntry(toDirectory directory: URL, filename: String) throws -> URL {
     return try handler()
   }
-
+  
   override func writeKeysEntry(toDirectory directory: URL, filename: String) throws -> URL {
     return try handler()
   }
-
+  
   
 }
 
 class KeychainServiceMock: KeychainService {
-
+  
   var setRevisionTokenHandler: ((String) -> Void)?
-
+  
   func setRevisionToken(_ token: String) {
     setRevisionTokenHandler?(token)
   }
-
+  
   var revisionToken: String {
     return "revisionToken"
   }
@@ -110,78 +110,78 @@ class KeychainServiceMock: KeychainService {
 }
 
 class BTSecureStorageMock: BTSecureStorage {
-
+  
   var userStateHandler: (() -> UserState)?
   var storeExposuresHandler: (([Exposure]) -> Void)?
   init(notificationCenter: NotificationCenter) {
     super.init(inMemory: true, notificationCenter: notificationCenter)
   }
-
+  
   override var userState: UserState {
     return userStateHandler?() ?? super.userState
   }
-
+  
   override func storeExposures(_ exposures: [Exposure]) {
     storeExposuresHandler?(exposures)
   }
 }
 
 class APIClientMock: APIClient {
-
+  
   var requestHander: (Any, RequestType) -> (Any)
   var downloadRequestHander: ((Any, RequestType) -> (Any))?
-
+  
   init(requestHander: @escaping (Any, RequestType) -> (Any)) {
     self.requestHander = requestHander
   }
-
+  
   static var documentsDirectory: URL? {
     return nil
   }
-
+  
   func downloadRequest<T>(_ request: T, requestType: RequestType, completion: @escaping (Result<T.ResponseType>) -> Void) where T : APIRequest, T.ResponseType : DownloadableFile {
     completion(downloadRequestHander!(request, requestType) as! Result<T.ResponseType>)
   }
-
+  
   func request<T>(_ request: T, requestType: RequestType, completion: @escaping GenericCompletion) where T : APIRequest, T.ResponseType == Void {
-
+    
   }
-
+  
   func request<T>(_ request: T, requestType: RequestType, completion: @escaping (Result<JSONObject>) -> Void) where T : APIRequest, T.ResponseType == JSONObject {
   }
-
+  
   func request<T>(_ request: T, requestType: RequestType, completion: @escaping (Result<T.ResponseType>) -> Void) where T : APIRequest, T.ResponseType : Decodable {
     completion(requestHander(request, requestType) as! Result<T.ResponseType>)
   }
-
+  
   func requestList<T>(_ request: T, requestType: RequestType, completion: @escaping (Result<[T.ResponseType.Element]>) -> Void) where T : APIRequest, T.ResponseType : Collection, T.ResponseType.Element : Decodable {
-
+    
   }
-
+  
   func requestString<T>(_ request: T, requestType: RequestType, completion: @escaping (Result<T.ResponseType>) -> Void) where T : APIRequest, T.ResponseType == String {
     completion(requestHander(request, requestType) as! Result<T.ResponseType>)
   }
-
+  
   func cancelAllRequests() {
-
+    
   }
 }
 
 class NotificationCenterMock: NotificationCenter {
-
+  
   var addObserverHandler: ((_ observer: Any,
                             _ aSelector: Selector,
                             _ aName: NSNotification.Name?,
                             _ anObject: Any?) -> Void)?
   var postHandler: ((_ notification: Notification) -> Void)?
-
+  
   override func addObserver(_ observer: Any,
                             selector aSelector: Selector,
                             name aName: NSNotification.Name?,
                             object anObject: Any?) {
     addObserverHandler?(observer, aSelector, aName, anObject)
   }
-
+  
   override func post(_ notification: Notification) {
     postHandler?(notification)
   }
@@ -189,19 +189,19 @@ class NotificationCenterMock: NotificationCenter {
 
 class ENManagerMock: ExposureNotificationManager {
   var detectExposuresHandler: ((_ configuration: ENExposureConfiguration,
-                                         _ completionHandler: @escaping ENDetectExposuresHandler) -> Progress)?
-
+                                _ completionHandler: @escaping ENDetectExposuresHandler) -> Progress)?
+  
   func detectExposures(configuration: ENExposureConfiguration, completionHandler: @escaping ENDetectExposuresHandler) -> Progress {
     return detectExposuresHandler?(configuration, completionHandler) ?? Progress()
   }
-
+  
   @available(iOS 13.7, *)
   func getExposureWindows(summary: ENExposureDetectionSummary,
                           completionHandler: @escaping ENGetExposureWindowsHandler) -> Progress {
     return Progress()
   }
-
-
+  
+  
   var activateHandler: ((_ completionHandler: @escaping ENErrorHandler) -> Void)?
   var invalidateHandler: (() -> Void)?
   var setExposureNotificationEnabledHandler: ((_ enabled: Bool, _ completionHandler: @escaping ENErrorHandler) -> Void)?
@@ -212,75 +212,75 @@ class ENManagerMock: ExposureNotificationManager {
   var enDetectExposuresHandler: ((_ configuration: ENExposureConfiguration, _ diagnosisKeyURLs: [URL], _ completionHandler: @escaping ENDetectExposuresHandler) -> Progress)?
   var getExposureInfoHandler: ((_ summary: ENExposureDetectionSummary, _ userExplanation: String, _ completionHandler: @escaping ENGetExposureInfoHandler) -> Progress)?
   var dispatchQueue: DispatchQueue = DispatchQueue.main
-
+  
   var invalidationHandler: (() -> Void)?
-
+  
   func authorizationStatus() -> ENAuthorizationStatus {
     return authorizationStatusHandler?() ?? .unknown
   }
-
+  
   var exposureNotificationEnabled: Bool {
     return exposureNotificationEnabledHandler?() ?? false
   }
-
+  
   func detectExposures(configuration: ENExposureConfiguration, diagnosisKeyURLs: [URL], completionHandler: @escaping ENDetectExposuresHandler) -> Progress {
     return enDetectExposuresHandler?(configuration, diagnosisKeyURLs, completionHandler) ?? Progress()
   }
-
+  
   func getExposureInfo(summary: ENExposureDetectionSummary, userExplanation: String, completionHandler: @escaping ENGetExposureInfoHandler) -> Progress {
     return getExposureInfoHandler?(summary, userExplanation, completionHandler) ?? Progress()
   }
-
+  
   func getDiagnosisKeys(completionHandler: @escaping ENGetDiagnosisKeysHandler) {
     getDiagnosisKeysHandler?(completionHandler)
   }
-
+  
   func getTestDiagnosisKeys(completionHandler: @escaping ENGetDiagnosisKeysHandler) {
-
+    
   }
-
+  
   var exposureNotificationStatus: ENStatus {
     return exposureNotificationStatusHandler?() ?? .unknown
   }
-
+  
   func activate(completionHandler: @escaping ENErrorHandler) {
     activateHandler?(completionHandler)
   }
-
+  
   func invalidate() {
     invalidateHandler?()
   }
-
+  
   func setExposureNotificationEnabled(_ enabled: Bool, completionHandler: @escaping ENErrorHandler) {
     setExposureNotificationEnabledHandler?(enabled, completionHandler)
   }
 }
 
 class BGTaskSchedulerMock: BackgroundTaskScheduler {
-
+  
   var registerHandler: ((_ identifier: String, _ launchHandler: @escaping (BGTask) -> Void) -> Bool)?
   var submitHandler: ((_ taskRequest: BGTaskRequest) -> Void)?
-
+  
   func register(forTaskWithIdentifier identifier: String,
                 using queue: DispatchQueue?,
                 launchHandler: @escaping (BGTask) -> Void) -> Bool {
     return registerHandler?(identifier, launchHandler) ?? false
   }
-
+  
   func submit(_ taskRequest: BGTaskRequest) throws {
     submitHandler?(taskRequest)
   }
 }
 
 class UNUserNotificationCenterMock: UserNotificationCenter {
-
+  
   var addHandler: ((_ request: UNNotificationRequest, _ completionHandler: ((Error?) -> Void)?) -> Void)?
   var removeDeliveredNotificationsHandler: ((_ identifiers: [String]) -> Void)?
-
+  
   func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)?) {
     addHandler?(request, completionHandler)
   }
-
+  
   func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
     removeDeliveredNotificationsHandler?(identifiers)
   }
@@ -289,28 +289,28 @@ class UNUserNotificationCenterMock: UserNotificationCenter {
 // MARK: == UNIT TESTS ==
 
 class ExposureManagerTests: XCTestCase {
-
+  
   func testCreatesSharedInstance() {
     ExposureManager.createSharedInstance()
     XCTAssertNotNil(ExposureManager.shared)
   }
-
+  
   func testLifecycle() {
     let mockENManager = ENManagerMock()
     let activateExpectation = self.expectation(description: "Activate gets called")
     let invalidateExpectation = self.expectation(description: "Invalidate gets called")
-
+    
     let registerNotificationExpectation = self.expectation(description: "Registers for authorization changes")
-
+    
     let setExposureNotificationEnabledTrueExpectation = self.expectation(description: "When activated, if authorized and disabled, request to enable exposure notifications")
-
+    
     let notificationCenterMock = NotificationCenterMock()
     notificationCenterMock.addObserverHandler = { (_, _, name, _) in
       if name == Notification.Name.AuthorizationStatusDidChange {
         registerNotificationExpectation.fulfill()
       }
     }
-
+    
     mockENManager.activateHandler = { completionHandler in
       mockENManager.authorizationStatusHandler = {
         return .authorized
@@ -321,18 +321,18 @@ class ExposureManagerTests: XCTestCase {
       completionHandler(nil)
       activateExpectation.fulfill()
     }
-
+    
     mockENManager.invalidateHandler = {
       invalidateExpectation.fulfill()
     }
-
+    
     mockENManager.setExposureNotificationEnabledHandler = { enabled, completionHandler in
       if enabled {
         setExposureNotificationEnabledTrueExpectation.fulfill()
       }
       completionHandler(nil)
     }
-
+    
     _ = ExposureManager(exposureNotificationManager: mockENManager,
                         notificationCenter: notificationCenterMock)
     wait(for: [activateExpectation,
@@ -340,9 +340,9 @@ class ExposureManagerTests: XCTestCase {
                registerNotificationExpectation,
                setExposureNotificationEnabledTrueExpectation], timeout: 1)
   }
-
+  
   func testAwake() {
-
+    
     let broadcastAuthorizationStateExpectation = self.expectation(description: "A notification is post with the current authorization and enabled stated")
     let notificationCenterMock = NotificationCenterMock()
     notificationCenterMock.postHandler = { notification in
@@ -354,12 +354,12 @@ class ExposureManagerTests: XCTestCase {
     exposureManager.awake()
     wait(for: [broadcastAuthorizationStateExpectation], timeout: 0)
   }
-
+  
   func testEnabledtatus() {
-
+    
     let mockENManager = ENManagerMock()
     let exposureManager = ExposureManager(exposureNotificationManager: mockENManager)
-
+    
     mockENManager.exposureNotificationEnabledHandler = {
       return true
     }
@@ -369,12 +369,12 @@ class ExposureManagerTests: XCTestCase {
     }
     XCTAssertEqual(exposureManager.enabledState, ExposureManager.EnabledState.disabled)
   }
-
+  
   func testAuthorizationStatus() {
-
+    
     let mockENManager = ENManagerMock()
     let exposureManager = ExposureManager(exposureNotificationManager: mockENManager)
-
+    
     mockENManager.authorizationStatusHandler = {
       return .authorized
     }
@@ -396,12 +396,12 @@ class ExposureManagerTests: XCTestCase {
     XCTAssertEqual(exposureManager.authorizationState,
                    ExposureManager.AuthorizationState.unauthorized)
   }
-
+  
   func testBluetoothStatus() {
-
+    
     let mockENManager = ENManagerMock()
     let exposureManager = ExposureManager(exposureNotificationManager: mockENManager)
-
+    
     mockENManager.exposureNotificationStatusHandler = {
       return .bluetoothOff
     }
@@ -427,10 +427,10 @@ class ExposureManagerTests: XCTestCase {
     }
     XCTAssertTrue(exposureManager.isBluetoothEnabled)
   }
-
+  
   func testCurrentExposures() {
     let enManagerMock = ENManagerMock()
-
+    
     enManagerMock.enDetectExposuresHandler = { configuration, diagnosisKeys, completionHandler in
       let enExposureSummary = MockENExposureDetectionSummary()
       enExposureSummary.matchedKeyCountHandler = {
@@ -442,12 +442,12 @@ class ExposureManagerTests: XCTestCase {
       completionHandler(enExposureSummary, nil)
       return Progress()
     }
-
+    
     enManagerMock.detectExposuresHandler = { configuration, completion in
       completion(nil, GenericError.unknown)
       return Progress()
     }
-
+    
     let apiClientMock = APIClientMock { (request, requestType) -> (AnyObject) in
       return Result<String>.success(String.default) as AnyObject
     }
@@ -457,7 +457,7 @@ class ExposureManagerTests: XCTestCase {
       }
       return Result<ExposureConfigurationV1>.success(ExposureConfigurationV1.placeholder) as AnyObject
     }
-
+    
     let btSecureStorageMock = BTSecureStorageMock(notificationCenter: NotificationCenter())
     btSecureStorageMock.userStateHandler = {
       let userState = UserState()
@@ -471,7 +471,7 @@ class ExposureManagerTests: XCTestCase {
     let currentExposures = exposureManager.currentExposures
     XCTAssertNoThrow(try! JSONDecoder().decode(Array<Exposure>.self, from: currentExposures.data(using: .utf8) ?? Data()))
   }
-
+  
   func testEnableNotificationsSuccess() {
     let setEnabled = true
     let setExposureNotificationEnabledExpectation = self.expectation(description: "Request the change of state to the underlying manager")
@@ -497,7 +497,7 @@ class ExposureManagerTests: XCTestCase {
     wait(for: [setExposureNotificationEnabledExpectation,
                broadcastAuthorizationStateExpectation], timeout: 0)
   }
-
+  
   func testEnableNotificationsError() {
     let setExposureNotificationEnabledExpectation = self.expectation(description: "Request the change of state to the underlying manager")
     let mockENManager = ENManagerMock()
@@ -521,7 +521,7 @@ class ExposureManagerTests: XCTestCase {
     wait(for: [setExposureNotificationEnabledExpectation,
                broadcastAuthorizationStateExpectation], timeout: 0)
   }
-
+  
   func testGetCurrentENPermissionsStatus() {
     let mockENManager = ENManagerMock()
     mockENManager.authorizationStatusHandler = {
@@ -536,11 +536,11 @@ class ExposureManagerTests: XCTestCase {
       XCTAssertEqual(enabled, ExposureManager.EnabledState.enabled.rawValue)
     }
   }
-
+  
   func testBluetoothNotificationOn() {
     let addNotificatiionRequestExpectation = self.expectation(description: "A notification request is added with the proper title and body")
     let removeNotificationsExpectation = self.expectation(description: "when is not authorized and bluetooth is not off we just remove all delivered notifications")
-
+    
     let unUserNotificationCenterMock = UNUserNotificationCenterMock()
     unUserNotificationCenterMock.addHandler = { request, completionHandler in
       addNotificatiionRequestExpectation.fulfill()
@@ -551,7 +551,7 @@ class ExposureManagerTests: XCTestCase {
       //we execute the callback with an error just to get more test coverage :)
       completionHandler?(GenericError.unknown)
     }
-
+    
     let mockENManager = ENManagerMock()
     mockENManager.authorizationStatusHandler = {
       return .authorized
@@ -566,22 +566,22 @@ class ExposureManagerTests: XCTestCase {
     exposureManager.notifyUserBlueToothOffIfNeeded()
     wait(for: [addNotificatiionRequestExpectation, removeNotificationsExpectation], timeout: 0)
   }
-
+  
   func testRecentExposures() {
-    let withExposures = storageWithExposures()
+    let withExposures = defaultStorage()
     XCTAssertEqual(withExposures.userState.recentExposures.count, 1)
   }
-
+  
   func testBluetoothNotificationOff() {
     let addNotificatiionRequestExpectation = self.expectation(description: "A notification request is added with the proper title and body")
     let removeNotificationsExpectation = self.expectation(description: "when is not authorized and bluetooth is not off we just remove all delivered notifications")
-
+    
     let unUserNotificationCenterMock = UNUserNotificationCenterMock()
     unUserNotificationCenterMock.removeDeliveredNotificationsHandler = { identifiers in
       removeNotificationsExpectation.fulfill()
       XCTAssertEqual(identifiers[0], String.bluetoothNotificationIdentifier)
     }
-
+    
     let mockENManager = ENManagerMock()
     mockENManager.exposureNotificationStatusHandler = {
       return .active
@@ -593,7 +593,7 @@ class ExposureManagerTests: XCTestCase {
     exposureManager.notifyUserBlueToothOffIfNeeded()
     wait(for: [addNotificatiionRequestExpectation, removeNotificationsExpectation], timeout: 0)
   }
-
+  
   func testFetchExposureKeysSuccess() {
     let expectation = self.expectation(description: "a call is made to get the diagnosis keys")
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -604,7 +604,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 0)
   }
-
+  
   func testFetchExposureKeysError() {
     let expectation = self.expectation(description: "a call is made to get the diagnosis keys")
     let exposureManager = defaultExposureManager(withKeys: false, enAPIVersion: .v1)
@@ -615,17 +615,17 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 0)
   }
-
+  
   func testFetchLastDetectionDate() {
     let userState = UserState()
     let exposureManager = defaultExposureManager(enAPIVersion: .v1, userState: userState)
-
+    
     // Last detection date should initially be nil
     exposureManager.fetchLastDetectionDate { (posixDate, error) in
       XCTAssertNil(posixDate)
       XCTAssertEqual(error?.errorCode, ExposureManagerErrorCode.detectionNeverPerformed.rawValue)
     }
-
+    
     let date = Date()
     userState.lastExposureCheckDate = date
     exposureManager.fetchLastDetectionDate { (posixDate, error) in
@@ -633,11 +633,11 @@ class ExposureManagerTests: XCTestCase {
       XCTAssertEqual(posixDate, NSNumber(value: date.posixRepresentation))
     }
   }
-
+  
   func testRemainingFileCapacityReset() {
     let expectation = self.expectation(description: "remainingFileCapacity is updated")
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
-
+    
     exposureManager.detectExposuresV1 { (result) in
       switch result {
       case .success:
@@ -648,12 +648,12 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 5)
   }
-
+  
   func testUpdateLastExposureDetectionDateV1() {
     let expectation = self.expectation(description: "lastExposureCheckDate is updated")
-
+    
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
-
+    
     XCTAssertNil(exposureManager.btSecureStorage.lastExposureCheckDate)
     exposureManager.detectExposuresV1 { _ in
       XCTAssertNotNil(exposureManager.btSecureStorage.lastExposureCheckDate)
@@ -661,13 +661,13 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 50)
   }
-
+  
   func testRemainingFileCapacityNoResetForDetectionError() {
     let expectation = self.expectation(description: "remainingFileCapacity is not updated")
-
+    
     let exposureManager = defaultExposureManager(enAPIVersion: .v1,
                                                  forceExposureDetectionError: true)
-
+    
     exposureManager.detectExposuresV1 { (result) in
       switch result {
       case .failure:
@@ -678,7 +678,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 5)
   }
-
+  
   func testDebugFetchDiagnosisKeys() {
     let debugAction = DebugAction.fetchDiagnosisKeys
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -692,7 +692,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDebugSimulateExposureDetectionError() {
     let debugAction = DebugAction.simulateExposureDetectionError
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -706,7 +706,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [successExpectactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDebugSimulateExposure() {
     let debugAction = DebugAction.simulateExposure
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -720,14 +720,14 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [successExpectactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDebugFetchExposures() {
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
     let debugAction = DebugAction.fetchExposures
     let successExpetactionResolve = self.expectation(description: "resolve is called")
     let successExpectationReject = self.expectation(description: "reject is not called")
     successExpectationReject.isInverted = true
-
+    
     exposureManager.handleDebugAction(debugAction, resolve: { (success) in
       successExpetactionResolve.fulfill()
     }) { (_, _, _) in
@@ -735,7 +735,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 2)
   }
-
+  
   func testDebugResetExposures() {
     let debugAction = DebugAction.resetExposures
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -749,7 +749,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDebugToggleENAuthorization() {
     let debugAction = DebugAction.toggleENAuthorization
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -763,7 +763,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDebugShowLastProcessedFilePath() {
     let debugAction = DebugAction.showLastProcessedFilePath
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -777,7 +777,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDetectExposuresKeysDownloadingError() {
     let expectation = self.expectation(description: "the exposure detection call returns an error")
     let exposureManager = defaultExposureManager(enAPIVersion: .v1,
@@ -792,7 +792,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 5)
   }
-
+  
   func testDetectExposuresUnpackagingError() {
     let expectation = self.expectation(description: "the exposure detection call returns an error")
     let exposureManager = defaultExposureManager(enAPIVersion: .v1,
@@ -805,10 +805,10 @@ class ExposureManagerTests: XCTestCase {
       default: XCTFail()
       }
     }
-
+    
     wait(for: [expectation], timeout: 5)
   }
-
+  
   func testDetectExposuresGetExposureInfoError() {
     let expectation = self.expectation(description: "the exposure detection call returns an error")
     let exposureManager = defaultExposureManager(enAPIVersion: .v1, forceGetExposureInfoError: true)
@@ -822,7 +822,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 5)
   }
-
+  
   func testExposureSummaryScoringMatchedKey0() {
     let enExposureSummary = MockENExposureDetectionSummary()
     enExposureSummary.matchedKeyCountHandler = {
@@ -830,7 +830,7 @@ class ExposureManagerTests: XCTestCase {
     }
     XCTAssertFalse(enExposureSummary.isAboveScoreThreshold(with: ExposureConfigurationV1.placeholder))
   }
-
+  
   func testExposureSummaryScoringMatchedKey1() {
     let enExposureSummary = MockENExposureDetectionSummary()
     enExposureSummary.matchedKeyCountHandler = {
@@ -858,7 +858,7 @@ class ExposureManagerTests: XCTestCase {
     }
     XCTAssertFalse(enExposureSummary.isAboveScoreThreshold(with: configuration))
   }
-
+  
   func testExposureSummaryScoringMatchedKey3() {
     let enExposureSummary = MockENExposureDetectionSummary()
     enExposureSummary.matchedKeyCountHandler = {
@@ -874,7 +874,7 @@ class ExposureManagerTests: XCTestCase {
     }
     XCTAssertTrue(enExposureSummary.isAboveScoreThreshold(with: configuration))
   }
-
+  
   func testExposureSummaryScoringMatchedKey4() {
     let enExposureSummary = MockENExposureDetectionSummary()
     enExposureSummary.matchedKeyCountHandler = {
@@ -890,7 +890,7 @@ class ExposureManagerTests: XCTestCase {
     }
     XCTAssertTrue(enExposureSummary.isAboveScoreThreshold(with: configuration))
   }
-
+  
   func testDetectExposuresSuccessScoreBelow() {
     let storeExposureExpectation = self.expectation(description: "The exposure does not get stored")
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -904,7 +904,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [storeExposureExpectation], timeout:1)
   }
-
+  
   func testDetectExposuresSuccessScoreAbove() {
     let expectation = self.expectation(description: "1 exposure is detected")
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -918,7 +918,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 5)
   }
-
+  
   func testRegisterBackgroundTask() {
     let registerExpectation = self.expectation(description: "A background task with the given identifier is registered")
     let bgSchedulerMock = BGTaskSchedulerMock()
@@ -930,7 +930,7 @@ class ExposureManagerTests: XCTestCase {
     exposureManager.registerBackgroundTask()
     wait(for: [registerExpectation], timeout: 0)
   }
-
+  
   func testSubmitBackgroundTask() {
     let mockEnManager = ENManagerMock()
     mockEnManager.authorizationStatusHandler = {
@@ -946,7 +946,7 @@ class ExposureManagerTests: XCTestCase {
     exposureManager.scheduleBackgroundTaskIfNeeded()
     wait(for: [submitExpectation], timeout: 0)
   }
-
+  
   func testGetExposureConfigurationV1FallbackToDefault() {
     let expectation = self.expectation(description: "it falls back to the placeholder exposure configuration")
     let exposureManager = defaultExposureManager(enAPIVersion: .v1, forceDownloadConfigurationError: true)
@@ -959,9 +959,9 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 5)
   }
-
+  
   // MARK: == DETECTION EXPOSURE V2 TESTS ==
-
+  
   @available(iOS 13.7, *)
   func testDetectExposuresV2AggregateDetectError() {
     let expectation = self.expectation(description: "the exposure detection call returns an error")
@@ -977,60 +977,60 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [expectation], timeout: 5)
   }
-
+  
   @available(iOS 13.7, *)
   func testUpdateLastExposureDetectionDateV2() {
     let expectation = self.expectation(description: "lastExposureCheckDate is updated")
-
+    
     let exposureManager = defaultExposureManager(enAPIVersion: .v2)
-
+    
     XCTAssertNil(exposureManager.btSecureStorage.lastExposureCheckDate)
-
+    
     exposureManager.detectExposuresV2 { _ in
       XCTAssertNotNil(exposureManager.btSecureStorage.lastExposureCheckDate)
       expectation.fulfill()
     }
     wait(for: [expectation], timeout: 5)
   }
-
+  
   @available(iOS 13.7, *)
   func testDetectExposuresSuccessPreexistingSavedExposureForDate() {
     let storeExposureExpectation = self.expectation(description: "The exposure does not get stored")
-
+    
     let userState = UserState()
     userState.exposures.append(Exposure(id: "3",
                                         date: halloween.posixRepresentation))
-
+    
     let exposureManager = defaultExposureManager(enAPIVersion: .v2, userState: userState)
-
+    
     (exposureManager.btSecureStorage as! BTSecureStorageMock).storeExposuresHandler = { exposures in
       XCTAssertEqual(exposures.count, 0)
       storeExposureExpectation.fulfill()
     }
-
+    
     exposureManager.detectExposuresV2 { _ in }
-
+    
     wait(for: [storeExposureExpectation], timeout: 5)
   }
-
+  
   @available(iOS 13.7, *)
   func testDetectExposuresSuccessNoPreexistingSavedExposureForDate() {
     let storeExposureExpectation = self.expectation(description: "The exposure is stored")
     let userState = UserState()
     userState.exposures.append(Exposure(id: "3",
                                         date: Date().posixRepresentation))
-
+    
     let exposureManager = defaultExposureManager(enAPIVersion: .v2, userState: userState)
     (exposureManager.btSecureStorage as! BTSecureStorageMock).storeExposuresHandler = { exposures in
       XCTAssertEqual(exposures.count, 1)
       storeExposureExpectation.fulfill()
     }
-
+    
     exposureManager.detectExposuresV2 { _ in }
-
+    
     wait(for: [storeExposureExpectation], timeout: 5)
   }
-
+  
   @available(iOS 13.7, *)
   func testValidDailySummariesConfiguration() {
     let dict: [String: Any] = ["DailySummariesConfig": ["attenuationDurationThresholds": [40,53,60],
@@ -1061,7 +1061,7 @@ class ExposureManagerTests: XCTestCase {
     let config = DailySummariesConfiguration.create(from: jsonData)!
     XCTAssertEqual(config.daysSinceOnsetToInfectiousness[NSNumber(value: ENDaysSinceOnsetOfSymptomsUnknown)], 1)
   }
-
+  
   @available(iOS 13.7, *)
   func testDetectExposuresV2SuccessScoreBelow() {
     let storeExposureExpectation = self.expectation(description: "The exposure does not gets stored")
@@ -1077,7 +1077,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [storeExposureExpectation], timeout: 5)
   }
-
+  
   @available(iOS 13.7, *)
   func testDetectExposuresV2SuccessScoreAbove() {
     let storeExposureExpectation = self.expectation(description: "The exposure gets stored")
@@ -1093,7 +1093,7 @@ class ExposureManagerTests: XCTestCase {
     }
     wait(for: [storeExposureExpectation], timeout: 5)
   }
-
+  
   @available(iOS 13.7, *)
   func testGetExposureConfigurationV2FallbackToDefault() {
     let apiClientMock = APIClientMock { (request, requestType) -> (AnyObject) in


### PR DESCRIPTION
#### Why:
We'd like the iOS unit tests to be as readable and maintainable as possible

#### This commit:
This commit removes duplicate setup code where possible from existing unit tests, and consolidates what is reusable in an extension on `ExposureManagerUnitTests`