### PR TITLE
Fix for Deep Linking Bug on iOS

### DIFF
--- a/ios/BT/ExposureManager+Debug.swift
+++ b/ios/BT/ExposureManager+Debug.swift
@@ -37,18 +37,7 @@ extension ExposureManager: ExposureManagerDebuggable {
       let exposure = Exposure(id: UUID().uuidString,
                               date: Date().posixRepresentation - Int(TimeInterval.random(in: 0...13)) * 24 * 60 * 60 * 1000)
       btSecureStorage.storeExposures([exposure])
-      let content = UNMutableNotificationContent()
-      content.title = String.newExposureNotificationTitle.localized
-      content.body = String.newExposureNotificationBody.localized
-      content.sound = .default
-      let request = UNNotificationRequest(identifier: "identifier", content: content, trigger: nil)
-      userNotificationCenter.add(request) { error in
-        DispatchQueue.main.async {
-          if let error = error {
-            print("Error showing error user notification: \(error)")
-          }
-        }
-      }
+      notifyUserExposureDetected()
       resolve("Exposures: \(btSecureStorage.userState.exposures)")
     case .fetchExposures:
       resolve(currentExposures)

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -514,6 +514,25 @@ extension ExposureManager {
     }
   }
 
+  ///Notifies the user that an exposure has been detected
+  func notifyUserExposureDetected() {
+    let content = UNMutableNotificationContent()
+    content.title = String.newExposureNotificationTitle.localized
+    content.body = String.newExposureNotificationBody.localized
+    content.sound = .default
+    content.userInfo = [String.notificationUrlKey: "\(String.notificationUrlBasePath)\(String.notificationUrlExposureHistoryPath)"]
+    let request = UNNotificationRequest(identifier: String.newExposureNotificationIdentifier,
+                                        content: content,
+                                        trigger: nil)
+    userNotificationCenter.add(request) { error in
+      DispatchQueue.main.async {
+        if let error = error {
+          print("Error showing error user notification: \(error)")
+        }
+      }
+    }
+  }
+
 }
 
 // MARK: - Private
@@ -672,22 +691,4 @@ extension ExposureManager {
     }
   }
 
-  ///Notifies the user that an exposure has been detected
-  func notifyUserExposureDetected() {
-    let content = UNMutableNotificationContent()
-    content.title = String.newExposureNotificationTitle.localized
-    content.body = String.newExposureNotificationBody.localized
-    content.sound = .default
-    content.userInfo = [String.notificationUrlKey: "\(String.notificationUrlBasePath)\(String.notificationUrlExposureHistoryPath)"]
-    let request = UNNotificationRequest(identifier: String.newExposureNotificationIdentifier,
-                                        content: content,
-                                        trigger: nil)
-    userNotificationCenter.add(request) { error in
-      DispatchQueue.main.async {
-        if let error = error {
-          print("Error showing error user notification: \(error)")
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
### Why
When tapping an exposure notification (APNS), the user should be navigated to the exposure history screen

### This Commit
This commit ensures that deep linking in iOS is supported when the push notification is triggered from the debug menu

![Sep-22-2020 12-35-39](https://user-images.githubusercontent.com/2637355/93911306-391fbd80-fcd0-11ea-9fac-12d0bf42a3b7.gif)
