### PR TITLE
Handle network timeout for code submission

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -127,6 +127,9 @@ const CodeInputForm: FunctionComponent = () => {
       case "NetworkConnection": {
         return t("export.error.network_connection_error")
       }
+      case "Timeout": {
+        return t("export.error.timeout_error")
+      }
       default: {
         return t("export.error.unknown_code_verification_error")
       }

--- a/src/AffectedUserFlow/fetchWithTimeout.ts
+++ b/src/AffectedUserFlow/fetchWithTimeout.ts
@@ -1,4 +1,4 @@
-const TIMEOUT_ERROR = "timeout"
+const TIMEOUT_ERROR = "timeout" as const
 const DEFAULT_TIMEOUT = 5000
 
 const fetchWithTimeout = async (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -56,7 +56,6 @@
   },
   "export": {
     "code_input_body_bluetooth": "Enter your verification code",
-    "code_input_button_cancel": "Cancel",
     "code_input_placeholder": "Enter Code",
     "code_input_title_bluetooth": "Verify your diagnosis",
     "complete_body_bluetooth": "You’re helping contain the spread of the virus and protect others in your community.",
@@ -73,6 +72,7 @@
       "invalid_code": "Try a different code",
       "invalid_format": "Codes may only contain numbers and letters",
       "network_connection_error": "There is no internet connection",
+      "timeout_error": "Request took too long",
       "unknown_code_verification_error": "Try a different code",
       "verification_code_used": "Verification code has already been used"
     },
@@ -146,7 +146,6 @@
   "home": {
     "bluetooth_info_body": "Your phone detects other phones you spend time in close proximity with using Bluetooth Low Energy. This allows the app to log your log daily encounters anonymously, even when you don’t have the app open on your device.",
     "bluetooth": {
-      "all_services_on_subheader": "{{applicationName}} will remain active after the app has been closed",
       "bluetooth_disabled_error_message": "Go to the Settings app and enable Bluetooth to fix this error",
       "bluetooth_disabled_error_title": "Enable Bluetooth in Settings",
       "bluetooth_header": "Bluetooth",
@@ -157,7 +156,6 @@
       "share": "Share {{applicationName}}",
       "share_message": "Check out this app {{applicationName}}, which can help us contain COVID-19! {{appDownloadLink}}",
       "tracing_off_header": "Exposure Detection Off",
-      "tracing_off_subheader": "Enable Bluetooth and Proximity Tracing to get info about possible exposures",
       "tracing_on_header": "Exposure Detection On"
     },
     "call_emergency_services": "Call Emergency Services",


### PR DESCRIPTION
Why:
We are currently not timing out long network requests for the post
request to submit a verification code. We would like to apply a 5 second
timeout to this requests, like we are doing with the key submission
request.

This commit:
Switches the fetch call with a fetchWithTimeout call and adds and error
message for requests that timeout on the verification code form.
