### PR TITLE
Remove loading indicator from button component

### DIFF
--- a/__mocks__/@react-navigation/stack.ts
+++ b/__mocks__/@react-navigation/stack.ts
@@ -1,0 +1,3 @@
+export const useHeaderHeight = (): number => {
+  return 0
+}

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useState } from "react"
 import {
-  ActivityIndicator,
   Alert,
   StyleSheet,
   TextInput,
@@ -13,7 +12,7 @@ import {
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 
-import { Text, Button } from "../../components"
+import { Text, Button, LoadingIndicator } from "../../components"
 import { useAffectedUserContext } from "../AffectedUserContext"
 import * as API from "../verificationAPI"
 import { calculateHmac } from "../hmac"
@@ -23,14 +22,7 @@ import {
   AffectedUserFlowStackScreens,
 } from "../../navigation"
 
-import {
-  Spacing,
-  Layout,
-  Forms,
-  Colors,
-  Outlines,
-  Typography,
-} from "../../styles"
+import { Spacing, Forms, Colors, Typography } from "../../styles"
 import Logger from "../../logger"
 
 const defaultErrorMessage = ""
@@ -198,7 +190,6 @@ const CodeInputForm: FunctionComponent = () => {
           blurOnSubmit={false}
         />
         <Text style={style.errorSubtitle}>{errorMessage}</Text>
-        {isLoading ? <LoadingIndicator /> : null}
         <Button
           onPress={handleOnPressSubmit}
           label={t("common.next")}
@@ -207,24 +198,11 @@ const CodeInputForm: FunctionComponent = () => {
           hasRightArrow
         />
       </ScrollView>
+      {isLoading && <LoadingIndicator />}
     </KeyboardAvoidingView>
   )
 }
 
-const LoadingIndicator = () => {
-  return (
-    <View style={style.activityIndicatorContainer}>
-      <ActivityIndicator
-        size={"large"}
-        color={Colors.neutral100}
-        style={style.activityIndicator}
-        testID={"loading-indicator"}
-      />
-    </View>
-  )
-}
-
-const indicatorWidth = 120
 const style = StyleSheet.create({
   outerContentContainer: {
     minHeight: "100%",
@@ -268,20 +246,6 @@ const style = StyleSheet.create({
   },
   button: {
     alignSelf: "flex-start",
-  },
-  activityIndicatorContainer: {
-    position: "absolute",
-    left: Layout.halfWidth,
-    top: Layout.halfHeight,
-    marginLeft: -(indicatorWidth / 2),
-    marginTop: -(indicatorWidth / 2),
-    zIndex: Layout.zLevel2,
-  },
-  activityIndicator: {
-    width: indicatorWidth,
-    height: indicatorWidth,
-    backgroundColor: Colors.transparentNeutral30,
-    borderRadius: Outlines.baseBorderRadius,
   },
 })
 

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -12,7 +12,7 @@ import { useNavigation } from "@react-navigation/native"
 import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 
 import { ExposureKey } from "../../exposureKey"
-import { Text, Button } from "../../components"
+import { Text, Button, LoadingIndicator } from "../../components"
 import {
   useStatusBarEffect,
   AffectedUserFlowStackScreens,
@@ -230,7 +230,6 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
         </View>
 
         <Button
-          loading={isLoading}
           label={t("export.consent_button_title")}
           onPress={handleOnPressConfirm}
           customButtonStyle={style.button}
@@ -250,6 +249,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
           height={Iconography.xxxSmall}
         />
       </TouchableOpacity>
+      {isLoading && <LoadingIndicator />}
     </View>
   )
 }

--- a/src/Callback/Form.tsx
+++ b/src/Callback/Form.tsx
@@ -1,7 +1,6 @@
 import React, { useState, FunctionComponent } from "react"
 import { useTranslation } from "react-i18next"
 import {
-  ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
   StyleSheet,
@@ -15,11 +14,11 @@ import { useNavigation } from "@react-navigation/native"
 
 import { useStatusBarEffect, CallbackStackScreens } from "../navigation"
 import { useConfigurationContext } from "../ConfigurationContext"
-import { Button, Text } from "../components"
+import { Button, LoadingIndicator, Text } from "../components"
 import * as API from "./callbackAPI"
 import Logger from "../logger"
 
-import { Spacing, Layout, Forms, Colors, Outlines, Typography } from "../styles"
+import { Spacing, Forms, Colors, Typography } from "../styles"
 
 const defaultErrorMessage = " "
 
@@ -95,90 +94,78 @@ const CallbackForm: FunctionComponent = () => {
   }
 
   return (
-    <ScrollView
-      style={style.container}
-      contentContainerStyle={style.contentContainer}
-    >
-      <KeyboardAvoidingView
-        keyboardVerticalOffset={Spacing.xSmall}
-        behavior={isIOS ? "position" : undefined}
+    <>
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
       >
-        <View>
-          <View style={style.headerContainer}>
-            <Text style={style.header}>{t("callback.request_a_call")}</Text>
-            <Text style={style.subheader}>
-              {t("callback.fill_out_the_info", {
-                healthAuthorityName,
-              })}
-            </Text>
+        <KeyboardAvoidingView
+          keyboardVerticalOffset={Spacing.xSmall}
+          behavior={isIOS ? "position" : undefined}
+        >
+          <View>
+            <View style={style.headerContainer}>
+              <Text style={style.header}>{t("callback.request_a_call")}</Text>
+              <Text style={style.subheader}>
+                {t("callback.fill_out_the_info", {
+                  healthAuthorityName,
+                })}
+              </Text>
+            </View>
+            <View style={style.inputContainer}>
+              <Text style={style.inputLabel}>{t("callback.firstname")}</Text>
+              <TextInput
+                value={firstname}
+                style={style.textInput}
+                keyboardType={"default"}
+                returnKeyType={"done"}
+                onChangeText={handleOnChangeFirstname}
+                blurOnSubmit={false}
+                onSubmitEditing={Keyboard.dismiss}
+                autoCapitalize={"none"}
+              />
+            </View>
+            <View style={style.inputContainer}>
+              <Text style={style.inputLabel}>{t("callback.lastname")}</Text>
+              <TextInput
+                value={lastname}
+                style={style.textInput}
+                keyboardType={"default"}
+                returnKeyType={"done"}
+                onChangeText={handleOnChangeLastname}
+                blurOnSubmit={false}
+                onSubmitEditing={Keyboard.dismiss}
+                autoCapitalize={"none"}
+              />
+            </View>
+            <View style={style.inputContainer}>
+              <Text style={style.inputLabel}>
+                {t("callback.phone_number_required")}
+              </Text>
+              <TextInput
+                value={phoneNumber}
+                style={style.textInput}
+                keyboardType="phone-pad"
+                returnKeyType="done"
+                onChangeText={handleOnChangePhoneNumber}
+                blurOnSubmit={false}
+                onSubmitEditing={Keyboard.dismiss}
+                testID="phone-number-input"
+                multiline
+              />
+            </View>
+            <Text style={style.errorSubtitle}>{errorMessage}</Text>
           </View>
-          <View style={style.inputContainer}>
-            <Text style={style.inputLabel}>{t("callback.firstname")}</Text>
-            <TextInput
-              value={firstname}
-              style={style.textInput}
-              keyboardType={"default"}
-              returnKeyType={"done"}
-              onChangeText={handleOnChangeFirstname}
-              blurOnSubmit={false}
-              onSubmitEditing={Keyboard.dismiss}
-              autoCapitalize={"none"}
-            />
-          </View>
-          <View style={style.inputContainer}>
-            <Text style={style.inputLabel}>{t("callback.lastname")}</Text>
-            <TextInput
-              value={lastname}
-              style={style.textInput}
-              keyboardType={"default"}
-              returnKeyType={"done"}
-              onChangeText={handleOnChangeLastname}
-              blurOnSubmit={false}
-              onSubmitEditing={Keyboard.dismiss}
-              autoCapitalize={"none"}
-            />
-          </View>
-          <View style={style.inputContainer}>
-            <Text style={style.inputLabel}>
-              {t("callback.phone_number_required")}
-            </Text>
-            <TextInput
-              value={phoneNumber}
-              style={style.textInput}
-              keyboardType="phone-pad"
-              returnKeyType="done"
-              onChangeText={handleOnChangePhoneNumber}
-              blurOnSubmit={false}
-              onSubmitEditing={Keyboard.dismiss}
-              testID="phone-number-input"
-              multiline
-            />
-          </View>
-          <Text style={style.errorSubtitle}>{errorMessage}</Text>
-        </View>
-        {isLoading ? <LoadingIndicator /> : null}
-        <Button
-          onPress={handleOnPressSubmit}
-          label={t("common.submit")}
-          loading={isLoading}
-          customButtonStyle={style.button}
-          disabled={buttonDisabled}
-        />
-      </KeyboardAvoidingView>
-    </ScrollView>
-  )
-}
-
-const LoadingIndicator = () => {
-  return (
-    <View style={style.activityIndicatorContainer}>
-      <ActivityIndicator
-        size={"large"}
-        color={Colors.neutral100}
-        style={style.activityIndicator}
-        testID={"loading-indicator"}
-      />
-    </View>
+          <Button
+            onPress={handleOnPressSubmit}
+            label={t("common.submit")}
+            customButtonStyle={style.button}
+            disabled={buttonDisabled}
+          />
+        </KeyboardAvoidingView>
+      </ScrollView>
+      {isLoading && <LoadingIndicator />}
+    </>
   )
 }
 
@@ -206,7 +193,7 @@ const style = StyleSheet.create({
   },
   errorSubtitle: {
     ...Typography.error,
-    paddingTop: Spacing.xxSmall,
+    height: Spacing.huge,
   },
   inputContainer: {
     marginBottom: Spacing.medium,
@@ -220,24 +207,6 @@ const style = StyleSheet.create({
   },
   button: {
     alignSelf: "flex-start",
-  },
-  activityIndicatorContainer: {
-    position: "absolute",
-    zIndex: Layout.zLevel1,
-    alignItems: "center",
-    justifyContent: "center",
-    left: 0,
-    right: 0,
-    top: 0,
-    bottom: 0,
-    width: "100%",
-    height: "100%",
-  },
-  activityIndicator: {
-    width: 100,
-    height: 100,
-    backgroundColor: Colors.transparentNeutral30,
-    borderRadius: Outlines.baseBorderRadius,
   },
 })
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from "react"
 import {
-  ActivityIndicator,
   StyleSheet,
   View,
   ViewStyle,
@@ -17,7 +16,6 @@ import { Outlines, Spacing, Colors, Buttons, Typography } from "../styles"
 interface ButtonProps {
   label: string
   onPress: () => void
-  loading?: boolean
   disabled?: boolean
   customButtonStyle?: ViewStyle
   customButtonInnerStyle?: ViewStyle
@@ -32,7 +30,6 @@ const Button: FunctionComponent<ButtonProps> = ({
   label,
   onPress,
   disabled,
-  loading,
   customButtonStyle,
   customButtonInnerStyle,
   customTextStyle,
@@ -44,7 +41,7 @@ const Button: FunctionComponent<ButtonProps> = ({
   const determineBackgroundColor = (): string => {
     if (outlined) {
       return Colors.transparent
-    } else if (disabled || loading) {
+    } else if (disabled) {
       return Colors.secondary75
     } else {
       return Colors.primary100
@@ -64,7 +61,7 @@ const Button: FunctionComponent<ButtonProps> = ({
   const determineTextStyle = (): TextStyle => {
     if (outlined) {
       return style.outlinedButtonText
-    } else if (disabled || loading) {
+    } else if (disabled) {
       return style.textDisabled
     } else {
       return style.text
@@ -73,7 +70,7 @@ const Button: FunctionComponent<ButtonProps> = ({
   const textStyle = { ...determineTextStyle(), ...customTextStyle }
 
   const determineShadowEnabled = (): ViewStyle => {
-    if (disabled || loading || outlined) {
+    if (disabled || outlined) {
       return {}
     } else {
       return style.buttonContainerShadow
@@ -106,32 +103,28 @@ const Button: FunctionComponent<ButtonProps> = ({
       onPress={onPress}
       accessibilityLabel={label}
       accessibilityRole="button"
-      disabled={disabled || loading}
+      disabled={disabled}
       testID={testID}
       style={buttonContainerStyle}
     >
       <View style={buttonStyle}>
-        {loading ? (
-          <ActivityIndicator size={"small"} />
-        ) : (
-          <>
-            {hasPlusIcon && (
-              <SvgXml
-                xml={Icons.Plus}
-                fill={disabled ? Colors.black : Colors.white}
-                style={style.leftPlus}
-              />
-            )}
-            <Text style={textStyle}>{label}</Text>
-            {hasRightArrow && (
-              <SvgXml
-                xml={Icons.Arrow}
-                fill={determineRightArrowColor()}
-                style={style.rightArrow}
-              />
-            )}
-          </>
-        )}
+        <>
+          {hasPlusIcon && (
+            <SvgXml
+              xml={Icons.Plus}
+              fill={disabled ? Colors.black : Colors.white}
+              style={style.leftPlus}
+            />
+          )}
+          <Text style={textStyle}>{label}</Text>
+          {hasRightArrow && (
+            <SvgXml
+              xml={Icons.Arrow}
+              fill={determineRightArrowColor()}
+              style={style.rightArrow}
+            />
+          )}
+        </>
       </View>
     </TouchableOpacity>
   )

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,9 +1,13 @@
 import React, { FunctionComponent } from "react"
 import { ActivityIndicator, StyleSheet, View } from "react-native"
+import { useHeaderHeight } from "@react-navigation/stack"
 
 import { Colors, Layout, Outlines } from "../styles"
 
 const LoadingIndicator: FunctionComponent = () => {
+  const headerHeight = useHeaderHeight()
+  const style = createStyle(headerHeight)
+
   return (
     <View style={style.activityIndicatorContainer}>
       <ActivityIndicator
@@ -17,21 +21,25 @@ const LoadingIndicator: FunctionComponent = () => {
 }
 
 const indicatorWidth = 120
-const style = StyleSheet.create({
-  activityIndicatorContainer: {
-    position: "absolute",
-    left: Layout.halfWidth,
-    top: Layout.halfHeight,
-    marginLeft: -(indicatorWidth / 2),
-    marginTop: -(indicatorWidth / 2),
-    zIndex: Layout.zLevel2,
-  },
-  activityIndicator: {
-    width: indicatorWidth,
-    height: indicatorWidth,
-    backgroundColor: Colors.transparentNeutral30,
-    borderRadius: Outlines.baseBorderRadius,
-  },
-})
+const createStyle = (headerHeight: number) => {
+  /* eslint-disable react-native/no-unused-styles */
+
+  return StyleSheet.create({
+    activityIndicatorContainer: {
+      position: "absolute",
+      left: Layout.halfWidth,
+      top: Layout.halfHeight - headerHeight,
+      marginLeft: -(indicatorWidth / 2),
+      marginTop: -(indicatorWidth / 2),
+      zIndex: Layout.zLevel2,
+    },
+    activityIndicator: {
+      width: indicatorWidth,
+      height: indicatorWidth,
+      backgroundColor: Colors.transparentNeutral30,
+      borderRadius: Outlines.baseBorderRadius,
+    },
+  })
+}
 
 export default LoadingIndicator


### PR DESCRIPTION
Why:
----
We would like for our `Button` component to not handle any loading logic.

This commit:
----
- Removes the loading prop from the `Button` component
- Uses the `LoadingIndicator` component in place of displaying a loading state within the `Button` itself where applicable

Co-authored-by: Alejandro Dustet <alejandro@thoughtbot.com>