### PR TITLE
Update check for exposures button style

### DIFF
--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -57,7 +57,7 @@ describe("History", () => {
         const checkForNewExposuresSpy = jest.fn()
         const showMessageSpy = showMessage as jest.Mock
 
-        const { getByLabelText } = render(
+        const { getByTestId } = render(
           <ExposureContext.Provider
             value={factories.exposureContext.build({
               checkForNewExposures: checkForNewExposuresSpy,
@@ -67,7 +67,7 @@ describe("History", () => {
           </ExposureContext.Provider>,
         )
 
-        fireEvent.press(getByLabelText("Check for exposures"))
+        fireEvent.press(getByTestId("check-for-exposures-button"))
 
         await waitFor(() => {
           expect(showMessageSpy).toHaveBeenCalledWith(
@@ -85,7 +85,7 @@ describe("History", () => {
         checkForNewExposuresSpy.mockResolvedValueOnce(failureResponse)
         const showMessageSpy = showMessage as jest.Mock
 
-        const { getByLabelText } = render(
+        const { getByTestId } = render(
           <ExposureContext.Provider
             value={factories.exposureContext.build({
               checkForNewExposures: checkForNewExposuresSpy,
@@ -95,7 +95,7 @@ describe("History", () => {
           </ExposureContext.Provider>,
         )
 
-        fireEvent.press(getByLabelText("Check for exposures"))
+        fireEvent.press(getByTestId("check-for-exposures-button"))
 
         await waitFor(() => {
           expect(showMessageSpy).toHaveBeenCalledWith(

--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -35,7 +35,7 @@ describe("History", () => {
         .fn()
         .mockResolvedValueOnce(SUCCESS_RESPONSE)
 
-      const { getByLabelText } = render(
+      const { getByTestId } = render(
         <ExposureContext.Provider
           value={factories.exposureContext.build({
             checkForNewExposures: checkForNewExposuresSpy,
@@ -45,7 +45,7 @@ describe("History", () => {
         </ExposureContext.Provider>,
       )
 
-      fireEvent.press(getByLabelText("Check for exposures"))
+      fireEvent.press(getByTestId("check-for-exposures-button"))
 
       await waitFor(() => {
         expect(checkForNewExposuresSpy).toHaveBeenCalled()

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, TouchableOpacity, View, ScrollView } from "react-native"
 import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
 import { useNavigation, useIsFocused } from "@react-navigation/native"
+import { showMessage } from "react-native-flash-message"
 
 import { ExposureDatum } from "../../exposure"
 import { LoadingIndicator, StatusBar, Text } from "../../components"
@@ -15,15 +16,7 @@ import NoExposures from "./NoExposures"
 
 import { Icons } from "../../assets"
 import { ExposureHistoryStackScreens } from "../../navigation"
-import {
-  Buttons,
-  Spacing,
-  Typography,
-  Colors,
-  Outlines,
-  Affordances,
-} from "../../styles"
-import { showMessage } from "react-native-flash-message"
+import { Buttons, Spacing, Typography, Colors, Affordances } from "../../styles"
 
 type Posix = number
 
@@ -109,6 +102,7 @@ const History: FunctionComponent<HistoryProps> = ({
       <TouchableOpacity
         onPress={handleOnPressCheckForExposures}
         style={style.button}
+        testID="check-for-exposures-button"
       >
         <Text style={style.buttonText}>
           {t("exposure_history.check_for_exposures")}

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigation, useIsFocused } from "@react-navigation/native"
 
 import { ExposureDatum } from "../../exposure"
-import { StatusBar, Text, Button } from "../../components"
+import { LoadingIndicator, StatusBar, Text } from "../../components"
 import { useStatusBarEffect } from "../../navigation/index"
 import { useExposureContext } from "../../ExposureContext"
 
@@ -106,15 +106,15 @@ const History: FunctionComponent<HistoryProps> = ({
           )}
         </View>
       </ScrollView>
-      <View style={style.bottomActionsContainer}>
-        <Button
-          label={t("exposure_history.check_for_exposures")}
-          onPress={handleOnPressCheckForExposures}
-          loading={checkingForExposures}
-          customButtonStyle={style.button}
-          customButtonInnerStyle={style.buttonInner}
-        />
-      </View>
+      <TouchableOpacity
+        onPress={handleOnPressCheckForExposures}
+        style={style.button}
+      >
+        <Text style={style.buttonText}>
+          {t("exposure_history.check_for_exposures")}
+        </Text>
+      </TouchableOpacity>
+      {checkingForExposures && <LoadingIndicator />}
     </>
   )
 }
@@ -156,21 +156,11 @@ const style = StyleSheet.create({
     marginTop: Spacing.xxLarge,
     marginBottom: Spacing.large,
   },
-  bottomActionsContainer: {
-    alignItems: "center",
-    borderTopWidth: Outlines.hairline,
-    borderColor: Colors.neutral10,
-    backgroundColor: Colors.secondary10,
-    paddingTop: Spacing.small,
-    paddingBottom: Spacing.medium,
-    paddingHorizontal: Spacing.medium,
-  },
   button: {
-    width: "100%",
+    ...Buttons.fixedBottom,
   },
-  buttonInner: {
-    ...Buttons.medium,
-    width: "100%",
+  buttonText: {
+    ...Typography.buttonFixedBottom,
   },
 })
 

--- a/src/SymptomHistory/SelectSymptoms.tsx
+++ b/src/SymptomHistory/SelectSymptoms.tsx
@@ -17,7 +17,14 @@ import { showMessage } from "react-native-flash-message"
 import { posixToDayjs } from "../utils/dateTime"
 import Checkbox from "./Checkbox"
 
-import { Affordances, Colors, Outlines, Spacing, Typography } from "../styles"
+import {
+  Affordances,
+  Buttons,
+  Colors,
+  Outlines,
+  Spacing,
+  Typography,
+} from "../styles"
 import { SymptomHistoryStackParams } from "../navigation/SymptomHistoryStack"
 
 const SelectSymptomsScreen: FunctionComponent = () => {
@@ -158,14 +165,10 @@ const style = StyleSheet.create({
     borderColor: Colors.neutral50,
   },
   button: {
-    alignItems: "center",
-    paddingTop: Spacing.medium,
-    paddingBottom: Spacing.medium,
-    backgroundColor: Colors.primary100,
+    ...Buttons.fixedBottom,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
-    fontSize: Typography.large,
+    ...Typography.buttonFixedBottom,
   },
 })
 

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,0 +1,37 @@
+import React, { FunctionComponent } from "react"
+import { ActivityIndicator, StyleSheet, View } from "react-native"
+
+import { Colors, Layout, Outlines } from "../styles"
+
+const LoadingIndicator: FunctionComponent = () => {
+  return (
+    <View style={style.activityIndicatorContainer}>
+      <ActivityIndicator
+        size={"large"}
+        color={Colors.neutral100}
+        style={style.activityIndicator}
+        testID={"loading-indicator"}
+      />
+    </View>
+  )
+}
+
+const indicatorWidth = 120
+const style = StyleSheet.create({
+  activityIndicatorContainer: {
+    position: "absolute",
+    left: Layout.halfWidth,
+    top: Layout.halfHeight,
+    marginLeft: -(indicatorWidth / 2),
+    marginTop: -(indicatorWidth / 2),
+    zIndex: Layout.zLevel2,
+  },
+  activityIndicator: {
+    width: indicatorWidth,
+    height: indicatorWidth,
+    backgroundColor: Colors.transparentNeutral30,
+    borderRadius: Outlines.baseBorderRadius,
+  },
+})
+
+export default LoadingIndicator

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,15 @@ import Text from "./Text"
 import StatusBar from "./StatusBar"
 import ListItem from "./ListItem"
 import ListItemSeparator from "./ListItemSeparator"
+import LoadingIndicator from "./LoadingIndicator"
 import SwitchListItem from "./SwitchListItem"
 
-export { Text, Button, StatusBar, ListItem, ListItemSeparator, SwitchListItem }
+export {
+  Text,
+  Button,
+  StatusBar,
+  ListItem,
+  ListItemSeparator,
+  LoadingIndicator,
+  SwitchListItem,
+}

--- a/src/configuration/copy.json
+++ b/src/configuration/copy.json
@@ -7,8 +7,5 @@
   },
   "legal": {
     "en": ""
-  },
-  "callback_success": {
-    "en": ""
   }
 }

--- a/src/configuration/copy.json
+++ b/src/configuration/copy.json
@@ -7,5 +7,8 @@
   },
   "legal": {
     "en": ""
+  },
+  "callback_success": {
+    "en": ""
   }
 }

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -64,3 +64,11 @@ export const tinyRounded: ViewStyle = {
   ...maxCornerRoundness,
   ...tertiaryBlue,
 }
+
+export const fixedBottom: ViewStyle = {
+  ...base,
+  paddingTop: Spacing.medium,
+  paddingBottom: Spacing.medium,
+  backgroundColor: Colors.primary100,
+  width: "100%",
+}

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -198,6 +198,11 @@ export const buttonPrimaryDisabled: TextStyle = {
   color: Colors.neutral140,
 }
 
+export const buttonFixedBottom: TextStyle = {
+  ...buttonPrimary,
+  fontSize: large,
+}
+
 export const buttonSecondary: TextStyle = {
   ...body1,
   ...semiBold,


### PR DESCRIPTION
Why: we would like to have a consistent button style for buttons that are fixed to the bottom of the screen. Currently the check for exposures button on the exposure history screen uses a different style than the save button on the the select symptoms screen.

This commit:
- Updates the exposure history screen to use the same button style as the select symptoms screen
- Abstracts the button styling to `Buttons` and `Typography` style modules
- Creates a `LoadingIndicator` component that can easily be applied to any screen
- Uses the new `LoadingIndicator` component to show the loading state when checking for new exposures

![gif2](https://user-images.githubusercontent.com/39350030/96294097-d31a1380-0fb9-11eb-975f-a9f713e707ad.gif)