### PR TITLE
Delete Data Confirmation + Settings Stack Navigation Bar Consistency

### DIFF
--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -83,7 +83,7 @@ const style = StyleSheet.create({
     backgroundColor: Colors.primaryLightBackground,
   },
   headerContainer: {
-    marginTop: 40,
+    marginTop: Spacing.xSmall,
     width: "100%",
     flexDirection: "row",
     alignItems: "flex-end",
@@ -122,7 +122,7 @@ const style = StyleSheet.create({
     borderColor: Colors.neutral10,
     backgroundColor: Colors.secondary10,
     paddingTop: Spacing.small,
-    paddingBottom: Spacing.xxHuge,
+    paddingBottom: Spacing.small,
     paddingHorizontal: Spacing.small,
   },
   buttonContainer: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -377,8 +377,8 @@
   },
   "settings": {
     "data_deleted": "Data deleted",
-    "delete_data_disclosure1": "When you tap the \"Delete My Data\" button below, we'll remove the data that the app has stored on your phone.",
-    "delete_data_disclosure2": "This button does not delete the Rotating Proximity Identifiers or Temporary Exposure Keys created or collected by your phone for Proximity Tracing.\n\nYou can delete additional data through your phone's Settings.",
+    "delete_data_disclosure1": "When you tap the \"Delete My Data\" button below, the app will delete the Symptom History data that is stored on your phone.",
+    "delete_data_disclosure2": "This button does not delete the data created or collected by your phone for Exposure Notifications.\n\nYou can delete additional data through your phone's Settings.\n\n> Settings\n> Exposure Notifications \n> Exposure Logging Status/Active \n> Delete Exposure Log",
     "delete_my_data": "Delete My Data",
     "errors": {
       "deleting_data": "Sorry, we could not delete your data"

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -140,10 +140,7 @@ const MainNavigator: FunctionComponent = () => {
           name={Stacks.AffectedUserStack}
           component={AffectedUserStack}
         />
-        <Stack.Screen
-          name={ModalStackScreens.HowItWorksReviewFromSettings}
-          options={TransitionPresets.ModalTransition}
-        >
+        <Stack.Screen name={ModalStackScreens.HowItWorksReviewFromSettings}>
           {(props) => <HowItWorksStack {...props} mountLocation="Settings" />}
         </Stack.Screen>
         <Stack.Screen

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -2,10 +2,7 @@ import React, { FunctionComponent } from "react"
 import {
   createStackNavigator,
   StackNavigationOptions,
-  HeaderBackButton,
 } from "@react-navigation/stack"
-import { useTranslation } from "react-i18next"
-import { useNavigation } from "@react-navigation/native"
 
 import Settings from "../Settings/"
 import Legal from "../Settings/Legal"
@@ -14,49 +11,17 @@ import ENLocalDiagnosisKey from "../Settings/ENLocalDiagnosisKeyScreen"
 import ExposureListDebug from "../Settings/ExposureListDebugScreen"
 import { SettingsStackScreens } from "./index"
 
-import { Colors, Headers } from "../styles"
+import { Headers } from "../styles"
 import DeleteConfirmation from "../Settings/DeleteConfirmation"
+import { applyHeaderLeftBackButton } from "./HeaderLeftBackButton"
 
 const Stack = createStackNavigator()
 
-const headerLeftDark = () => {
-  return <HeaderLeft tintColor={Colors.white} />
-}
-
-const headerLeftLight = () => {
-  return <HeaderLeft tintColor={Colors.primaryDarkBackround} />
-}
-
-interface HeaderLeftProps {
-  tintColor: string
-}
-
-const HeaderLeft: FunctionComponent<HeaderLeftProps> = ({ tintColor }) => {
-  const navigation = useNavigation()
-
-  return (
-    <HeaderBackButton
-      labelVisible={false}
-      tintColor={tintColor}
-      onPress={() => navigation.goBack()}
-    />
-  )
-}
-
 const SettingsStack: FunctionComponent = () => {
-  const { t } = useTranslation()
-
   const defaultScreenOptions: StackNavigationOptions = {
-    headerStyle: {
-      ...Headers.headerStyle,
-    },
-    headerTitleStyle: {
-      ...Headers.headerTitleStyle,
-    },
-    headerBackTitleVisible: false,
-    headerTintColor: Colors.headerText,
-    headerTitleAlign: "center",
-    headerLeft: headerLeftDark,
+    ...Headers.headerMinimalOptions,
+    headerLeft: applyHeaderLeftBackButton(),
+    headerRight: () => null,
   }
 
   return (
@@ -69,30 +34,27 @@ const SettingsStack: FunctionComponent = () => {
       <Stack.Screen
         name={SettingsStackScreens.Legal}
         component={Legal}
-        options={{ headerTitle: t("screen_titles.legal") }}
+        options={defaultScreenOptions}
       />
       <Stack.Screen
         name={SettingsStackScreens.DeleteConfirmation}
         component={DeleteConfirmation}
-        options={{
-          headerTitle: "",
-          headerLeft: headerLeftLight,
-          headerStyle: { backgroundColor: Colors.primaryLightBackground },
-        }}
+        options={defaultScreenOptions}
       />
       <Stack.Screen
         name={SettingsStackScreens.ENDebugMenu}
         component={ENDebugMenu}
-        options={{ headerTitle: t("screen_titles.debug") }}
+        options={defaultScreenOptions}
       />
       <Stack.Screen
         name={SettingsStackScreens.ExposureListDebugScreen}
         component={ExposureListDebug}
-        options={{ headerTitle: t("screen_titles.exposures") }}
+        options={defaultScreenOptions}
       />
       <Stack.Screen
         name={SettingsStackScreens.ENLocalDiagnosisKey}
         component={ENLocalDiagnosisKey}
+        options={defaultScreenOptions}
       />
     </Stack.Navigator>
   )

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -9,11 +9,11 @@ import Legal from "../Settings/Legal"
 import ENDebugMenu from "../Settings/ENDebugMenu"
 import ENLocalDiagnosisKey from "../Settings/ENLocalDiagnosisKeyScreen"
 import ExposureListDebug from "../Settings/ExposureListDebugScreen"
+import DeleteConfirmation from "../Settings/DeleteConfirmation"
 import { SettingsStackScreens } from "./index"
+import { applyHeaderLeftBackButton } from "./HeaderLeftBackButton"
 
 import { Headers } from "../styles"
-import DeleteConfirmation from "../Settings/DeleteConfirmation"
-import { applyHeaderLeftBackButton } from "./HeaderLeftBackButton"
 
 const Stack = createStackNavigator()
 


### PR DESCRIPTION
#### Why:
We'd like the "Delete Data" confirmation screen to have appropriate copy, and also we'd like to use consistent navigation bar styling for screens in the settings stack

#### This commit:
This commit updates copy for the "Delete Data" confirmation screen, and also ensures that screens in the settings stack use the standard white nav bar and back button

** Note: at some point the "How the app works" screen will need a different nav bar to reflect the fact that it is presented modally rather than pushed onto the stack

Co-authored by Sam Zimmerman @Ferrumofomega sam.zimmerman@pathcheck.org

![Simulator Screen Shot - iPhone 11 Pro - 2020-10-21 at 21 47 36](https://user-images.githubusercontent.com/2637355/96808895-ca757300-13e7-11eb-80e5-1eba5661ea15.png)

