### PR TITLE
Handle empty exposure keys error publishing keys

### DIFF
--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -133,40 +133,90 @@ describe("PublishConsentForm", () => {
   })
 
   describe("on a no-op key submission", () => {
-    it("displays a message explaining the cause to the user", async () => {
-      const navigateSpy = jest.fn()
-      ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
-      const newKeysInserted = 1
-      const noOpPostResponse = {
-        kind: "no-op" as const,
-        reason: ExposureAPI.PostKeysNoOpReason.NoTokenForExistingKeys,
-        newKeysInserted,
-        message: "no_token_for_existing_keys",
-      }
-      const postDiagnosisKeysSpy = jest.spyOn(ExposureAPI, "postDiagnosisKeys")
-      postDiagnosisKeysSpy.mockResolvedValueOnce(noOpPostResponse)
-      const alertSpy = jest.spyOn(Alert, "alert")
-
-      const { getByLabelText } = render(
-        <PublishConsentForm
-          hmacKey="hmacKey"
-          certificate="certificate"
-          exposureKeys={[]}
-          storeRevisionToken={jest.fn()}
-          revisionToken=""
-          appPackageName=""
-          regionCodes={[""]}
-        />,
-      )
-
-      fireEvent.press(getByLabelText("I Understand and Consent"))
-
-      await waitFor(() => {
-        expect(alertSpy).toHaveBeenCalledWith(
-          "Attempt to submit existing keys",
-          `Existing data was sent to the server. This usually means that this process was attempted previously from this device, but on a different application. You can communicate this to the authority that provided the verification code that was used. There were ${newKeysInserted} new keys added.`,
-          [{ onPress: expect.any(Function) }],
+    describe("when the error is related to the revision token", () => {
+      it("displays a message explaining the cause to the user", async () => {
+        const navigateSpy = jest.fn()
+        ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+        const newKeysInserted = 1
+        const noOpPostResponse = {
+          kind: "no-op" as const,
+          reason: ExposureAPI.PostKeysNoOpReason.NoTokenForExistingKeys,
+          newKeysInserted,
+          message: "no_token_for_existing_keys",
+        }
+        const postDiagnosisKeysSpy = jest.spyOn(
+          ExposureAPI,
+          "postDiagnosisKeys",
         )
+        postDiagnosisKeysSpy.mockResolvedValueOnce(noOpPostResponse)
+        const alertSpy = jest.spyOn(Alert, "alert")
+
+        const { getByLabelText } = render(
+          <PublishConsentForm
+            hmacKey="hmacKey"
+            certificate="certificate"
+            exposureKeys={[]}
+            storeRevisionToken={jest.fn()}
+            revisionToken=""
+            appPackageName=""
+            regionCodes={[""]}
+          />,
+        )
+
+        fireEvent.press(getByLabelText("I Understand and Consent"))
+
+        await waitFor(() => {
+          expect(
+            alertSpy,
+          ).toHaveBeenCalledWith(
+            "Attempt to submit existing keys",
+            `Existing data was sent to the server. This usually means that this process was attempted previously from this device, but on a different application. You can communicate this to the authority that provided the verification code that was used. There were ${newKeysInserted} new keys added.`,
+            [{ onPress: expect.any(Function) }],
+          )
+        })
+      })
+    })
+
+    describe("when the error is related to an empty exposure history", () => {
+      it("displays a message explaining the cause to the user", async () => {
+        const navigateSpy = jest.fn()
+        ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
+        const noOpPostResponse = {
+          kind: "no-op" as const,
+          reason: ExposureAPI.PostKeysNoOpReason.EmptyExposureKeys,
+          newKeysInserted: 0,
+          message: "message",
+        }
+        const postDiagnosisKeysSpy = jest.spyOn(
+          ExposureAPI,
+          "postDiagnosisKeys",
+        )
+        postDiagnosisKeysSpy.mockResolvedValueOnce(noOpPostResponse)
+        const alertSpy = jest.spyOn(Alert, "alert")
+
+        const { getByLabelText } = render(
+          <PublishConsentForm
+            hmacKey="hmacKey"
+            certificate="certificate"
+            exposureKeys={[]}
+            storeRevisionToken={jest.fn()}
+            revisionToken=""
+            appPackageName=""
+            regionCodes={[""]}
+          />,
+        )
+
+        fireEvent.press(getByLabelText("I Understand and Consent"))
+
+        await waitFor(() => {
+          expect(
+            alertSpy,
+          ).toHaveBeenCalledWith(
+            "No encounter logging data is available",
+            "It looks like you have no encounter logs on your device, please wait 24 hours to proceed if you recently reset your data. You may need to request a new verification code.",
+            [{ onPress: expect.any(Function) }],
+          )
+        })
       })
     })
   })

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -34,6 +34,7 @@ import {
   PostKeysError,
   PostKeysNoOp,
   PostKeysFailure,
+  PostKeysNoOpReason,
 } from "../exposureNotificationAPI"
 
 interface PublishConsentFormProps {
@@ -73,20 +74,41 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
     Logger.error(
       `IncompleteKeySumbission.${noOpResponse.reason}.${noOpResponse.message}`,
     )
-    Alert.alert(
-      t("export.publish_keys.no_op.title"),
-      t("export.publish_keys.no_op.no_token_for_existing_keys", {
-        newKeysInserted,
-      }),
-      [
-        {
-          onPress: () =>
-            navigation.navigate(
-              AffectedUserFlowStackScreens.AffectedUserComplete,
-            ),
-        },
-      ],
-    )
+
+    const { alertTitle, alertMessage } = noOpAlertContent(noOpResponse)
+
+    Alert.alert(alertTitle, alertMessage, [
+      {
+        onPress: () =>
+          navigation.navigate(
+            AffectedUserFlowStackScreens.AffectedUserComplete,
+          ),
+      },
+    ])
+  }
+
+  const noOpAlertContent = ({ reason, newKeysInserted }: PostKeysNoOp) => {
+    switch (reason) {
+      case PostKeysNoOpReason.NoTokenForExistingKeys: {
+        return {
+          alertTitle: t(
+            "export.publish_keys.no_op.no_token_for_existing_keys_title",
+          ),
+          alertMessage: t(
+            "export.publish_keys.no_op.no_token_for_existing_keys",
+            {
+              newKeysInserted,
+            },
+          ),
+        }
+      }
+      case PostKeysNoOpReason.EmptyExposureKeys: {
+        return {
+          alertTitle: t("export.publish_keys.no_op.empty_exposure_keys_title"),
+          alertMessage: t("export.publish_keys.no_op.empty_exposure_keys"),
+        }
+      }
+    }
   }
 
   const errorMessageTitle = (errorNature: PostKeysError) => {

--- a/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
@@ -112,6 +112,37 @@ describe("postDiagnosisKeys", () => {
         message,
       })
     })
+
+    it("returns a no-op EmptyExposureKeys response if the error corresponds", async () => {
+      const newKeysInserted = 0
+      const message =
+        "unable to validate diagnosis verification: calculating expect HMAC: cannont calculate hmac on empty exposure keys"
+      const jsonResponse = {
+        error: message,
+        insertedExposures: newKeysInserted,
+      }
+
+      ;(fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        json: jest.fn().mockResolvedValueOnce(jsonResponse),
+      })
+
+      const result = await postDiagnosisKeys(
+        [],
+        [],
+        "certificate",
+        "hmacKey",
+        "appPackageName",
+        "revisionToken",
+      )
+
+      expect(result).toEqual({
+        kind: "no-op",
+        reason: PostKeysNoOpReason.EmptyExposureKeys,
+        newKeysInserted,
+        message,
+      })
+    })
   })
 
   describe("on a retry response", () => {

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -41,6 +41,7 @@ export type PostKeysSuccess = {
 
 export enum PostKeysNoOpReason {
   NoTokenForExistingKeys = "NoTokenForExistingKeys",
+  EmptyExposureKeys = "EmptyExposureKeys",
 }
 
 export type PostKeysNoOp = {
@@ -73,6 +74,8 @@ class PostDiagnosisKeysRequest {
   private static MAX_RETRIES = 3
   private static RETRY_STATUS_CODES = [429, 503]
   private static INTERNAL_ERROR = "internal_error"
+  private static EMPTY_EXPOSURE_KEYS =
+    "unable to validate diagnosis verification: calculating expect HMAC: cannont calculate hmac on empty exposure keys"
   private static EXISTING_KEYS_SENT_RESPONSE =
     "no revision token, but sent existing keys"
   private static TIMEOUT = 5000
@@ -141,6 +144,14 @@ class PostDiagnosisKeysRequest {
           kind: "no-op" as const,
           reason: PostKeysNoOpReason.NoTokenForExistingKeys,
           newKeysInserted: insertedExposures || 0,
+          message: error,
+        }
+      }
+      case PostDiagnosisKeysRequest.EMPTY_EXPOSURE_KEYS: {
+        return {
+          kind: "no-op" as const,
+          reason: PostKeysNoOpReason.EmptyExposureKeys,
+          newKeysInserted: 0,
           message: error,
         }
       }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -86,8 +86,10 @@
         "unknown": "Failed to submit the exposure data"
       },
       "no_op": {
+        "empty_exposure_keys_title": "No encounter logging data is available",
+        "empty_exposure_keys": "It looks like you have no encounter logs on your device, please wait 24 hours to proceed if you recently reset your data. You may need to request a new verification code.",
         "no_token_for_existing_keys": "Existing data was sent to the server. This usually means that this process was attempted previously from this device, but on a different application. You can communicate this to the authority that provided the verification code that was used. There were {{newKeysInserted}} new keys added.",
-        "title": "Attempt to submit existing keys"
+        "no_token_for_existing_keys_title": "Attempt to submit existing keys"
       }
     },
     "start_header_bluetooth": "Help contain the spread of the virus and protect others in your community"


### PR DESCRIPTION
Why:
----

In the event a user tries to publish their keys on a fresh device, the server will return an error since there can not be an hmac calculated on an empty set of exposure keys.

This Commit:
----

- Add a no-op error handling for the error message of an empty set of exposure keys