### PR TITLE
Improve home screen card UX

### DIFF
--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -59,14 +59,19 @@ const Home: FunctionComponent = () => {
     emergencyPhoneNumber,
   } = useConfigurationContext()
 
-  const ChevronRightIcon = () => {
+  interface SectionButtonProps {
+    text: string
+  }
+
+  const SectionButton: FunctionComponent<SectionButtonProps> = ({ text }) => {
     return (
-      <View style={style.chevronRightIcon}>
+      <View style={style.sectionButton}>
+        <Text style={style.sectionButtonText}>{text}</Text>
         <SvgXml
           xml={Icons.ChevronRight}
-          width={Iconography.xxSmall}
-          height={Iconography.xxSmall}
-          fill={Colors.neutral.shade75}
+          width={Iconography.xxxSmall}
+          height={Iconography.xxxSmall}
+          color={Colors.primary.shade110}
         />
       </View>
     )
@@ -146,7 +151,6 @@ const Home: FunctionComponent = () => {
         onPress={handleOnPressTalkToContactTracer}
         style={style.floatingContainer}
       >
-        <ChevronRightIcon />
         <Image
           source={Images.HowItWorksValueProposition}
           style={style.image}
@@ -159,6 +163,7 @@ const Home: FunctionComponent = () => {
         <Text style={style.sectionBodyText}>
           {t("home.to_submit_your_test")}
         </Text>
+        <SectionButton text={t("home.request_call")} />
       </TouchableOpacity>
     )
   }
@@ -173,7 +178,6 @@ const Home: FunctionComponent = () => {
         onPress={handleOnPressReportTestResult}
         style={style.floatingContainer}
       >
-        <ChevronRightIcon />
         <Image
           source={Images.ProtectPrivacySubmitKeys}
           style={style.image}
@@ -186,6 +190,7 @@ const Home: FunctionComponent = () => {
         <Text style={style.sectionBodyText}>
           {t("home.if_you_have_a_code")}
         </Text>
+        <SectionButton text={t("home.report_result")} />
       </TouchableOpacity>
     )
   }
@@ -200,17 +205,19 @@ const Home: FunctionComponent = () => {
         onPress={handleOnPressTakeSelfAssessment}
         style={style.floatingContainer}
       >
-        <ChevronRightIcon />
         <Image
           source={Images.SelfAssessment}
           style={style.image}
           width={150}
           height={IMAGE_HEIGHT}
         />
-        <Text style={style.sectionHeaderText}>{t("home.feeling_sick")}</Text>
+        <Text style={style.sectionHeaderText}>
+          {t("home.not_feeling_well")}
+        </Text>
         <Text style={style.sectionBodyText}>
           {t("home.check_if_your_symptoms")}
         </Text>
+        <SectionButton text={t("home.take_assessment")} />
       </TouchableOpacity>
     )
   }
@@ -221,29 +228,31 @@ const Home: FunctionComponent = () => {
     }
 
     return (
-      <TouchableOpacity
-        onPress={handleOnPressCallEmergencyServices}
-        accessibilityLabel={t(
-          "self_assessment.call_emergency_services.call_emergencies",
-          {
-            emergencyPhoneNumber,
-          },
-        )}
-        accessibilityRole="button"
-        style={style.emergencyButtonContainer}
-      >
-        <SvgXml
-          xml={Icons.Phone}
-          fill={Colors.neutral.white}
-          width={Iconography.xSmall}
-          height={Iconography.xSmall}
-        />
-        <Text style={style.emergencyButtonText}>
-          {t("home.call_emergency_services", {
-            emergencyPhoneNumber,
-          })}
-        </Text>
-      </TouchableOpacity>
+      <View style={style.emergencyButtonOuterContainer}>
+        <TouchableOpacity
+          onPress={handleOnPressCallEmergencyServices}
+          accessibilityLabel={t(
+            "self_assessment.call_emergency_services.call_emergencies",
+            {
+              emergencyPhoneNumber,
+            },
+          )}
+          accessibilityRole="button"
+          style={style.emergencyButtonContainer}
+        >
+          <SvgXml
+            xml={Icons.Phone}
+            fill={Colors.neutral.white}
+            width={Iconography.xSmall}
+            height={Iconography.xSmall}
+          />
+          <Text style={style.emergencyButtonText}>
+            {t("home.call_emergency_services", {
+              emergencyPhoneNumber,
+            })}
+          </Text>
+        </TouchableOpacity>
+      </View>
     )
   }
 
