### PR TITLE
Fix various styling issues and inconsistencies

### DIFF
--- a/src/Activation/ActivateBluetooth.tsx
+++ b/src/Activation/ActivateBluetooth.tsx
@@ -80,22 +80,20 @@ const ActivateBluetooth: FunctionComponent = () => {
           </Text>
           <Text style={style.body}>{t("onboarding.bluetooth_body")}</Text>
         </View>
-        <View style={style.buttonsContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressChangeBluetoothStatus}
-            style={style.button}
-          >
-            <Text style={style.buttonText}>{t("common.settings")}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={handleOnPressMaybeLater}
-            style={style.secondaryButton}
-          >
-            <Text style={style.secondaryButtonText}>
-              {t("common.maybe_later")}
-            </Text>
-          </TouchableOpacity>
-        </View>
+        <TouchableOpacity
+          onPress={handleOnPressChangeBluetoothStatus}
+          style={style.button}
+        >
+          <Text style={style.buttonText}>{t("common.settings")}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={handleOnPressMaybeLater}
+          style={style.secondaryButton}
+        >
+          <Text style={style.secondaryButtonText}>
+            {t("common.maybe_later")}
+          </Text>
+        </TouchableOpacity>
       </ScrollView>
     </SafeAreaView>
   )
@@ -127,9 +125,6 @@ const style = StyleSheet.create({
   body: {
     ...Typography.body1,
     marginBottom: Spacing.xxLarge,
-  },
-  buttonsContainer: {
-    alignSelf: "flex-start",
   },
   button: {
     ...Buttons.primary,

--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -70,24 +70,20 @@ const ActivateExposureNotifications: FunctionComponent = () => {
             {t("onboarding.proximity_tracing_subheader3")}
           </Text>
         </View>
-        <View style={style.buttonsContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressActivateExposureNotifications}
-            style={style.button}
-          >
-            <Text style={style.buttonText}>
-              {t("onboarding.proximity_tracing_button")}
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={handleOnPressDontEnable}
-            style={style.secondaryButton}
-          >
-            <Text style={style.secondaryButtonText}>
-              {t("common.no_thanks")}
-            </Text>
-          </TouchableOpacity>
-        </View>
+        <TouchableOpacity
+          onPress={handleOnPressActivateExposureNotifications}
+          style={style.button}
+        >
+          <Text style={style.buttonText}>
+            {t("onboarding.proximity_tracing_button")}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={handleOnPressDontEnable}
+          style={style.secondaryButton}
+        >
+          <Text style={style.secondaryButtonText}>{t("common.no_thanks")}</Text>
+        </TouchableOpacity>
       </ScrollView>
     </SafeAreaView>
   )
@@ -118,9 +114,6 @@ const style = StyleSheet.create({
   body: {
     ...Typography.body1,
     marginBottom: Spacing.xxLarge,
-  },
-  buttonsContainer: {
-    alignSelf: "flex-start",
   },
   button: {
     ...Buttons.primary,

--- a/src/Activation/ActivateLocation.tsx
+++ b/src/Activation/ActivateLocation.tsx
@@ -70,22 +70,20 @@ const ActivateLocation: FunctionComponent = () => {
           </Text>
           <Text style={style.body}>{t("onboarding.location_body")}</Text>
         </View>
-        <View style={style.buttonsContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressAllowLocationAccess}
-            style={style.button}
-          >
-            <Text style={style.buttonText}>{t("common.settings")}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={handleOnPressMaybeLater}
-            style={style.secondaryButton}
-          >
-            <Text style={style.secondaryButtonText}>
-              {t("common.maybe_later")}
-            </Text>
-          </TouchableOpacity>
-        </View>
+        <TouchableOpacity
+          onPress={handleOnPressAllowLocationAccess}
+          style={style.button}
+        >
+          <Text style={style.buttonText}>{t("common.settings")}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={handleOnPressMaybeLater}
+          style={style.secondaryButton}
+        >
+          <Text style={style.secondaryButtonText}>
+            {t("common.maybe_later")}
+          </Text>
+        </TouchableOpacity>
       </ScrollView>
     </SafeAreaView>
   )
@@ -117,9 +115,6 @@ const style = StyleSheet.create({
   body: {
     ...Typography.body1,
     marginBottom: Spacing.xxLarge,
-  },
-  buttonsContainer: {
-    alignSelf: "flex-start",
   },
   button: {
     ...Buttons.primary,

--- a/src/Activation/NotificationPermissions.tsx
+++ b/src/Activation/NotificationPermissions.tsx
@@ -55,25 +55,21 @@ const NotificationsPermissions: FunctionComponent = () => {
             {t("onboarding.notification_subheader3")}
           </Text>
         </View>
-        <View style={style.buttonsContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressEnable}
-            style={style.button}
-            accessibilityLabel={t("label.launch_enable_notif")}
-          >
-            <Text style={style.buttonText}>
-              {t("label.launch_enable_notif")}
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={handleOnPressMaybeLater}
-            style={style.secondaryButton}
-          >
-            <Text style={style.secondaryButtonText}>
-              {t("common.maybe_later")}
-            </Text>
-          </TouchableOpacity>
-        </View>
+        <TouchableOpacity
+          onPress={handleOnPressEnable}
+          style={style.button}
+          accessibilityLabel={t("label.launch_enable_notif")}
+        >
+          <Text style={style.buttonText}>{t("label.launch_enable_notif")}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={handleOnPressMaybeLater}
+          style={style.secondaryButton}
+        >
+          <Text style={style.secondaryButtonText}>
+            {t("common.maybe_later")}
+          </Text>
+        </TouchableOpacity>
       </ScrollView>
     </SafeAreaView>
   )
@@ -105,9 +101,6 @@ const style = StyleSheet.create({
   body: {
     ...Typography.body1,
     marginBottom: Spacing.xxLarge,
-  },
-  buttonsContainer: {
-    alignSelf: "flex-start",
   },
   button: {
     ...Buttons.primary,

--- a/src/AffectedUserFlow/Complete.tsx
+++ b/src/AffectedUserFlow/Complete.tsx
@@ -67,7 +67,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.medium,
   },
   contentText: {
-    ...Typography.body2,
+    ...Typography.body1,
     textAlign: "center",
     marginBottom: Spacing.xxxLarge,
   },

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -17,7 +17,7 @@ const ExposureDetail: FunctionComponent = () => {
   const route = useRoute<
     RouteProp<ExposureHistoryStackParamList, "ExposureDetail">
   >()
-  useStatusBarEffect("light-content", Colors.header.background)
+  useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()
 
   const { exposureDatum } = route.params

--- a/src/ExposureHistory/MoreInfo.tsx
+++ b/src/ExposureHistory/MoreInfo.tsx
@@ -8,7 +8,7 @@ import { Text } from "../components"
 import { Spacing, Typography, Colors } from "../styles"
 
 const MoreInfo: FunctionComponent = () => {
-  useStatusBarEffect("light-content", Colors.header.background)
+  useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()
 
   return (
@@ -40,7 +40,7 @@ const MoreInfo: FunctionComponent = () => {
 
 const style = StyleSheet.create({
   container: {
-    backgroundColor: Colors.secondary.shade10,
+    backgroundColor: Colors.background.primaryLight,
     padding: Spacing.medium,
   },
   contentContainer: {

--- a/src/Home/ActivationStatusView.tsx
+++ b/src/Home/ActivationStatusView.tsx
@@ -44,7 +44,7 @@ const ActivationStatusView: FunctionComponent<ActivationStatusProps> = ({
   const { t } = useTranslation()
 
   const activeContent: Content = {
-    backgroundColor: Colors.accent.success10,
+    backgroundColor: Colors.accent.success25,
     borderColor: Colors.accent.success100,
     bodyText: t("common.on"),
     statusIcon: Icons.CheckInCircle,
@@ -55,7 +55,7 @@ const ActivationStatusView: FunctionComponent<ActivationStatusProps> = ({
   }
 
   const inactiveContent: Content = {
-    backgroundColor: Colors.accent.danger10,
+    backgroundColor: Colors.accent.danger25,
     borderColor: Colors.accent.danger100,
     bodyText: t("common.off"),
     statusIcon: Icons.XInCircle,

--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -60,8 +60,9 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
   return (
     <>
       <ScrollView
-        alwaysBounceVertical={false}
+        style={style.container}
         contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
       >
         <View>
           <Image
@@ -110,6 +111,9 @@ const createStyle = (insets: EdgeInsets) => {
 
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
+    container: {
+      backgroundColor: Colors.background.primaryLight,
+    },
     contentContainer: {
       flexGrow: 1,
       justifyContent: "space-between",

--- a/src/SelfAssessment/AgeRangeQuestion.tsx
+++ b/src/SelfAssessment/AgeRangeQuestion.tsx
@@ -8,6 +8,7 @@ import {
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
+import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 
 import { Text } from "../components"
 import { Colors, Forms, Iconography } from "../styles"
@@ -16,14 +17,17 @@ import { useSelfAssessmentContext } from "../SelfAssessmentContext"
 import { AgeRange } from "./selfAssessment"
 import SelfAssessmentLayout from "./SelfAssessmentLayout"
 
-import { Typography, Spacing, Buttons } from "../styles"
 import { Icons } from "../assets"
+import { Typography, Spacing, Buttons } from "../styles"
 
 const AgeRangeQuestion: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
   const { EIGHTEEN_TO_SIXTY_FOUR, SIXTY_FIVE_AND_OVER } = AgeRange
   const { ageRange, updateAgeRange } = useSelfAssessmentContext()
+
+  const insets = useSafeAreaInsets()
+  const style = createStyle(insets)
 
   const ageRangeToString = (range: AgeRange) => {
     switch (range) {
@@ -94,6 +98,9 @@ const RadioButton: FunctionComponent<RadioButtonProps> = ({
 }) => {
   const [pressing, setPressing] = useState<boolean>(false)
 
+  const insets = useSafeAreaInsets()
+  const style = createStyle(insets)
+
   const radioIcon = isSelected ? Icons.RadioSelected : Icons.RadioUnselected
   const radioColor = isSelected
     ? Colors.primary.shade100
@@ -127,38 +134,39 @@ const RadioButton: FunctionComponent<RadioButtonProps> = ({
   )
 }
 
-const style = StyleSheet.create({
-  headerText: {
-    ...Typography.header1,
-    marginBottom: Spacing.medium,
-  },
-  radioContainer: {
-    ...Forms.radioOrCheckboxContainer,
-  },
-  radioText: {
-    ...Forms.radioOrCheckboxText,
-  },
-  button: {
-    ...Buttons.primaryThin,
-    alignSelf: "center",
-    width: "100%",
-  },
-  buttonDisabled: {
-    ...Buttons.primaryThinDisabled,
-    alignSelf: "center",
-    width: "100%",
-  },
-  buttonText: {
-    ...Typography.buttonPrimary,
-    marginRight: Spacing.small,
-  },
-  buttonDisabledText: {
-    ...Typography.buttonPrimaryDisabled,
-    marginRight: Spacing.small,
-  },
-  pressing: {
-    opacity: 0.5,
-  },
-})
+const createStyle = (insets: EdgeInsets) => {
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    headerText: {
+      ...Typography.header1,
+      marginBottom: Spacing.medium,
+    },
+    radioContainer: {
+      ...Forms.radioOrCheckboxContainer,
+    },
+    radioText: {
+      ...Forms.radioOrCheckboxText,
+    },
+    button: {
+      ...Buttons.fixedBottomThin,
+      paddingBottom: insets.bottom + Spacing.small,
+    },
+    buttonDisabled: {
+      ...Buttons.fixedBottomThinDisabled,
+      paddingBottom: insets.bottom + Spacing.small,
+    },
+    buttonText: {
+      ...Typography.buttonFixedBottom,
+      marginRight: Spacing.small,
+    },
+    buttonDisabledText: {
+      ...Typography.buttonFixedBottomDisabled,
+      marginRight: Spacing.small,
+    },
+    pressing: {
+      opacity: 0.5,
+    },
+  })
+}
 
 export default AgeRangeQuestion

--- a/src/SelfAssessment/EmergencySymptomsQuestions.tsx
+++ b/src/SelfAssessment/EmergencySymptomsQuestions.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, TouchableOpacity } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
+import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 
 import { SelfAssessmentStackScreens, useStatusBarEffect } from "../navigation"
 import { Text } from "../components"
@@ -24,6 +25,9 @@ const EmergencySymptomsQuestions: FunctionComponent = () => {
     emergencySymptoms,
     updateSymptoms,
   } = useSelfAssessmentContext()
+
+  const insets = useSafeAreaInsets()
+  const style = createStyle(insets)
 
   const {
     CHEST_PAIN,
@@ -94,25 +98,27 @@ const EmergencySymptomsQuestions: FunctionComponent = () => {
   )
 }
 
-const style = StyleSheet.create({
-  headerText: {
-    ...Typography.header1,
-    marginBottom: Spacing.medium,
-  },
-  subheaderText: {
-    ...Typography.header4,
-    ...Typography.base,
-    marginBottom: Spacing.huge,
-  },
-  button: {
-    ...Buttons.primaryThin,
-    alignSelf: "center",
-    width: "100%",
-  },
-  buttonText: {
-    ...Typography.buttonPrimary,
-    marginRight: Spacing.small,
-  },
-})
+const createStyle = (insets: EdgeInsets) => {
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    headerText: {
+      ...Typography.header1,
+      marginBottom: Spacing.medium,
+    },
+    subheaderText: {
+      ...Typography.header4,
+      ...Typography.base,
+      marginBottom: Spacing.huge,
+    },
+    button: {
+      ...Buttons.fixedBottomThin,
+      paddingBottom: insets.bottom + Spacing.small,
+    },
+    buttonText: {
+      ...Typography.buttonFixedBottom,
+      marginRight: Spacing.small,
+    },
+  })
+}
 
 export default EmergencySymptomsQuestions

--- a/src/SelfAssessment/GeneralSymptoms.tsx
+++ b/src/SelfAssessment/GeneralSymptoms.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { StyleSheet, TouchableOpacity } from "react-native"
 import { SvgXml } from "react-native-svg"
+import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 
 import { SelfAssessmentStackScreens } from "../navigation"
 import { useSelfAssessmentContext } from "../SelfAssessmentContext"
@@ -34,6 +35,9 @@ const GeneralSymptoms: FunctionComponent = () => {
     otherSymptoms,
     updateSymptoms,
   } = useSelfAssessmentContext()
+
+  const insets = useSafeAreaInsets()
+  const style = createStyle(insets)
 
   const symptomToString = (
     symptom: PrimarySymptom | SecondarySymptom | OtherSymptom,
@@ -136,34 +140,35 @@ const GeneralSymptoms: FunctionComponent = () => {
   )
 }
 
-const style = StyleSheet.create({
-  headerText: {
-    ...Typography.header1,
-    marginBottom: Spacing.medium,
-  },
-  subheaderText: {
-    ...Typography.header4,
-    ...Typography.base,
-    marginBottom: Spacing.huge,
-  },
-  button: {
-    ...Buttons.primaryThin,
-    alignSelf: "center",
-    width: "100%",
-  },
-  buttonDisabled: {
-    ...Buttons.primaryThinDisabled,
-    alignSelf: "center",
-    width: "100%",
-  },
-  buttonText: {
-    ...Typography.buttonPrimary,
-    marginRight: Spacing.small,
-  },
-  buttonDisabledText: {
-    ...Typography.buttonPrimaryDisabled,
-    marginRight: Spacing.small,
-  },
-})
+const createStyle = (insets: EdgeInsets) => {
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    headerText: {
+      ...Typography.header1,
+      marginBottom: Spacing.medium,
+    },
+    subheaderText: {
+      ...Typography.header4,
+      ...Typography.base,
+      marginBottom: Spacing.huge,
+    },
+    button: {
+      ...Buttons.fixedBottomThin,
+      paddingBottom: insets.bottom + Spacing.small,
+    },
+    buttonDisabled: {
+      ...Buttons.fixedBottomThinDisabled,
+      paddingBottom: insets.bottom + Spacing.small,
+    },
+    buttonText: {
+      ...Typography.buttonFixedBottom,
+      marginRight: Spacing.small,
+    },
+    buttonDisabledText: {
+      ...Typography.buttonFixedBottomDisabled,
+      marginRight: Spacing.small,
+    },
+  })
+}
 
 export default GeneralSymptoms

--- a/src/SelfAssessment/SelfAssessmentIntro.tsx
+++ b/src/SelfAssessment/SelfAssessmentIntro.tsx
@@ -1,5 +1,11 @@
 import React, { FunctionComponent } from "react"
-import { ScrollView, StyleSheet, TouchableOpacity, View } from "react-native"
+import {
+  Image,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
@@ -8,8 +14,8 @@ import { SelfAssessmentStackScreens, useStatusBarEffect } from "../navigation"
 import { Text } from "../components"
 import { useConfigurationContext } from "../ConfigurationContext"
 
-import { Icons } from "../assets"
-import { Buttons, Colors, Spacing, Typography } from "../styles"
+import { Icons, Images } from "../assets"
+import { Buttons, Colors, Outlines, Spacing, Typography } from "../styles"
 
 const SelfAssessmentIntro: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
@@ -30,6 +36,7 @@ const SelfAssessmentIntro: FunctionComponent = () => {
       contentContainerStyle={style.contentContainer}
       alwaysBounceVertical={false}
     >
+      <Image source={Images.SelfAssessment} style={style.image} />
       <Text style={style.headerText}>
         {t("self_assessment.intro.covid19_self_assessment")}
       </Text>
@@ -75,6 +82,12 @@ const style = StyleSheet.create({
     paddingHorizontal: Spacing.medium,
     paddingVertical: Spacing.large,
   },
+  image: {
+    resizeMode: "contain",
+    width: Spacing.xxxMassive,
+    height: Spacing.xxxMassive,
+    marginBottom: Spacing.large,
+  },
   headerText: {
     ...Typography.header1,
     ...Typography.bold,
@@ -83,10 +96,13 @@ const style = StyleSheet.create({
   subheaderText: {
     ...Typography.body1,
     color: Colors.text.primary,
-    marginBottom: Spacing.xxxHuge,
+    marginBottom: Spacing.large,
   },
   bulletListContainer: {
-    marginBottom: Spacing.large,
+    paddingTop: Spacing.large,
+    marginBottom: Spacing.small,
+    borderTopColor: Colors.neutral.shade10,
+    borderTopWidth: Outlines.hairline,
   },
   bulletText: {
     ...Typography.body2,

--- a/src/SelfAssessment/SelfAssessmentLayout.tsx
+++ b/src/SelfAssessment/SelfAssessmentLayout.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, ReactNode } from "react"
 import { StyleSheet, View, ScrollView } from "react-native"
-import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 import { useStatusBarEffect } from "../navigation"
 
 import { Colors, Spacing } from "../styles"
@@ -14,8 +13,6 @@ const SelfAssessmentLayout: FunctionComponent<SelfAssessmentLayoutProps> = ({
   bottomActionsContent,
 }) => {
   useStatusBarEffect("dark-content", Colors.secondary.shade10)
-  const insets = useSafeAreaInsets()
-  const style = createStyle(insets)
 
   return (
     <View style={style.outerContainer}>
@@ -25,33 +22,23 @@ const SelfAssessmentLayout: FunctionComponent<SelfAssessmentLayoutProps> = ({
       >
         {children}
       </ScrollView>
-      <View style={style.bottomActionsContainer}>{bottomActionsContent}</View>
+      <View>{bottomActionsContent}</View>
     </View>
   )
 }
 
-const createStyle = (insets: EdgeInsets) => {
-  /* eslint-disable react-native/no-unused-styles */
-  return StyleSheet.create({
-    outerContainer: {
-      justifyContent: "space-between",
-      flex: 1,
-      backgroundColor: Colors.background.primaryLight,
-    },
-    contentContainer: {
-      justifyContent: "space-between",
-      paddingBottom: Spacing.xxLarge,
-      paddingHorizontal: Spacing.large,
-      paddingTop: Spacing.large,
-    },
-    bottomActionsContainer: {
-      alignItems: "center",
-      paddingTop: Spacing.small,
-      paddingBottom: insets.bottom + Spacing.small,
-      backgroundColor: Colors.secondary.shade10,
-      paddingHorizontal: Spacing.large,
-    },
-  })
-}
+const style = StyleSheet.create({
+  outerContainer: {
+    justifyContent: "space-between",
+    flex: 1,
+    backgroundColor: Colors.background.primaryLight,
+  },
+  contentContainer: {
+    justifyContent: "space-between",
+    paddingBottom: Spacing.xxLarge,
+    paddingHorizontal: Spacing.large,
+    paddingTop: Spacing.large,
+  },
+})
 
 export default SelfAssessmentLayout

--- a/src/SelfAssessment/UnderlyingConditions.tsx
+++ b/src/SelfAssessment/UnderlyingConditions.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, TouchableOpacity } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
+import { useSafeAreaInsets, EdgeInsets } from "react-native-safe-area-context"
 
 import { SelfAssessmentStackScreens } from "../navigation"
 import { useSelfAssessmentContext } from "../SelfAssessmentContext"
@@ -35,6 +36,9 @@ const UnderlyingConditions: FunctionComponent = () => {
     underlyingConditions,
     updateUnderlyingConditions,
   } = useSelfAssessmentContext()
+
+  const insets = useSafeAreaInsets()
+  const style = createStyle(insets)
 
   const underlyingConditionToString = (condition: UnderlyingCondition) => {
     switch (condition) {
@@ -150,25 +154,27 @@ const UnderlyingConditions: FunctionComponent = () => {
   )
 }
 
-const style = StyleSheet.create({
-  headerText: {
-    ...Typography.header1,
-    marginBottom: Spacing.medium,
-  },
-  subheaderText: {
-    ...Typography.header4,
-    ...Typography.base,
-    marginBottom: Spacing.huge,
-  },
-  button: {
-    ...Buttons.primaryThin,
-    alignSelf: "center",
-    width: "100%",
-  },
-  buttonText: {
-    ...Typography.buttonPrimary,
-    marginRight: Spacing.small,
-  },
-})
+const createStyle = (insets: EdgeInsets) => {
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    headerText: {
+      ...Typography.header1,
+      marginBottom: Spacing.medium,
+    },
+    subheaderText: {
+      ...Typography.header4,
+      ...Typography.base,
+      marginBottom: Spacing.huge,
+    },
+    button: {
+      ...Buttons.fixedBottomThin,
+      paddingBottom: insets.bottom + Spacing.small,
+    },
+    buttonText: {
+      ...Typography.buttonFixedBottom,
+      marginRight: Spacing.small,
+    },
+  })
+}
 
 export default UnderlyingConditions

--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -11,15 +11,7 @@ import { TouchableOpacity } from "react-native"
 import { useStatusBarEffect } from "../navigation"
 import { SUCCESS_RESPONSE } from "../OperationResponse"
 
-import {
-  Outlines,
-  Spacing,
-  Buttons,
-  Typography,
-  Layout,
-  Colors,
-  Affordances,
-} from "../styles"
+import { Spacing, Buttons, Typography, Colors, Affordances } from "../styles"
 
 const DeleteConfirmation: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.secondary.shade10)
@@ -46,30 +38,29 @@ const DeleteConfirmation: FunctionComponent = () => {
     <>
       <StatusBar backgroundColor={Colors.secondary.shade10} />
       <View style={style.container}>
-        <ScrollView>
-          <View style={style.headerContainer}>
-            <Text style={style.headerText}>{t("settings.delete_my_data")}</Text>
-          </View>
-          <View style={style.bodyContainer}>
-            <Text style={style.bodyText}>
-              {t("settings.delete_data_disclosure1")}
-            </Text>
-            <Text style={style.subheaderText}>{"Note"}</Text>
-            <Text style={style.bodyText}>
-              {t("settings.delete_data_disclosure2")}
-            </Text>
-          </View>
+        <ScrollView
+          style={style.scrollContentContainer}
+          alwaysBounceVertical={false}
+        >
+          <Text style={style.headerText}>{t("settings.delete_my_data")}</Text>
+          <Text style={style.bodyText}>
+            {t("settings.delete_data_disclosure1")}
+          </Text>
+          <Text style={style.subheaderText}>
+            {`${t("settings.delete_data_note")}:`}
+          </Text>
+          <Text style={style.bodyText}>
+            {t("settings.delete_data_disclosure2")}
+          </Text>
         </ScrollView>
-        <View style={style.bottomActionsContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressDeleteAllData}
-            accessibilityLabel={t("settings.delete_my_data")}
-            accessibilityRole="button"
-            style={style.buttonContainer}
-          >
-            <Text style={style.buttonText}>{t("settings.delete_my_data")}</Text>
-          </TouchableOpacity>
-        </View>
+        <TouchableOpacity
+          onPress={handleOnPressDeleteAllData}
+          accessibilityLabel={t("settings.delete_my_data")}
+          accessibilityRole="button"
+          style={style.buttonContainer}
+        >
+          <Text style={style.buttonText}>{t("settings.delete_my_data")}</Text>
+        </TouchableOpacity>
       </View>
     </>
   )
@@ -77,69 +68,31 @@ const DeleteConfirmation: FunctionComponent = () => {
 
 const style = StyleSheet.create({
   container: {
-    flex: 1,
-    justifyContent: "space-between",
     height: "100%",
     backgroundColor: Colors.background.primaryLight,
   },
-  headerContainer: {
-    marginTop: Spacing.xSmall,
-    width: "100%",
-    flexDirection: "row",
-    alignItems: "flex-end",
-    justifyContent: "space-between",
-    zIndex: Layout.zLevel1,
+  scrollContentContainer: {
+    paddingTop: Spacing.small,
+    paddingHorizontal: Spacing.large,
   },
   headerText: {
-    flex: 10,
     ...Typography.header2,
-    paddingHorizontal: Spacing.large,
-    paddingBottom: Spacing.xLarge,
-    color: Colors.primary.shade150,
-  },
-  bodyContainer: {
-    paddingHorizontal: Spacing.large,
-    flex: 1,
-    paddingTop: Spacing.medium,
+    marginBottom: Spacing.medium,
   },
   bodyText: {
     ...Typography.body1,
-    paddingBottom: Spacing.xxxLarge,
+    marginBottom: Spacing.xxxLarge,
   },
   subheaderText: {
     ...Typography.header4,
-    paddingBottom: Spacing.xxSmall,
-  },
-  closeIconContainer: {
-    position: "absolute",
-    right: 0,
-    top: 0,
-    padding: Spacing.medium,
-  },
-  bottomActionsContainer: {
-    alignItems: "center",
-    borderTopWidth: Outlines.hairline,
-    borderColor: Colors.neutral.shade10,
-    backgroundColor: Colors.secondary.shade10,
-    paddingTop: Spacing.small,
-    paddingBottom: Spacing.small,
-    paddingHorizontal: Spacing.small,
+    marginBottom: Spacing.xxSmall,
   },
   buttonContainer: {
-    ...Buttons.primary,
-    ...Buttons.medium,
-    width: "100%",
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignSelf: "center",
-    paddingHorizontal: Spacing.xLarge,
-    borderRadius: Outlines.borderRadiusMax,
+    ...Buttons.fixedBottom,
     backgroundColor: Colors.accent.danger100,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
-    flexGrow: 1,
-    textAlign: "center",
+    ...Typography.buttonFixedBottom,
   },
 })
 

--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -1,20 +1,24 @@
 import React, { FunctionComponent } from "react"
+import {
+  TouchableOpacity,
+  StatusBar,
+  StyleSheet,
+  View,
+  ScrollView,
+} from "react-native"
 import { useTranslation } from "react-i18next"
-import { StatusBar, StyleSheet, View, ScrollView } from "react-native"
 import { showMessage } from "react-native-flash-message"
 
 import { useOnboardingContext } from "../OnboardingContext"
 import { useSymptomHistoryContext } from "../SymptomHistory/SymptomHistoryContext"
-
 import { Text } from "../components"
-import { TouchableOpacity } from "react-native"
 import { useStatusBarEffect } from "../navigation"
 import { SUCCESS_RESPONSE } from "../OperationResponse"
 
 import { Spacing, Buttons, Typography, Colors, Affordances } from "../styles"
 
 const DeleteConfirmation: FunctionComponent = () => {
-  useStatusBarEffect("dark-content", Colors.secondary.shade10)
+  useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { resetOnboarding } = useOnboardingContext()
   const { deleteAllEntries } = useSymptomHistoryContext()
 
@@ -77,6 +81,7 @@ const style = StyleSheet.create({
   },
   headerText: {
     ...Typography.header2,
+    ...Typography.semiBold,
     marginBottom: Spacing.medium,
   },
   bodyText: {

--- a/src/Settings/Legal.tsx
+++ b/src/Settings/Legal.tsx
@@ -19,7 +19,7 @@ import { useStatusBarEffect } from "../navigation"
 import { Colors, Spacing, Typography } from "../styles"
 
 const Legal: FunctionComponent = () => {
-  useStatusBarEffect("light-content", Colors.header.background)
+  useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const {
     t,
     i18n: { language: localeCode },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -372,8 +372,9 @@
   },
   "settings": {
     "data_deleted": "Data deleted",
+    "delete_data_note": "Note",
     "delete_data_disclosure1": "When you tap the \"Delete My Data\" button below, the app will delete the Symptom History data that is stored on your phone.",
-    "delete_data_disclosure2": "This button does not delete the data created or collected by your phone for Exposure Notifications.\n\nYou can delete additional data through your phone's Settings.\n\n> Settings\n> Exposure Notifications \n> Exposure Logging Status/Active \n> Delete Exposure Log",
+    "delete_data_disclosure2": "This does not delete the data created or collected by your phone for Exposure Notifications.\n\nYou can delete this additional data in your device Settings.",
     "delete_my_data": "Delete My Data",
     "errors": {
       "deleting_data": "Sorry, we could not delete your data"

--- a/src/navigation/ExposureHistoryStack.tsx
+++ b/src/navigation/ExposureHistoryStack.tsx
@@ -1,6 +1,8 @@
 import React, { FunctionComponent } from "react"
-import { createStackNavigator } from "@react-navigation/stack"
-import { useTranslation } from "react-i18next"
+import {
+  createStackNavigator,
+  StackNavigationOptions,
+} from "@react-navigation/stack"
 
 import ExposureHistoryScreen from "../ExposureHistory/index"
 import MoreInfo from "../ExposureHistory/MoreInfo"
@@ -9,6 +11,7 @@ import {
   ExposureHistoryStackScreens,
   ExposureHistoryStackScreen,
 } from "./index"
+import { applyHeaderLeftBackButton } from "./HeaderLeftBackButton"
 
 import { Headers } from "../styles"
 
@@ -17,9 +20,13 @@ type ExposureHistoryStackParams = {
 }
 const Stack = createStackNavigator<ExposureHistoryStackParams>()
 
-const ExposureHistoryStack: FunctionComponent = () => {
-  const { t } = useTranslation()
+const defaultScreenOptions: StackNavigationOptions = {
+  ...Headers.headerMinimalOptions,
+  headerLeft: applyHeaderLeftBackButton(),
+  headerRight: () => null,
+}
 
+const ExposureHistoryStack: FunctionComponent = () => {
   return (
     <Stack.Navigator>
       <Stack.Screen
@@ -30,18 +37,12 @@ const ExposureHistoryStack: FunctionComponent = () => {
       <Stack.Screen
         name={ExposureHistoryStackScreens.MoreInfo}
         component={MoreInfo}
-        options={{
-          ...Headers.headerScreenOptions,
-          title: t("navigation.more_info"),
-        }}
+        options={defaultScreenOptions}
       />
       <Stack.Screen
         name={ExposureHistoryStackScreens.ExposureDetail}
         component={ExposureDetail}
-        options={{
-          ...Headers.headerScreenOptions,
-          title: t("navigation.exposure"),
-        }}
+        options={defaultScreenOptions}
       />
     </Stack.Navigator>
   )

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -17,13 +17,13 @@ import { Headers } from "../styles"
 
 const Stack = createStackNavigator()
 
-const SettingsStack: FunctionComponent = () => {
-  const defaultScreenOptions: StackNavigationOptions = {
-    ...Headers.headerMinimalOptions,
-    headerLeft: applyHeaderLeftBackButton(),
-    headerRight: () => null,
-  }
+const defaultScreenOptions: StackNavigationOptions = {
+  ...Headers.headerMinimalOptions,
+  headerLeft: applyHeaderLeftBackButton(),
+  headerRight: () => null,
+}
 
+const SettingsStack: FunctionComponent = () => {
   return (
     <Stack.Navigator screenOptions={defaultScreenOptions}>
       <Stack.Screen

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -59,7 +59,7 @@ export const primary: ViewStyle = {
   ...Outlines.lightShadow,
   borderRadius: Outlines.borderRadiusMax,
   paddingHorizontal: Spacing.xHuge,
-  minWidth: 180,
+  width: "100%",
   maxWidth: Layout.screenWidth * 0.95,
   backgroundColor: Colors.primary.shade100,
 }
@@ -121,8 +121,22 @@ export const card: ViewStyle = {
 
 export const fixedBottom: ViewStyle = {
   ...base,
-  paddingTop: Spacing.medium,
-  paddingBottom: Spacing.medium,
+  paddingVertical: Spacing.medium,
   backgroundColor: Colors.primary.shade100,
   width: "100%",
+}
+
+export const fixedBottomDisabled: ViewStyle = {
+  ...fixedBottom,
+  backgroundColor: Colors.neutral.shade50,
+}
+
+export const fixedBottomThin: ViewStyle = {
+  ...fixedBottom,
+  paddingVertical: Spacing.small,
+}
+
+export const fixedBottomThinDisabled: ViewStyle = {
+  ...fixedBottomThin,
+  backgroundColor: Colors.neutral.shade50,
 }

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -98,6 +98,7 @@ export const secondary: ViewStyle = {
   ...base,
   ...medium,
   ...transparent,
+  width: "100%",
   paddingHorizontal: Spacing.huge,
 }
 

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -203,6 +203,10 @@ export const buttonFixedBottom: TextStyle = {
   ...buttonPrimary,
 }
 
+export const buttonFixedBottomDisabled: TextStyle = {
+  ...buttonPrimaryDisabled,
+}
+
 export const buttonSecondary: TextStyle = {
   ...body1,
   ...semiBold,


### PR DESCRIPTION
Why: there are styling issues and inconsistencies across the app that should be fixed to improve UX.

This commit:
- Updates most of the buttons in the app to be full width, instead of having some full width buttons and some buttons that are only as big as their children
- Updates the nav headers on the `MoreInfo` and `ExposureDetails` screens to use the updated nav header style
- Updates the `ActivationStatusView` to use the same red and green colors as the `Home` screen
- Updates the self assessment bottom buttons to use the same "fixed bottom" style as several of the other screens
- Adds the `SelfAssessment` image to the self assessment intro screen and updates the styles slightly
- Updates the `DeleteConfirmation` screen styles to use the same "fixed bottom" button style as several of the other screens and improve the UX
- Updates some translations to improve copy clarity