### PR TITLE
Update .whitesource configuration file

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,9 +1,9 @@
 {
   "scanSettings": {
-    "baseBranches": []
+    "baseBranches": ["develop"]
   },
   "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "failure"
+    "vulnerableCheckRunConclusionLevel": "success"
   },
   "issueSettings": {
     "minSeverityLevel": "LOW"


### PR DESCRIPTION
#### Why:

Restrict WhiteSource to only generate issues for the _develop_ branch and maximize limited number of scans. Without the _baseBranches_ parameter set, WhiteSource will generate issues for all branches.

Additionally, setting the ConclusionLevel to _success_ as there are numerous vulnerable packages being tracked though have no documented remediation at this time. Issues will still generate tickets though the scan will not result in a failure.

#### This commit:

New configuration limits issue generation to _develop_ branch and sets the ConclusionLevel to _success_

Configuration updated as per https://whitesource.atlassian.net/wiki/spaces/WD/pages/697696422/WhiteSource+for+GitHub.com