@@ -315,25 +324,33 @@ const style = StyleSheet.create({
   floatingContainer: {
     ...Affordances.floatingContainer,
   },
-  chevronRightIcon: {
-    position: "absolute",
-    top: Spacing.large,
-    right: Spacing.large,
-  },
   image: {
     resizeMode: "contain",
-    marginBottom: Spacing.xSmall,
+    marginBottom: Spacing.small,
   },
   sectionHeaderText: {
     ...Typography.header3,
-    marginBottom: Spacing.xxSmall,
     color: Colors.neutral.black,
+    marginBottom: Spacing.xSmall,
   },
   sectionBodyText: {
-    ...Typography.header4,
+    ...Typography.header5,
     ...Typography.base,
+    lineHeight: Typography.mediumLineHeight,
     color: Colors.neutral.shade100,
-    marginBottom: Spacing.small,
+    marginBottom: Spacing.xLarge,
+  },
+  sectionButton: {
+    ...Buttons.card,
+  },
+  sectionButtonText: {
+    ...Typography.buttonCard,
+  },
+  emergencyButtonOuterContainer: {
+    borderTopWidth: Outlines.hairline,
+    borderColor: Colors.neutral.shade25,
+
+    paddingTop: Spacing.large,
   },
   emergencyButtonContainer: {
     ...Buttons.primary,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -144,6 +144,9 @@
     "your_device_is_scanning": "Your device is scanning for exposures and will continue to do so even if you close the app."
   },
   "home": {
+    "request_call": "Request Call",
+    "report_result": "Report Result",
+    "take_assessment": "Take Assessment",
     "bluetooth_info_body": "Your phone detects other phones you spend time in close proximity with using Bluetooth Low Energy. This allows the app to log your log daily encounters anonymously, even when you don’t have the app open on your device.",
     "bluetooth": {
       "all_services_on_subheader": "{{applicationName}} will remain active after the app has been closed",
@@ -163,7 +166,7 @@
     "call_emergency_services": "Call Emergency Services",
     "check_if_your_symptoms": "Enter your symptoms and get an instant recommendation on how to stay safe.",
     "did_you_test_positive": "Did you test positive for COVID-19?",
-    "feeling_sick": "Feeling sick?",
+    "not_feeling_well": "Not feeling well?",
     "fix": "Fix issues with {{technology}}",
     "get_more_info": "Get more info on {{technology}}",
     "have_a_positive_test": "Have a positive test result code?",
@@ -179,7 +182,7 @@
       "unauthorized_error_message_ios": "To enable Exposure Notifications, go to the Exposure Notification section in Settings and Share Exposure Information and set the Active Region to {{applicationName}}",
       "unauthorized_error_title": "Enable Exposure Notifications"
     },
-    "to_submit_your_test": "To get your test result code, you'll need to speak with a contact tracer."
+    "to_submit_your_test": "To submit your positive test result, you'll need to get your positive test result code from a contact tracer."
   },
   "label": {
     "check": "Checkmark",

--- a/src/styles/affordances.ts
+++ b/src/styles/affordances.ts
@@ -41,7 +41,7 @@ export const floatingContainer: ViewStyle = {
   ...Outlines.lightShadow,
   backgroundColor: Colors.background.primaryLight,
   borderRadius: Outlines.borderRadiusLarge,
-  paddingVertical: Spacing.medium,
+  paddingVertical: Spacing.large,
   paddingHorizontal: Spacing.large,
   marginBottom: Spacing.large,
 }

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -108,6 +108,17 @@ export const tinyRounded: ViewStyle = {
   ...tertiaryBlue,
 }
 
+export const card: ViewStyle = {
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center",
+  alignSelf: "flex-start",
+  paddingVertical: Spacing.xxSmall,
+  paddingHorizontal: Spacing.medium,
+  borderRadius: Outlines.borderRadiusMax,
+  backgroundColor: Colors.neutral.shade10,
+}
+
 export const fixedBottom: ViewStyle = {
   ...base,
   paddingTop: Spacing.medium,

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,6 +1,7 @@
 import { TextStyle } from "react-native"
 
 import * as Colors from "./colors"
+import * as Spacing from "./spacing"
 
 // Font Size
 export const xSmall = 13
@@ -206,6 +207,14 @@ export const buttonSecondary: TextStyle = {
   ...body1,
   ...semiBold,
   color: Colors.primary.shade100,
+}
+
+export const buttonCard: TextStyle = {
+  ...body2,
+  ...bold,
+  textTransform: "uppercase",
+  color: Colors.primary.shade110,
+  marginRight: Spacing.xSmall,
 }
 
 export const tappableListItem: TextStyle = {


### PR DESCRIPTION
Why: it was not clear to some users that the home screen cards were
tappable.

This commit:
- Updates the home screen cards to have clear button-like CTAs, thereby
  making it clear that the cards are tappable
- Adds a border above the call emergency services button to separate it
  from the primary actions on the home screen

![gif](https://user-images.githubusercontent.com/39350030/97200636-b2e31500-176e-11eb-86ff-56cd6f62b38d.gif)