### PR TITLE
Fix how it works screen display issue

### DIFF
--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -146,6 +146,8 @@ const createStyle = (insets: EdgeInsets) => {
     bottomButtonText: {
       ...Typography.header5,
       color: Colors.primary.shade100,
+      paddingHorizontal: Spacing.large,
+      textAlign: "center",
     },
   })
 }


### PR DESCRIPTION
Why: when the text at the bottom of the HowItWorks screens was longer
than the width of the device, the text would look weird.

This commit:
- Updates the style of the "How we protect your privacy" text on the
  HowItWorks screen so it looks correct even with more characters

![Screen Shot 2020-10-26 at 1 25 10 PM](https://user-images.githubusercontent.com/39350030/97224668-b6869400-178e-11eb-93db-bad34ee90968.png)