### PR TITLE
Exposure Detection Success/Failure Message

### DIFF
--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -72,7 +72,7 @@ describe("History", () => {
         await waitFor(() => {
           expect(showMessageSpy).toHaveBeenCalledWith(
             expect.objectContaining({
-              message: "Successfully checked for exposures",
+              message: "Success",
             }),
           )
         })
@@ -100,7 +100,7 @@ describe("History", () => {
         await waitFor(() => {
           expect(showMessageSpy).toHaveBeenCalledWith(
             expect.objectContaining({
-              message: "There was a problem checking for exposures",
+              message: "Something went wrong",
             }),
           )
         })

--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -1,14 +1,17 @@
 import React from "react"
 import { fireEvent, render, waitFor } from "@testing-library/react-native"
+import { showMessage } from "react-native-flash-message"
 import { useNavigation } from "@react-navigation/native"
 
 import { ExposureDatum } from "../../exposure"
 import { DateTimeUtils } from "../../utils"
 import { factories } from "../../factories"
 import { ExposureContext } from "../../ExposureContext"
+import { failureResponse, SUCCESS_RESPONSE } from "../../OperationResponse"
 
 import History from "./index"
 
+jest.mock("react-native-flash-message")
 jest.mock("@react-navigation/native")
 ;(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() })
 
@@ -28,7 +31,9 @@ describe("History", () => {
   describe("when the refresh button is tapped", () => {
     it("checks for new exposures", async () => {
       const exposures: ExposureDatum[] = []
-      const checkForNewExposuresSpy = jest.fn()
+      const checkForNewExposuresSpy = jest
+        .fn()
+        .mockResolvedValueOnce(SUCCESS_RESPONSE)
 
       const { getByLabelText } = render(
         <ExposureContext.Provider
@@ -44,6 +49,61 @@ describe("History", () => {
 
       await waitFor(() => {
         expect(checkForNewExposuresSpy).toHaveBeenCalled()
+      })
+    })
+
+    describe("when exposure check is successful", () => {
+      it("displays a success message", async () => {
+        const checkForNewExposuresSpy = jest.fn()
+        const showMessageSpy = showMessage as jest.Mock
+
+        const { getByLabelText } = render(
+          <ExposureContext.Provider
+            value={factories.exposureContext.build({
+              checkForNewExposures: checkForNewExposuresSpy,
+            })}
+          >
+            <History exposures={[]} lastDetectionDate={null} />
+          </ExposureContext.Provider>,
+        )
+
+        fireEvent.press(getByLabelText("Check for exposures"))
+
+        await waitFor(() => {
+          expect(showMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: "Successfully checked for exposures",
+            }),
+          )
+        })
+      })
+    })
+
+    describe("when exposure check is not successful", () => {
+      it("displays a failure message", async () => {
+        const checkForNewExposuresSpy = jest.fn()
+        checkForNewExposuresSpy.mockResolvedValueOnce(failureResponse)
+        const showMessageSpy = showMessage as jest.Mock
+
+        const { getByLabelText } = render(
+          <ExposureContext.Provider
+            value={factories.exposureContext.build({
+              checkForNewExposures: checkForNewExposuresSpy,
+            })}
+          >
+            <History exposures={[]} lastDetectionDate={null} />
+          </ExposureContext.Provider>,
+        )
+
+        fireEvent.press(getByLabelText("Check for exposures"))
+
+        await waitFor(() => {
+          expect(showMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: "There was a problem checking for exposures",
+            }),
+          )
+        })
       })
     })
   })

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -55,12 +55,12 @@ const History: FunctionComponent<HistoryProps> = ({
     const checkResult = await checkForNewExposures()
     if (checkResult.kind === "success") {
       showMessage({
-        message: t("exposure_history.check_successful"),
+        message: t("common.success"),
         ...Affordances.successFlashMessageOptions,
       })
     } else {
       showMessage({
-        message: t("exposure_history.check_error"),
+        message: t("common.something_went_wrong"),
         ...Affordances.errorFlashMessageOptions,
       })
     }

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -15,7 +15,15 @@ import NoExposures from "./NoExposures"
 
 import { Icons } from "../../assets"
 import { ExposureHistoryStackScreens } from "../../navigation"
-import { Buttons, Spacing, Typography, Colors, Outlines } from "../../styles"
+import {
+  Buttons,
+  Spacing,
+  Typography,
+  Colors,
+  Outlines,
+  Affordances,
+} from "../../styles"
+import { showMessage } from "react-native-flash-message"
 
 type Posix = number
 
@@ -44,7 +52,18 @@ const History: FunctionComponent<HistoryProps> = ({
 
   const handleOnPressCheckForExposures = async () => {
     setCheckingForExposures(true)
-    await checkForNewExposures()
+    const checkResult = await checkForNewExposures()
+    if (checkResult.kind === "success") {
+      showMessage({
+        message: t("exposure_history.check_successful"),
+        ...Affordances.successFlashMessageOptions,
+      })
+    } else {
+      showMessage({
+        message: t("exposure_history.check_error"),
+        ...Affordances.errorFlashMessageOptions,
+      })
+    }
     setCheckingForExposures(false)
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -92,6 +92,8 @@
   },
   "exposure_history": {
     "check_for_exposures": "Check for exposures",
+    "check_successful": "Successfully checked for exposures",
+    "check_error": "There was a problem checking for exposures",
     "exposure_detail": {
       "2m_apart": "2m apart",
       "6ft_apart": "6ft apart",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,7 +32,8 @@
     "skip": "Skip",
     "something_went_wrong": "Something went wrong",
     "start": "Start",
-    "submit": "Submit"
+    "submit": "Submit",
+    "success": "Success"
   },
   "covid_data": {
     "cases_today": "Cases today",
@@ -92,8 +93,6 @@
   },
   "exposure_history": {
     "check_for_exposures": "Check for exposures",
-    "check_successful": "Successfully checked for exposures",
-    "check_error": "There was a problem checking for exposures",
     "exposure_detail": {
       "2m_apart": "2m apart",
       "6ft_apart": "6ft apart",


### PR DESCRIPTION
#### Why:
Currently, when a user taps the `Check for exposures` button on the exposure history screen it updates the `Last updated at` info only.  This is quite subtle and its not always clear to users that the check for exposures happened successfully.  We would like to find a way to indicate to the user whether the check was successful or not, even if there where no new exposures found.

#### This commit:
This commit implements a toast/flash message indicating to the user whether the most recent exposure check was successful or not

![Oct-15-2020 10-11-37](https://user-images.githubusercontent.com/2637355/96141673-3d09be80-0ecf-11eb-8d2c-5d7c1e5af1cf.gif)
