### PR TITLE
Allow verification codes of 6 to 16 alphanumeric chars

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
@@ -191,15 +191,20 @@ describe("CodeInputForm", () => {
     })
 
     it("informs of a formatting error", async () => {
-      const { getByTestId, getByLabelText, getByText } = render(
+      const { getByTestId, getByLabelText, getByText, queryByText } = render(
         <AffectedUserProvider>
           <CodeInputForm />
         </AffectedUserProvider>,
       )
-      fireEvent.changeText(getByTestId("code-input"), "1234-678")
+      fireEvent.changeText(getByTestId("code-input"), "$A12345")
 
       expect(getByLabelText("Next")).toBeDisabled()
       expect(getByText("Invalid format")).toBeDefined()
+
+      fireEvent.changeText(getByTestId("code-input"), "A1234578")
+
+      expect(getByLabelText("Next")).toBeEnabled()
+      expect(queryByText("Invalid format")).toBeNull()
     })
   })
 })

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
@@ -198,13 +198,16 @@ describe("CodeInputForm", () => {
       )
       fireEvent.changeText(getByTestId("code-input"), "$A12345")
 
-      expect(getByLabelText("Next")).toBeDisabled()
-      expect(getByText("Invalid format")).toBeDefined()
+      const nextButton = getByLabelText("Next")
+      const errorMessageText = "Codes may only contain numbers and letters"
+
+      expect(nextButton).toBeDisabled()
+      expect(getByText(errorMessageText)).toBeDefined()
 
       fireEvent.changeText(getByTestId("code-input"), "A1234578")
 
-      expect(getByLabelText("Next")).toBeEnabled()
-      expect(queryByText("Invalid format")).toBeNull()
+      expect(nextButton).toBeEnabled()
+      expect(queryByText(errorMessageText)).toBeNull()
     })
   })
 })

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -59,9 +59,10 @@ const CodeInputForm: FunctionComponent = () => {
 
   const handleOnChangeText = (newCode: string) => {
     setCode(newCode)
-    setErrorMessage("")
     if (newCode && codeContainsNonAlphanumericChars(newCode)) {
       setErrorMessage(t("export.error.invalid_format"))
+    } else {
+      setErrorMessage("")
     }
   }
 

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -48,13 +48,16 @@ const CodeInputForm: FunctionComponent = () => {
   const [errorMessage, setErrorMessage] = useState(defaultErrorMessage)
   const [isFocused, setIsFocused] = useState(false)
 
-  const codeLength = 8
-  const codeIsInvalidLength = code.length !== codeLength
-  const codeContainsNonDigitChars = (code: string) => !code.match(/^\d+$/)
+  const codeLengthMin = 6
+  const codeLengthMax = 16
+  const codeIsInvalidLength =
+    code.length < codeLengthMin || code.length > codeLengthMax
+  const codeContainsNonAlphanumericChars = (code: string) =>
+    !code.match(/^[a-zA-Z0-9]*$/)
 
   const handleOnChangeText = (newCode: string) => {
     setErrorMessage("")
-    if (newCode && codeContainsNonDigitChars(newCode)) {
+    if (newCode && codeContainsNonAlphanumericChars(newCode)) {
       setErrorMessage(t("export.error.invalid_format"))
     } else {
       setCode(newCode)
@@ -147,7 +150,8 @@ const CodeInputForm: FunctionComponent = () => {
     }
   }
 
-  const isDisabled = codeIsInvalidLength || codeContainsNonDigitChars(code)
+  const isDisabled =
+    codeIsInvalidLength || codeContainsNonAlphanumericChars(code)
 
   const codeInputFocusedStyle = isFocused && { ...style.codeInputFocused }
   const codeInputStyle = { ...style.codeInput, ...codeInputFocusedStyle }
@@ -174,7 +178,7 @@ const CodeInputForm: FunctionComponent = () => {
             value={code}
             placeholder="00000000"
             placeholderTextColor={Colors.placeholderText}
-            maxLength={codeLength}
+            maxLength={codeLengthMax}
             style={codeInputStyle}
             keyboardType="number-pad"
             returnKeyType="done"

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -8,6 +8,7 @@ import {
   Keyboard,
   ScrollView,
   KeyboardAvoidingView,
+  Platform,
 } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
@@ -157,10 +158,16 @@ const CodeInputForm: FunctionComponent = () => {
   const codeInputFocusedStyle = isFocused && { ...style.codeInputFocused }
   const codeInputStyle = { ...style.codeInput, ...codeInputFocusedStyle }
 
+  const keyboardAvoidingViewBehavior = Platform.select({
+    ios: "position" as const,
+    android: "height" as const,
+    default: "position" as const,
+  })
+
   return (
     <KeyboardAvoidingView
       contentContainerStyle={style.outerContentContainer}
-      behavior="position"
+      behavior={keyboardAvoidingViewBehavior}
     >
       <ScrollView
         contentContainerStyle={style.contentContainer}

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -58,11 +58,10 @@ const CodeInputForm: FunctionComponent = () => {
     !code.match(/^[a-zA-Z0-9]*$/)
 
   const handleOnChangeText = (newCode: string) => {
+    setCode(newCode)
     setErrorMessage("")
     if (newCode && codeContainsNonAlphanumericChars(newCode)) {
       setErrorMessage(t("export.error.invalid_format"))
-    } else {
-      setCode(newCode)
     }
   }
 
@@ -190,7 +189,6 @@ const CodeInputForm: FunctionComponent = () => {
           placeholderTextColor={Colors.placeholderText}
           maxLength={codeLengthMax}
           style={codeInputStyle}
-          keyboardType="number-pad"
           returnKeyType="done"
           onChangeText={handleOnChangeText}
           onFocus={handleOnToggleFocus}
@@ -251,8 +249,9 @@ const style = StyleSheet.create({
   errorSubtitle: {
     ...Typography.error,
     color: Colors.errorText,
-    marginTop: Spacing.xSmall,
+    marginTop: Spacing.xxSmall,
     marginBottom: Spacing.small,
+    minHeight: Spacing.xxxHuge,
   },
   codeInput: {
     ...Forms.textInput,

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -7,11 +7,12 @@ import {
   View,
   Keyboard,
   ScrollView,
+  KeyboardAvoidingView,
 } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
-import { Text, Button, StatusBar } from "../../components"
+import { Text, Button } from "../../components"
 import { useAffectedUserContext } from "../AffectedUserContext"
 import * as API from "../verificationAPI"
 import { calculateHmac } from "../hmac"
@@ -157,11 +158,14 @@ const CodeInputForm: FunctionComponent = () => {
   const codeInputStyle = { ...style.codeInput, ...codeInputFocusedStyle }
 
   return (
-    <>
-      <StatusBar backgroundColor={Colors.primaryLightBackground} />
+    <KeyboardAvoidingView
+      contentContainerStyle={style.outerContentContainer}
+      behavior="position"
+    >
       <ScrollView
         contentContainerStyle={style.contentContainer}
         testID={"affected-user-code-input-form"}
+        alwaysBounceVertical={false}
       >
         <View style={style.headerContainer}>
           <Text style={style.header}>
@@ -172,23 +176,21 @@ const CodeInputForm: FunctionComponent = () => {
             {t("export.code_input_body_bluetooth")}
           </Text>
         </View>
-        <View>
-          <TextInput
-            testID="code-input"
-            value={code}
-            placeholder="00000000"
-            placeholderTextColor={Colors.placeholderText}
-            maxLength={codeLengthMax}
-            style={codeInputStyle}
-            keyboardType="number-pad"
-            returnKeyType="done"
-            onChangeText={handleOnChangeText}
-            onFocus={handleOnToggleFocus}
-            onBlur={handleOnToggleFocus}
-            onSubmitEditing={Keyboard.dismiss}
-            blurOnSubmit={false}
-          />
-        </View>
+        <TextInput
+          testID="code-input"
+          value={code}
+          placeholder={t("export.code_input_placeholder").toUpperCase()}
+          placeholderTextColor={Colors.placeholderText}
+          maxLength={codeLengthMax}
+          style={codeInputStyle}
+          keyboardType="number-pad"
+          returnKeyType="done"
+          onChangeText={handleOnChangeText}
+          onFocus={handleOnToggleFocus}
+          onBlur={handleOnToggleFocus}
+          onSubmitEditing={Keyboard.dismiss}
+          blurOnSubmit={false}
+        />
         <Text style={style.errorSubtitle}>{errorMessage}</Text>
         {isLoading ? <LoadingIndicator /> : null}
         <Button
@@ -199,7 +201,7 @@ const CodeInputForm: FunctionComponent = () => {
           hasRightArrow
         />
       </ScrollView>
-    </>
+    </KeyboardAvoidingView>
   )
 }
 
@@ -218,10 +220,16 @@ const LoadingIndicator = () => {
 
 const indicatorWidth = 120
 const style = StyleSheet.create({
+  outerContentContainer: {
+    minHeight: "100%",
+  },
   contentContainer: {
+    minHeight: "100%",
     backgroundColor: Colors.primaryLightBackground,
+    paddingTop: Spacing.large,
     paddingBottom: Spacing.xxxHuge,
     paddingHorizontal: Spacing.medium,
+    justifyContent: "center",
   },
   headerContainer: {
     marginBottom: Spacing.xxLarge,
@@ -245,7 +253,7 @@ const style = StyleSheet.create({
     fontSize: Typography.xLarge,
     textAlignVertical: "center",
     textAlign: "center",
-    letterSpacing: 8,
+    letterSpacing: 4,
     paddingTop: Spacing.small + 2,
   },
   codeInputFocused: {

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -17,11 +17,7 @@ const CodeInputScreen: FunctionComponent = () => {
 
   return (
     <View style={style.container}>
-      {isENEnabled || true ? (
-        <CodeInputForm />
-      ) : (
-        <EnableExposureNotifications />
-      )}
+      {isENEnabled ? <CodeInputForm /> : <EnableExposureNotifications />}
     </View>
   )
 }

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -17,7 +17,11 @@ const CodeInputScreen: FunctionComponent = () => {
 
   return (
     <View style={style.container}>
-      {isENEnabled ? <CodeInputForm /> : <EnableExposureNotifications />}
+      {isENEnabled || true ? (
+        <CodeInputForm />
+      ) : (
+        <EnableExposureNotifications />
+      )}
     </View>
   )
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -72,7 +72,7 @@
     "enable_exposure_notifications_title": "Enable exposure notifications to continue",
     "error": {
       "invalid_code": "Try a different code",
-      "invalid_format": "Invalid format",
+      "invalid_format": "Codes may only contain numbers and letters",
       "network_connection_error": "There is no internet connection",
       "unknown_code_verification_error": "Try a different code",
       "verification_code_used": "Verification code has already been used"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -59,6 +59,7 @@
     "code_input_button_back": "Back",
     "code_input_button_cancel": "Cancel",
     "code_input_title_bluetooth": "Verify your diagnosis",
+    "code_input_placeholder": "Enter Code",
     "complete_body_bluetooth": "You’re helping contain the spread of the virus and protect others in your community.",
     "complete_title": "Thanks for keeping your community safe!",
     "consent_body_0": "Sharing your positive diagnosis is optional and can only be done with your consent.",


### PR DESCRIPTION
Why:
----
As a user, I would like to be able to input a verification code on the report positive test result flow that is between 6 and 16 alphanumeric characters. Right now, the input only accepts exactly 8 digits.

This commit:
----
- Updates the code input to take a minimum of 6 and a maximum of 16 characters.
- Updates the code input to only accept alphanumeric characters and show an error message if non-alphanumeric characters are used
- Changes the keyboard type for the code input to be the default keyboard
- Fixes some accessibility issues with the code input screen so that the keyboard does not cover the input

Co-Authored-By: Alejandro Dustet <alejandro@thoughtbot.com>

![gif](https://user-images.githubusercontent.com/39350030/96635715-3f628300-12ea-11eb-8045-261f220f809c.gif)