### PR TITLE
Remove navigation header within PublishConsentForm

### DIFF
--- a/src/AffectedUserFlow/Complete.tsx
+++ b/src/AffectedUserFlow/Complete.tsx
@@ -24,6 +24,7 @@ export const AffectedUserComplete: FunctionComponent = () => {
       <ScrollView
         style={style.container}
         contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
       >
         <Image source={Images.CheckInCircle} style={style.image} />
         <Text style={style.header}>{t("export.complete_title")}</Text>

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -19,28 +19,6 @@ describe("PublishConsentForm", () => {
     jest.resetAllMocks()
   })
 
-  it("navigates to the home screen when user cancels", () => {
-    const navigateSpy = jest.fn()
-    ;(useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy })
-    const { getByLabelText } = render(
-      <ExposureContext.Provider value={factories.exposureContext.build()}>
-        <PublishConsentForm
-          hmacKey="hmacKey"
-          certificate="certificate"
-          exposureKeys={[]}
-          storeRevisionToken={jest.fn()}
-          revisionToken=""
-          appPackageName=""
-          regionCodes={[""]}
-        />
-      </ExposureContext.Provider>,
-    )
-
-    fireEvent.press(getByLabelText("Cancel"))
-
-    expect(navigateSpy).toHaveBeenCalledWith("Home")
-  })
-
   it("displays the consent title and body", () => {
     const { getByText } = render(
       <ExposureContext.Provider value={factories.exposureContext.build()}>

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -17,7 +17,6 @@ import {
   useStatusBarEffect,
   AffectedUserFlowStackScreens,
   ModalStackScreens,
-  Stacks,
 } from "../../navigation"
 import { Icons } from "../../assets"
 import {
@@ -163,52 +162,12 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
     }
   }
 
-  const handleOnPressBack = () => {
-    navigation.goBack()
-  }
-
-  const handleOnPressCancel = () => {
-    navigation.navigate(Stacks.Home)
-  }
-
   const handleOnPressProtectPrivacy = () => {
     navigation.navigate(ModalStackScreens.ProtectPrivacy)
   }
 
   return (
     <View style={style.outerContainer}>
-      <View style={style.navButtonContainer}>
-        <TouchableOpacity
-          onPress={handleOnPressBack}
-          accessible
-          accessibilityLabel={t("export.code_input_button_back")}
-        >
-          <View style={style.backButtonInnerContainer}>
-            <SvgXml
-              xml={Icons.ArrowLeft}
-              fill={Colors.black}
-              width={Iconography.xxSmall}
-              height={Iconography.xxSmall}
-            />
-          </View>
-        </TouchableOpacity>
-
-        <TouchableOpacity
-          onPress={handleOnPressCancel}
-          accessible
-          accessibilityLabel={t("export.code_input_button_cancel")}
-        >
-          <View style={style.cancelButtonInnerContainer}>
-            <SvgXml
-              xml={Icons.X}
-              fill={Colors.black}
-              width={Iconography.xxSmall}
-              height={Iconography.xxSmall}
-            />
-          </View>
-        </TouchableOpacity>
-      </View>
-
       <ScrollView
         contentContainerStyle={style.contentContainer}
         testID="publish-consent-form"
@@ -261,26 +220,9 @@ const createStyle = (insets: EdgeInsets) => {
       flex: 1,
       backgroundColor: Colors.primaryLightBackground,
     },
-    navButtonContainer: {
-      flexDirection: "row",
-      justifyContent: "space-between",
-      position: "absolute",
-      paddingTop: 25,
-      width: "100%",
-      borderBottomWidth: Outlines.hairline,
-      borderBottomColor: Colors.neutral10,
-      backgroundColor: Colors.primaryLightBackground,
-      zIndex: Layout.zLevel1,
-    },
-    backButtonInnerContainer: {
-      padding: Spacing.medium,
-    },
-    cancelButtonInnerContainer: {
-      padding: Spacing.medium,
-    },
     contentContainer: {
+      paddingTop: Spacing.medium,
       paddingHorizontal: Spacing.large,
-      paddingTop: 105,
       paddingBottom: Spacing.huge,
     },
     content: {

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -19,14 +19,7 @@ import {
   ModalStackScreens,
 } from "../../navigation"
 import { Icons } from "../../assets"
-import {
-  Outlines,
-  Colors,
-  Spacing,
-  Iconography,
-  Typography,
-  Layout,
-} from "../../styles"
+import { Colors, Spacing, Iconography, Typography } from "../../styles"
 import Logger from "../../logger"
 import {
   postDiagnosisKeys,


### PR DESCRIPTION
Why:
----
We were rendering two headers on the `PublishConsentForm` screen. One was coming from the navigation stack and the other was being rendered within the screen component itself. We would like to only have the header coming from the navigation stack.

This commit:
----
- Removes the navigation header within the `PublishConsentForm` screen

Co-authored-by: Alejandro Dustet <alejandro@thoughtbot.com>