### PR TITLE
Small Spec Updates

### DIFF
--- a/src/modals/AnonymizedDataConsentScreen.spec.tsx
+++ b/src/modals/AnonymizedDataConsentScreen.spec.tsx
@@ -26,7 +26,9 @@ describe("AnonymizedDataConsentScreen", () => {
       )
 
       const buttonText = getByText("Stop Sharing Data")
+      const headerText = "You are sharing anonymized data"
 
+      expect(applyModalHeader).toHaveBeenCalledWith(headerText)
       expect(buttonText).toBeDefined()
     })
 
@@ -62,7 +64,7 @@ describe("AnonymizedDataConsentScreen", () => {
   })
 
   describe("when a user has not consented to data sharing", () => {
-    it("displays the correct button text", () => {
+    it("displays the correct text", () => {
       const context = factories.analyticsContext.build({
         userConsentedToAnalytics: false,
       })

--- a/src/modals/AnonymizedDataConsentScreen.spec.tsx
+++ b/src/modals/AnonymizedDataConsentScreen.spec.tsx
@@ -78,7 +78,6 @@ describe("AnonymizedDataConsentScreen", () => {
       )
 
       const buttonText = getByText("I Understand and Consent")
-
       const headerText = "Share Anonymized Data"
 
       expect(buttonText).toBeDefined()

--- a/src/modals/AnonymizedDataConsentScreen.spec.tsx
+++ b/src/modals/AnonymizedDataConsentScreen.spec.tsx
@@ -5,8 +5,10 @@ import { useNavigation } from "@react-navigation/native"
 import AnonymizedDataConsentScreen from "./AnonymizedDataConsentScreen"
 import { factories } from "../factories"
 import { AnalyticsContext } from "../AnalyticsContext"
+import { applyModalHeader } from "../navigation/ModalHeader"
 
 jest.mock("@react-navigation/native")
+jest.mock("../navigation/ModalHeader")
 
 describe("AnonymizedDataConsentScreen", () => {
   describe("when a user has consented to data sharing", () => {
@@ -75,7 +77,10 @@ describe("AnonymizedDataConsentScreen", () => {
 
       const buttonText = getByText("I Understand and Consent")
 
+      const headerText = "Share Anonymized Data"
+
       expect(buttonText).toBeDefined()
+      expect(applyModalHeader).toHaveBeenCalledWith(headerText)
     })
 
     describe("and they press to accept consent", () => {


### PR DESCRIPTION
#### Why:
We'd like to have tests that confirm that the correct header text is being set on the anonymized data consent screen.

#### This commit:
This commit adds tests that confirm that the correct header text is being set on the anonymized data consent screen.

Co-Authored by Devin Jameson devin@thoughtbot.com