### PR TITLE
Update symptom entry interface names

### DIFF
--- a/src/SymptomHistory/SelectSymptoms.spec.tsx
+++ b/src/SymptomHistory/SelectSymptoms.spec.tsx
@@ -24,7 +24,7 @@ describe("SelectSymptomsForm", () => {
       const date = Date.now()
       const entry: SymptomEntry = {
         id: testId,
-        kind: "Symptoms",
+        kind: "UserInput",
         symptoms: new Set<Symptom>(["cough"]),
         date,
       }
@@ -53,7 +53,7 @@ describe("SelectSymptomsForm", () => {
       updateEntrySpy.mockResolvedValueOnce({ kind: "failure" })
       const entry: SymptomEntry = {
         id: "1",
-        kind: "Symptoms",
+        kind: "UserInput",
         symptoms: new Set(["cough"]),
         date: Date.now(),
       }

--- a/src/SymptomHistory/SelectSymptoms.tsx
+++ b/src/SymptomHistory/SelectSymptoms.tsx
@@ -26,7 +26,7 @@ const SelectSymptomsScreen: FunctionComponent = () => {
   >()
 
   const entry = route.params?.symptomEntry || {
-    kind: "NoData",
+    kind: "NoUserInput",
     date: Date.now(),
   }
 
@@ -47,7 +47,7 @@ export const SelectSymptomsForm: FunctionComponent<SelectSymptomsFormProps> = ({
   const { updateEntry } = useSymptomHistoryContext()
 
   const initialSelectedSymptoms =
-    entry.kind === "Symptoms" ? entry.symptoms : new Set<Symptom.Symptom>()
+    entry.kind === "UserInput" ? entry.symptoms : new Set<Symptom.Symptom>()
 
   const [selectedSymptoms, setSelectedSymptoms] = useState<
     Set<Symptom.Symptom>
@@ -88,7 +88,7 @@ export const SelectSymptomsForm: FunctionComponent<SelectSymptomsFormProps> = ({
     })
   }
 
-  const hasNoSymptomsSelected = selectedSymptoms.size === 0
+  const hasNoUserInputSelected = selectedSymptoms.size === 0
 
   const dayJsDate = posixToDayjs(entry.date)
   const dateText = dayJsDate?.local().format("MMMM D, YYYY")
@@ -106,7 +106,7 @@ export const SelectSymptomsForm: FunctionComponent<SelectSymptomsFormProps> = ({
               key={"no_symptoms"}
               label={t("symptom_history.no_symptoms")}
               onPress={handleOnPressNoSymptoms}
-              checked={hasNoSymptomsSelected}
+              checked={hasNoUserInputSelected}
             />
           </View>
           {Symptom.all.map((symptom: Symptom.Symptom) => {

--- a/src/SymptomHistory/SymptomEntryListItem.spec.tsx
+++ b/src/SymptomHistory/SymptomEntryListItem.spec.tsx
@@ -10,11 +10,11 @@ import { SymptomHistoryStackScreens } from "../navigation"
 jest.mock("@react-navigation/native")
 
 describe("SymptomEntryListItem", () => {
-  describe("when the entry is of kind NoData", () => {
+  describe("when the entry is of kind NoUserInput", () => {
     it("indicates to the user that no entry has been made", () => {
       const date = Date.parse("2020-1-1")
       const entry: SymptomEntry = {
-        kind: "NoData",
+        kind: "NoUserInput",
         date,
       }
       const { getByText } = render(<SymptomEntryListItem entry={entry} />)
@@ -23,13 +23,13 @@ describe("SymptomEntryListItem", () => {
     })
   })
 
-  describe("when the entry is of kind Symptoms", () => {
+  describe("when the entry is of kind UserInput", () => {
     describe("when the entry has no symptoms", () => {
       it("indicates to the user that they had no symptoms that day", () => {
         const date = Date.parse("2020-1-1")
         const entry: SymptomEntry = {
           id: "asdf",
-          kind: "Symptoms",
+          kind: "UserInput",
           date,
           symptoms: new Set<Symptom>(),
         }
@@ -44,7 +44,7 @@ describe("SymptomEntryListItem", () => {
         const date = Date.parse("2020-1-1")
         const entry: SymptomEntry = {
           id: "asdf",
-          kind: "Symptoms",
+          kind: "UserInput",
           date,
           symptoms: new Set<Symptom>(["cough", "fever"]),
         }
@@ -64,7 +64,7 @@ describe("SymptomEntryListItem", () => {
       })
       const date = Date.parse("2020-1-1")
       const symptomEntry: SymptomEntry = {
-        kind: "NoData",
+        kind: "NoUserInput",
         date,
       }
 

--- a/src/SymptomHistory/SymptomEntryListItem.tsx
+++ b/src/SymptomHistory/SymptomEntryListItem.tsx
@@ -50,10 +50,10 @@ const SymptomEntryListItem: FunctionComponent<SymptomEntryListItemProps> = ({
 
   const determineCardContent = (entry: SymptomEntry) => {
     switch (entry.kind) {
-      case "NoData": {
+      case "NoUserInput": {
         return <Text>{t("symptom_history.no_data")}</Text>
       }
-      case "Symptoms": {
+      case "UserInput": {
         if (entry.symptoms.size > 0) {
           return [...entry.symptoms].map(toSymptomText)
         } else {

--- a/src/SymptomHistory/SymptomHistoryContext.spec.tsx
+++ b/src/SymptomHistory/SymptomHistoryContext.spec.tsx
@@ -8,7 +8,7 @@ import {
 } from "./SymptomHistoryContext"
 import * as NativeModule from "./nativeModule"
 import { Symptom } from "./symptom"
-import { NoData, Symptoms } from "./symptomHistory"
+import { NoUserInput, UserInput } from "./symptomHistory"
 import Logger from "../logger"
 
 jest.mock("./nativeModule.ts")
@@ -23,12 +23,12 @@ describe("SymptomHistoryProvider", () => {
         createEntrySpy.mockResolvedValueOnce({})
         const date = Date.parse("2020-09-22 10:00")
         const symptoms = new Set<Symptom>(["cough"])
-        const entry: NoData = {
-          kind: "NoData",
+        const entry: NoUserInput = {
+          kind: "NoUserInput",
           date,
         }
 
-        const AddCheckLogSymptoms = () => {
+        const AddCheckLogUserInput = () => {
           const { updateEntry } = useSymptomHistoryContext()
 
           return (
@@ -43,7 +43,7 @@ describe("SymptomHistoryProvider", () => {
 
         const { getByLabelText } = render(
           <SymptomHistoryProvider>
-            <AddCheckLogSymptoms />
+            <AddCheckLogUserInput />
           </SymptomHistoryProvider>,
         )
 
@@ -63,14 +63,14 @@ describe("SymptomHistoryProvider", () => {
 
         const symptoms = new Set<Symptom>(["cough"])
         const testId = "asdf-asdf-asdf-asdf"
-        const entry: Symptoms = {
+        const entry: UserInput = {
           id: testId,
-          kind: "Symptoms",
+          kind: "UserInput",
           date,
           symptoms,
         }
 
-        const AddCheckLogSymptoms = () => {
+        const AddCheckLogUserInput = () => {
           const { updateEntry } = useSymptomHistoryContext()
 
           return (
@@ -85,7 +85,7 @@ describe("SymptomHistoryProvider", () => {
 
         const { getByLabelText } = render(
           <SymptomHistoryProvider>
-            <AddCheckLogSymptoms />
+            <AddCheckLogUserInput />
           </SymptomHistoryProvider>,
         )
 
@@ -113,7 +113,7 @@ describe("SymptomHistoryProvider", () => {
           const { updateEntry } = useSymptomHistoryContext()
 
           const date = Date.now()
-          const entry: NoData = { kind: "NoData", date }
+          const entry: NoUserInput = { kind: "NoUserInput", date }
 
           return (
             <TouchableOpacity

--- a/src/SymptomHistory/SymptomHistoryContext.tsx
+++ b/src/SymptomHistory/SymptomHistoryContext.tsx
@@ -29,7 +29,7 @@ export type SymptomHistoryState = {
 }
 const initialState: SymptomHistoryState = {
   symptomHistory: [],
-  updateEntry: (_entry: SymptomEntry, _newSymptoms: Set<Symptom>) => {
+  updateEntry: (_entry: SymptomEntry, _newUserInput: Set<Symptom>) => {
     return Promise.resolve(SUCCESS_RESPONSE)
   },
   deleteAllEntries: () => {
@@ -68,7 +68,7 @@ export const SymptomHistoryProvider: FunctionComponent = ({ children }) => {
     newSymptoms: Set<Symptom>,
   ) => {
     try {
-      if (entry.kind === "Symptoms") {
+      if (entry.kind === "UserInput") {
         await NativeModule.updateEntry(entry.id, entry.date, newSymptoms)
         await fetchEntries()
         return SUCCESS_RESPONSE

--- a/src/SymptomHistory/index.spec.tsx
+++ b/src/SymptomHistory/index.spec.tsx
@@ -18,18 +18,18 @@ describe("SymptomHistory", () => {
       const twoDaysAgo = Date.parse("2020-1-1")
       const history: SymptomHistory = [
         {
-          kind: "NoData",
+          kind: "NoUserInput",
           date: today,
         },
         {
           id: "a",
-          kind: "Symptoms",
+          kind: "UserInput",
           date: oneDayAgo,
           symptoms: new Set<Symptom>(),
         },
         {
           id: "b",
-          kind: "Symptoms",
+          kind: "UserInput",
           date: twoDaysAgo,
           symptoms: new Set<Symptom>(["cough"]),
         },

--- a/src/SymptomHistory/symptomHistory.spec.ts
+++ b/src/SymptomHistory/symptomHistory.spec.ts
@@ -17,20 +17,20 @@ describe("toSymptomHistory", () => {
       const result = toSymptomHistory(today, rawEntries)
 
       const expected: SymptomHistory = [
-        { kind: "NoData", date: today },
-        { kind: "NoData", date: daysAgoFrom(1, today) },
-        { kind: "NoData", date: daysAgoFrom(2, today) },
-        { kind: "NoData", date: daysAgoFrom(3, today) },
-        { kind: "NoData", date: daysAgoFrom(4, today) },
-        { kind: "NoData", date: daysAgoFrom(5, today) },
-        { kind: "NoData", date: daysAgoFrom(6, today) },
-        { kind: "NoData", date: daysAgoFrom(7, today) },
-        { kind: "NoData", date: daysAgoFrom(8, today) },
-        { kind: "NoData", date: daysAgoFrom(9, today) },
-        { kind: "NoData", date: daysAgoFrom(10, today) },
-        { kind: "NoData", date: daysAgoFrom(11, today) },
-        { kind: "NoData", date: daysAgoFrom(12, today) },
-        { kind: "NoData", date: daysAgoFrom(13, today) },
+        { kind: "NoUserInput", date: today },
+        { kind: "NoUserInput", date: daysAgoFrom(1, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(2, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(3, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(4, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(5, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(6, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(7, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(8, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(9, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(10, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(11, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(12, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(13, today) },
       ]
       expect(result).toEqual(expected)
     })
@@ -48,29 +48,29 @@ describe("toSymptomHistory", () => {
 
       const expected: SymptomHistory = [
         {
-          kind: "Symptoms",
+          kind: "UserInput",
           id: "a",
           date: today,
           symptoms: new Set<Symptom>(["cough"]),
         },
-        { kind: "NoData", date: daysAgoFrom(1, today) },
-        { kind: "NoData", date: daysAgoFrom(2, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(1, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(2, today) },
         {
-          kind: "Symptoms",
+          kind: "UserInput",
           id: "b",
           date: daysAgoFrom(3, today),
           symptoms: new Set<Symptom>(),
         },
-        { kind: "NoData", date: daysAgoFrom(4, today) },
-        { kind: "NoData", date: daysAgoFrom(5, today) },
-        { kind: "NoData", date: daysAgoFrom(6, today) },
-        { kind: "NoData", date: daysAgoFrom(7, today) },
-        { kind: "NoData", date: daysAgoFrom(8, today) },
-        { kind: "NoData", date: daysAgoFrom(9, today) },
-        { kind: "NoData", date: daysAgoFrom(10, today) },
-        { kind: "NoData", date: daysAgoFrom(11, today) },
-        { kind: "NoData", date: daysAgoFrom(12, today) },
-        { kind: "NoData", date: daysAgoFrom(13, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(4, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(5, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(6, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(7, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(8, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(9, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(10, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(11, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(12, today) },
+        { kind: "NoUserInput", date: daysAgoFrom(13, today) },
       ]
       expect(result).toEqual(expected)
     })
@@ -87,7 +87,7 @@ describe("toSymptomHistory", () => {
       const result = toSymptomHistory(today, rawEntries)
 
       const expected: SymptomEntry = {
-        kind: "Symptoms",
+        kind: "UserInput",
         id: "b",
         date: today,
         symptoms: new Set<Symptom>(["cough", "fever", "chills"]),
@@ -101,7 +101,7 @@ describe("toSymptomHistory", () => {
 const entryIsEqual = (entryA: SymptomEntry, entryB: SymptomEntry): boolean => {
   if (entryA.kind !== entryB.kind || entryA.date !== entryB.date) {
     return false
-  } else if (entryA.kind === "Symptoms" && entryB.kind === "Symptoms") {
+  } else if (entryA.kind === "UserInput" && entryB.kind === "UserInput") {
     return (
       entryA.id === entryB.id && setIsEqual(entryA.symptoms, entryB.symptoms)
     )

--- a/src/SymptomHistory/symptomHistory.ts
+++ b/src/SymptomHistory/symptomHistory.ts
@@ -3,19 +3,19 @@ import { Posix, isSameDay } from "../utils/dateTime"
 
 import * as Symptom from "./symptom"
 
-export interface NoData {
-  kind: "NoData"
+export interface NoUserInput {
+  kind: "NoUserInput"
   date: Posix
 }
 
-export interface Symptoms {
+export interface UserInput {
   id: string
-  kind: "Symptoms"
+  kind: "UserInput"
   date: Posix
   symptoms: Set<Symptom.Symptom>
 }
 
-export type SymptomEntry = NoData | Symptoms
+export type SymptomEntry = NoUserInput | UserInput
 
 export type SymptomHistory = SymptomEntry[]
 
@@ -64,7 +64,7 @@ const toEntry = (rawEntry: RawEntry): SymptomEntry => {
   }
 
   return {
-    kind: "Symptoms",
+    kind: "UserInput",
     id,
     date,
     symptoms: toSymptomSet(rawSymptoms),
@@ -100,21 +100,21 @@ const combineEntries = (
 ): SymptomEntry => {
   const entries = `${entryA.kind} ${entryB.kind}`
   switch (entries) {
-    case "NoData NoData": {
+    case "NoUserInput NoUserInput": {
       return entryA
     }
-    case "NoData Symptoms": {
+    case "NoUserInput UserInput": {
       return entryB
     }
-    case "Symptoms NoData": {
+    case "UserInput NoUserInput": {
       return entryA
     }
-    case "Symptoms Symptoms": {
-      const a = entryA as Symptoms
-      const b = entryB as Symptoms
+    case "UserInput UserInput": {
+      const a = entryA as UserInput
+      const b = entryB as UserInput
       return {
         id: a.id,
-        kind: "Symptoms",
+        kind: "UserInput",
         date: a.date,
         symptoms: union(a.symptoms, b.symptoms),
       }
@@ -126,16 +126,16 @@ const combineEntries = (
 }
 
 const blankHistory = (today: Posix, totalDays: number): SymptomHistory => {
-  const daysAgo = [...Array(totalDays)]
-    .map((_v, idx: number) => {
-      return totalDays - 1 - idx
-    })
-    .reverse()
+  const range = (length: number) => {
+    return [...Array(length)].map((_v, idx: number) => idx)
+  }
+
+  const daysAgo = range(totalDays)
 
   return daysAgo.map(
     (daysAgo: number): SymptomEntry => {
       return {
-        kind: "NoData",
+        kind: "NoUserInput",
         date: dayjs(today).subtract(daysAgo, "day").startOf("day").valueOf(),
       }
     },


### PR DESCRIPTION
Why:
Currently we have the type `SymptomEntry = NoData | Symptoms`, we would
like to change this to `type SymptomEntry = NoUserData | UserData` as
this is better indication of what the type is modeling

Co-Authored-By: Devin Jameson <devin@thoughtbot.com>