### PR TITLE
Affected User Flow Navigation Bar Updates

### DIFF
--- a/src/SelfAssessment/Guidance.spec.tsx
+++ b/src/SelfAssessment/Guidance.spec.tsx
@@ -1,11 +1,14 @@
 import React from "react"
-import { render } from "@testing-library/react-native"
+import { useNavigation } from "@react-navigation/native"
+import { fireEvent, render } from "@testing-library/react-native"
+
 import { SelfAssessmentContext } from "../SelfAssessmentContext"
 import Guidance from "./Guidance"
 import { factories } from "../factories"
 import { SymptomGroup } from "./selfAssessment"
 
 jest.mock("@react-navigation/native")
+;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 
 describe("Guidance", () => {
   it("displays the appropriate heading for primary 1 symptoms", () => {
@@ -65,6 +68,22 @@ describe("Guidance", () => {
 
     expect(queryByText(/Good to hear you’re feeling fine./)).not.toBeNull()
     expect(queryByText(/Your symptoms may be related to COVID-19/)).toBeNull()
+  })
+
+  it("allows the user to navigate back to the exposure history screen", () => {
+    const navigateSpy = jest.fn()
+    ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+    const context = factories.selfAssessmentContext.build({
+      symptomGroup: SymptomGroup.ASYMPTOMATIC,
+    })
+    const { getByLabelText } = render(
+      <SelfAssessmentContext.Provider value={context}>
+        <Guidance />
+      </SelfAssessmentContext.Provider>,
+    )
+
+    fireEvent.press(getByLabelText("Done"))
+    expect(navigateSpy).toHaveBeenCalledWith("ExposureHistoryFlow")
   })
 
   describe("displaying instructions", () => {

--- a/src/SelfAssessment/Guidance.tsx
+++ b/src/SelfAssessment/Guidance.tsx
@@ -183,6 +183,8 @@ const Guidance: FunctionComponent<GuidanceProps> = ({
     }
   }
 
+  const displayFindATestCenter = Boolean(findATestCenterUrl)
+
   const handleOnPressFindTestCenter = () => {
     if (findATestCenterUrl) {
       Linking.openURL(findATestCenterUrl)
@@ -208,13 +210,15 @@ const Guidance: FunctionComponent<GuidanceProps> = ({
       <View style={style.bulletListContainer}>
         {instructionsForSymptomGroup(symptomGroup)}
       </View>
-      <Button
-        label={t("self_assessment.guidance.find_a_test_center_nearby")}
-        onPress={handleOnPressFindTestCenter}
-        customButtonStyle={style.button}
-        customButtonInnerStyle={style.buttonInner}
-        hasRightArrow
-      />
+      {displayFindATestCenter && (
+        <Button
+          label={t("self_assessment.guidance.find_a_test_center_nearby")}
+          onPress={handleOnPressFindTestCenter}
+          customButtonStyle={style.button}
+          customButtonInnerStyle={style.buttonInner}
+          hasRightArrow
+        />
+      )}
       <Button
         onPress={handleOnPressDone}
         label={t("common.done")}

--- a/src/SelfAssessment/Guidance.tsx
+++ b/src/SelfAssessment/Guidance.tsx
@@ -9,8 +9,9 @@ import { useConfigurationContext } from "../ConfigurationContext"
 import { SymptomGroup } from "./selfAssessment"
 import { Stack, Stacks } from "../navigation"
 
-import { Outlines, Colors, Spacing, Typography } from "../styles"
+import { Buttons, Outlines, Colors, Spacing, Typography } from "../styles"
 import { Images } from "../assets"
+import { TouchableOpacity } from "react-native-gesture-handler"
 
 interface GuidanceProps {
   destinationOnCancel?: Stack
@@ -183,8 +184,6 @@ const Guidance: FunctionComponent<GuidanceProps> = ({
     }
   }
 
-  const displayFindATestCenter = Boolean(findATestCenterUrl)
-
   const handleOnPressFindTestCenter = () => {
     if (findATestCenterUrl) {
       Linking.openURL(findATestCenterUrl)
@@ -210,22 +209,21 @@ const Guidance: FunctionComponent<GuidanceProps> = ({
       <View style={style.bulletListContainer}>
         {instructionsForSymptomGroup(symptomGroup)}
       </View>
-      {displayFindATestCenter ? (
-        <Button
-          label={t("self_assessment.guidance.find_a_test_center_nearby")}
-          onPress={handleOnPressFindTestCenter}
-          customButtonStyle={style.button}
-          customButtonInnerStyle={style.buttonInner}
-          hasRightArrow
-        />
-      ) : (
-        <Button
-          onPress={handleOnPressDone}
-          label={t("common.done")}
-          customButtonStyle={style.button}
-          customButtonInnerStyle={style.buttonInner}
-        />
-      )}
+      <Button
+        label={t("self_assessment.guidance.find_a_test_center_nearby")}
+        onPress={handleOnPressFindTestCenter}
+        customButtonStyle={style.button}
+        customButtonInnerStyle={style.buttonInner}
+        hasRightArrow
+      />
+      <Button
+        onPress={handleOnPressDone}
+        label={t("common.done")}
+        customButtonStyle={style.doneButton}
+        customButtonInnerStyle={style.doneButtonInner}
+        customTextStyle={style.doneButtonText}
+        outlined
+      />
     </ScrollView>
   )
 }
@@ -299,6 +297,20 @@ const style = StyleSheet.create({
   },
   buttonInner: {
     width: "100%",
+  },
+  doneButton: {
+    marginTop: Spacing.large,
+    marginBottom: Spacing.small,
+    alignSelf: "center",
+    borderColor: Colors.secondary100,
+  },
+  doneButtonText: {
+    ...Typography.buttonPrimary,
+    color: Colors.primary110,
+  },
+  doneButtonInner: {
+    ...Buttons.tinyRounded,
+    backgroundColor: Colors.white,
   },
 })
 

--- a/src/SelfAssessment/Guidance.tsx
+++ b/src/SelfAssessment/Guidance.tsx
@@ -11,7 +11,6 @@ import { Stack, Stacks } from "../navigation"
 
 import { Buttons, Outlines, Colors, Spacing, Typography } from "../styles"
 import { Images } from "../assets"
-import { TouchableOpacity } from "react-native-gesture-handler"
 
 interface GuidanceProps {
   destinationOnCancel?: Stack

--- a/src/navigation/SelfAssessmentStack.tsx
+++ b/src/navigation/SelfAssessmentStack.tsx
@@ -1,13 +1,9 @@
 import React, { FunctionComponent } from "react"
-import { StyleSheet, TouchableOpacity, View } from "react-native"
-import { useNavigation } from "@react-navigation/native"
-import { useTranslation } from "react-i18next"
 import {
   createStackNavigator,
   HeaderStyleInterpolators,
   StackNavigationOptions,
 } from "@react-navigation/stack"
-import { SvgXml } from "react-native-svg"
 
 import { SelfAssessmentProvider } from "../SelfAssessmentContext"
 import { SelfAssessmentStackScreens, Stack as AllStacks } from "./index"
@@ -22,33 +18,9 @@ import AgeRangeQuestion from "../SelfAssessment/AgeRangeQuestion"
 import Guidance from "../SelfAssessment/Guidance"
 import { applyHeaderLeftBackButton } from "./HeaderLeftBackButton"
 
-import { Icons } from "../assets"
-import { Headers, Colors, Iconography, Spacing } from "../styles"
+import { Headers } from "../styles"
 
 const Stack = createStackNavigator()
-
-const backButton = () => <BackButton />
-const BackButton = () => {
-  const { t } = useTranslation()
-  const navigation = useNavigation()
-
-  return (
-    <TouchableOpacity
-      onPress={navigation.goBack}
-      accessible
-      accessibilityLabel={t("export.code_input_button_back")}
-    >
-      <View style={style.navigationButton}>
-        <SvgXml
-          xml={Icons.ArrowLeft}
-          fill={Colors.black}
-          width={Iconography.xxSmall}
-          height={Iconography.xxSmall}
-        />
-      </View>
-    </TouchableOpacity>
-  )
-}
 
 type SelfAssessmentStackProps = {
   destinationOnCancel: AllStacks
@@ -57,39 +29,15 @@ type SelfAssessmentStackProps = {
 const SelfAssessmentStack: FunctionComponent<SelfAssessmentStackProps> = ({
   destinationOnCancel,
 }) => {
-  const cancelButton = () => (
-    <CancelButton destinationOnCancel={destinationOnCancel} />
-  )
-  const CancelButton: FunctionComponent<SelfAssessmentStackProps> = ({
-    destinationOnCancel,
-  }) => {
-    const { t } = useTranslation()
-    const navigation = useNavigation()
-
-    return (
-      <TouchableOpacity
-        onPress={() => navigation.navigate(destinationOnCancel)}
-        accessible
-        accessibilityLabel={t("export.code_input_button_cancel")}
-      >
-        <View style={style.navigationButton}>
-          <SvgXml
-            xml={Icons.X}
-            fill={Colors.black}
-            width={Iconography.xxSmall}
-            height={Iconography.xxSmall}
-          />
-        </View>
-      </TouchableOpacity>
-    )
+  const navigationBarOptions: StackNavigationOptions = {
+    headerShown: false,
+    headerStyleInterpolator: HeaderStyleInterpolators.forNoAnimation,
   }
 
-  const navigationBarOptions: StackNavigationOptions = {
-    title: "",
-    headerStyle: { backgroundColor: Colors.primaryLightBackground },
-    headerLeft: backButton,
-    headerRight: cancelButton,
-    headerStyleInterpolator: HeaderStyleInterpolators.forNoAnimation,
+  const defaultScreenOptions = {
+    ...Headers.headerMinimalOptions,
+    headerLeft: applyHeaderLeftBackButton(),
+    headerRight: () => null,
   }
 
   return (
@@ -98,35 +46,37 @@ const SelfAssessmentStack: FunctionComponent<SelfAssessmentStackProps> = ({
         <Stack.Screen
           name={SelfAssessmentStackScreens.SelfAssessmentIntro}
           component={SelfAssessmentIntro}
-          options={{
-            ...Headers.headerMinimalOptions,
-            headerLeft: applyHeaderLeftBackButton(),
-            headerRight: () => null,
-          }}
+          options={defaultScreenOptions}
         />
         <Stack.Screen
           name={SelfAssessmentStackScreens.EmergencySymptomsQuestions}
           component={EmergencySymptomsQuestions}
+          options={defaultScreenOptions}
         />
         <Stack.Screen
           name={SelfAssessmentStackScreens.HowAreYouFeeling}
           component={HowAreYouFeeling}
+          options={defaultScreenOptions}
         />
         <Stack.Screen
           name={SelfAssessmentStackScreens.CallEmergencyServices}
           component={CallEmergencyServices}
+          options={defaultScreenOptions}
         />
         <Stack.Screen
           name={SelfAssessmentStackScreens.GeneralSymptoms}
           component={GeneralSymptoms}
+          options={defaultScreenOptions}
         />
         <Stack.Screen
           name={SelfAssessmentStackScreens.UnderlyingConditions}
           component={UnderlyingConditions}
+          options={defaultScreenOptions}
         />
         <Stack.Screen
           name={SelfAssessmentStackScreens.AgeRange}
           component={AgeRangeQuestion}
+          options={defaultScreenOptions}
         />
         <Stack.Screen name={SelfAssessmentStackScreens.Guidance}>
           {(props) => {
@@ -139,11 +89,5 @@ const SelfAssessmentStack: FunctionComponent<SelfAssessmentStackProps> = ({
     </SelfAssessmentProvider>
   )
 }
-
-const style = StyleSheet.create({
-  navigationButton: {
-    padding: Spacing.medium,
-  },
-})
 
 export default SelfAssessmentStack


### PR DESCRIPTION
#### Why:
We'd like our navigation bar conventions to be consistent across the app

#### This commit:
This commit swaps out the preexisting navbar (custom back button, `x` icon), with the navbar used elsewhere in the app (system back button), and adds a `Done` button to the "Guidance" screen so that the user can return to the exposure history screen once they have completed the affected user flow.

![Oct-13-2020 21-51-21](https://user-images.githubusercontent.com/2637355/95934661-67f4f500-0d9f-11eb-8873-ab2284ead0ea.gif)
