### PR TITLE
Stop sending date argument on the callback form

### DIFF
--- a/src/Callback/Form.tsx
+++ b/src/Callback/Form.tsx
@@ -61,7 +61,6 @@ const CallbackForm: FunctionComponent = () => {
         firstname,
         lastname,
         phoneNumber,
-        exposureDate: null,
       })
 
       if (response.kind === "success") {

--- a/src/Callback/callbackAPI.spec.tsx
+++ b/src/Callback/callbackAPI.spec.tsx
@@ -16,14 +16,12 @@ describe("postCallbackInfo", () => {
       const firstname = "firstname"
       const lastname = "lastname"
       const phoneNumber = "phoneNumber"
-      const exposureDate = "2020-09-16"
       const body = `grant_type=password&client_id=CALLBACK_CLIENT_ID&client_secret=CALLBACK_CLIENT_SECRET&username=CALLBACK_USERNAME&password=CALLBACK_PASSWORD`
 
       const result = await postCallbackInfo({
         firstname,
         lastname,
         phoneNumber,
-        exposureDate,
       })
 
       expect(fetchSpy).toHaveBeenCalledWith("CALLBACK_OAUTH_URL", {
@@ -41,7 +39,6 @@ describe("postCallbackInfo", () => {
           LA_First_Name__c: firstname,
           LA_Last_Name__c: lastname,
           LA_Mobile_Phone__c: phoneNumber,
-          LA_Exposure_Date__c: exposureDate,
         }),
       })
       expect(result).toEqual({ kind: "success" })
@@ -65,7 +62,6 @@ describe("postCallbackInfo", () => {
           firstname: "firstname",
           lastname: "lastname",
           phoneNumber: "phoneNumber",
-          exposureDate: "exposureDate",
         })
 
         expect(result).toEqual({ kind: "failure", error: "Unknown" })
@@ -90,7 +86,6 @@ describe("postCallbackInfo", () => {
           firstname: "firstname",
           lastname: "lastname",
           phoneNumber: "phoneNumber",
-          exposureDate: "exposureDate",
         })
 
         expect(result).toEqual({
@@ -115,7 +110,6 @@ describe("postCallbackInfo", () => {
         firstname: "firstname",
         lastname: "lastname",
         phoneNumber: "phoneNumber",
-        exposureDate: "exposureDate",
       })
 
       expect(result).toEqual({ kind: "failure", error: "AuthorizationFailed" })
@@ -133,7 +127,6 @@ describe("postCallbackInfo", () => {
         firstname: "firstname",
         lastname: "lastname",
         phoneNumber: "phoneNumber",
-        exposureDate: "exposureDate",
       })
 
       expect(result).toEqual({

--- a/src/Callback/callbackAPI.tsx
+++ b/src/Callback/callbackAPI.tsx
@@ -29,14 +29,12 @@ interface CallbackInfo {
   firstname: string
   lastname: string
   phoneNumber: string
-  exposureDate: string | null
 }
 
 export const postCallbackInfo = async ({
   firstname,
   lastname,
   phoneNumber,
-  exposureDate,
 }: CallbackInfo): Promise<NetworkResponse<PostCallbackInfoError>> => {
   const postOAuth = async () => {
     const oauthBody = `grant_type=password&client_id=${callbackClientId}&client_secret=${callbackClientSecret}&username=${callbackUsername}&password=${callbackPassword}`
@@ -52,7 +50,6 @@ export const postCallbackInfo = async ({
     LA_First_Name__c: firstname,
     LA_Last_Name__c: lastname,
     LA_Mobile_Phone__c: phoneNumber,
-    LA_Exposure_Date__c: exposureDate,
   }
 
   try {


### PR DESCRIPTION
Why:
----

The Callback api is receiving an optional date argument that it is being sent as null on the request and it is not being consumed on the API side. We need to stop sending it while we get the correct value for us to send.

This Commit:
----

- Remove the `exposureDate` argument from the request that goes out to the callback form api endpoint.
