### PR TITLE
Remove placeholder date for callback form

### DIFF
--- a/src/Callback/Form.tsx
+++ b/src/Callback/Form.tsx
@@ -56,13 +56,12 @@ const CallbackForm: FunctionComponent = () => {
     setIsLoading(true)
     setErrorMessage(defaultErrorMessage)
 
-    const fakeExposureDate = "2020-01-01"
     try {
       const response = await API.postCallbackInfo({
         firstname,
         lastname,
         phoneNumber,
-        exposureDate: fakeExposureDate,
+        exposureDate: null,
       })
 
       if (response.kind === "success") {

--- a/src/Callback/callbackAPI.tsx
+++ b/src/Callback/callbackAPI.tsx
@@ -29,14 +29,14 @@ interface CallbackInfo {
   firstname: string
   lastname: string
   phoneNumber: string
-  exposureDate: string
+  exposureDate: string | null
 }
 
 export const postCallbackInfo = async ({
   firstname,
   lastname,
   phoneNumber,
-  exposureDate = "2020-06-16",
+  exposureDate,
 }: CallbackInfo): Promise<NetworkResponse<PostCallbackInfoError>> => {
   const postOAuth = async () => {
     const oauthBody = `grant_type=password&client_id=${callbackClientId}&client_secret=${callbackClientSecret}&username=${callbackUsername}&password=${callbackPassword}`


### PR DESCRIPTION
Why:
Currently we have a placeholder date for the data payload for the
callback form api. While the endpoint accepts this date, it is not clear
what date should be used and we are going to send nothing as opposed to
the placeholder date.

This commit:
Removes the placeholder date and sends a null value to the backend for
the api.

Co-Authored-By: devin jameson <devin@thoughtbot.com>