### PR TITLE
(iOS) Open Settings App Url from Main Thread

### DIFF
--- a/ios/BT/bridge/UtilsModule.swift
+++ b/ios/BT/bridge/UtilsModule.swift
@@ -4,6 +4,8 @@ import Foundation
 class UtilsModule: NSObject {
   @objc func openAppSettings() -> Void {
     let appSettingsUrl = URL(string: UIApplication.openSettingsURLString)!
-    UIApplication.shared.open(appSettingsUrl, options: [:], completionHandler: nil)
+    DispatchQueue.main.async {
+      UIApplication.shared.open(appSettingsUrl, options: [:], completionHandler: nil)
+    }
   }
 }


### PR DESCRIPTION
#### Why:
Per Apple's documentation, `open(...` should be called from the main thread (https://developer.apple.com/documentation/uikit/uiapplication/1648685-open)

#### This commit:
This commit adjusts the invocation to run on the main thread