### PR TITLE
Fix how it works nav issue

### DIFF
--- a/src/navigation/HowItWorksStack.tsx
+++ b/src/navigation/HowItWorksStack.tsx
@@ -57,11 +57,11 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
   const handleOnNavigateOutOfStack = () => {
     switch (mountLocation) {
       case "Onboarding": {
-        navigation.goBack()
+        navigation.navigate(Stacks.Activation)
         break
       }
       case "Settings": {
-        navigation.navigate(Stacks.Activation)
+        navigation.goBack()
         break
       }
     }


### PR DESCRIPTION
Why: we had accidentally swapped the logic for navigating out of the
HowItWorks stack for the Settings and Onboarding mount locations.