### PR TITLE
Introduce line charts

### DIFF
--- a/src/CovidData/Card/CovidDataCard.tsx
+++ b/src/CovidData/Card/CovidDataCard.tsx
@@ -9,12 +9,10 @@ import {
 import { useNavigation } from "@react-navigation/native"
 
 import { HomeStackScreens } from "../../navigation"
-import PercentageChart from "../PercentageChart"
-import { CovidDataRequest } from "../Context"
-import * as CovidData from "../covidData"
-
-import SectionButton from "../../Home/SectionButton"
 import { Text } from "../../components"
+import SectionButton from "../../Home/SectionButton"
+import { CovidDataRequest } from "../Context"
+import CovidDataInfo from "./CovidDataInfo"
 
 import {
   Iconography,
@@ -56,22 +54,14 @@ const CovidDataCard: FunctionComponent<CovidDataCardProps> = ({
       case "LOADING":
         return <LoadingIndicator />
       case "SUCCESS": {
-        const percentage = CovidData.toNewCasesPercentage(dataRequest.data)
         return (
-          <View testID={"covid-data"}>
-            <PercentageChart
-              percentage={percentage}
-              label={t("covid_data.new_cases")}
-            />
-          </View>
+          <CovidDataInfo data={dataRequest.data} locationName={locationName} />
         )
       }
     }
   }
 
-  const headerText = t("covid_data.covid_stats_in", {
-    location: locationName.toUpperCase(),
-  })
+  const headerText = t("covid_data.covid_coverage")
 
   return (
     <TouchableOpacity
@@ -102,6 +92,7 @@ const LoadingIndicator = () => {
 interface ErrorMessageProps {
   message: string
 }
+
 const ErrorMessage: FunctionComponent<ErrorMessageProps> = ({ message }) => {
   return <Text style={style.errorMessageText}>{message}</Text>
 }
@@ -117,7 +108,7 @@ const style = StyleSheet.create({
     ...Typography.error,
   },
   sectionHeaderText: {
-    ...Typography.header3,
+    ...Typography.header5,
     marginBottom: Spacing.xxSmall,
     color: Colors.neutral.black,
   },

--- a/src/CovidData/Card/CovidDataInfo.tsx
+++ b/src/CovidData/Card/CovidDataInfo.tsx
@@ -1,0 +1,74 @@
+import React, { FunctionComponent } from "react"
+import { useTranslation } from "react-i18next"
+
+import { StyleSheet, View } from "react-native"
+
+import * as CovidData from "../covidData"
+import { Text } from "../../components"
+import LineChart from "../LineChart"
+
+import { Layout, Typography, Spacing, Colors } from "../../styles"
+
+interface CovidDataInfoProps {
+  data: CovidData.CovidData
+  locationName: string
+}
+
+const CovidDataInfo: FunctionComponent<CovidDataInfoProps> = ({
+  data,
+  locationName,
+}) => {
+  const { t } = useTranslation()
+
+  const lineData = CovidData.toLineChartCasesNew(data)
+
+  const lineChartWidth =
+    0.5 * (Layout.screenWidth - 2 * Spacing.medium - 2 * Spacing.medium)
+  const lineChartHeight = 80
+
+  const labelText = t("covid_data.new_cases")
+
+  return (
+    <View testID={"covid-data"}>
+      <Text style={style.headerText}>
+        {t("covid_data.spread_of_the_virus_in", { locationName })}
+      </Text>
+      <View style={style.dataContainer}>
+        <View style={style.trendContainer}>
+          <Text style={style.legendText}>{labelText}</Text>
+        </View>
+        <View style={style.chartContainer}>
+          <LineChart
+            lineData={lineData}
+            width={lineChartWidth}
+            height={lineChartHeight}
+            color={Colors.accent.success100}
+          />
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const style = StyleSheet.create({
+  headerText: {
+    ...Typography.body2,
+    marginBottom: Spacing.xxSmall,
+  },
+  dataContainer: {
+    flexDirection: "row",
+    marginTop: Spacing.xSmall,
+    marginBottom: Spacing.medium,
+  },
+  trendContainer: {
+    flex: 4,
+  },
+  chartContainer: {
+    flex: 3,
+  },
+  legendText: {
+    ...Typography.body2,
+  },
+})
+
+export default CovidDataInfo

--- a/src/CovidData/LineChart.tsx
+++ b/src/CovidData/LineChart.tsx
@@ -1,0 +1,143 @@
+import React, { FunctionComponent } from "react"
+import { Svg, Path } from "react-native-svg"
+
+import * as SvgPath from "./SvgPath"
+import { Colors } from "../styles"
+
+interface LineChartProps {
+  lineData: number[]
+  width: number
+  height: number
+  color: string
+}
+
+const NUMBER_OF_HORIZONTAL_LINES = 6
+
+const LineChart: FunctionComponent<LineChartProps> = ({
+  lineData,
+  width,
+  height,
+  color,
+}) => {
+  if (lineData.length < 2) {
+    return null
+  }
+
+  // Scale Data
+  const max = Math.max(...lineData)
+  const min = Math.min(...lineData)
+  const shrinkPathBy = 2
+  const scaleFactor = height / (max - min) / shrinkPathBy
+  const toScale = (datum: number) => {
+    return (datum - min) * scaleFactor
+  }
+
+  // Fit Path
+  const offset = height / 3
+  const xPadding = 10
+  const firstXPosition = xPadding / 2
+  const pathWidth = width - xPadding
+  const xStepWidth = pathWidth / (lineData.length - 1)
+  const toOffset = (datum: number) => {
+    return datum + offset
+  }
+  const toCoordinate = (datum: number, idx: number): SvgPath.Coordinate => {
+    const xCoordinate = idx === 0 ? firstXPosition : idx * xStepWidth
+    return [xCoordinate, height - datum]
+  }
+
+  const viewBox = `0 0 ${width} ${height}`
+
+  const scaledData = lineData.map(toScale)
+  const offsetData = scaledData.map(toOffset)
+  const coordinates = offsetData.map(toCoordinate)
+  const trendLinePath = SvgPath.toSmoothBezier(coordinates)
+
+  return (
+    <Svg height={height} width="100%" viewBox={viewBox}>
+      <HorizontalLines height={height} width={width} />
+      <Path
+        d={trendLinePath}
+        fill="none"
+        stroke={color}
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </Svg>
+  )
+}
+
+interface HorizontalLinesProps {
+  height: number
+  width: number
+}
+
+const HorizontalLines: FunctionComponent<HorizontalLinesProps> = ({
+  height,
+  width,
+}) => {
+  const buildHorizontalLineYPositions = (
+    currentYPosition: number,
+  ): number[] => {
+    const verticalSpacing = height / (NUMBER_OF_HORIZONTAL_LINES - 1)
+    return currentYPosition > height
+      ? []
+      : buildHorizontalLineYPositions(
+          currentYPosition + verticalSpacing,
+        ).concat([currentYPosition])
+  }
+
+  interface HorizontalLineProps {
+    start: SvgPath.Coordinate
+    end: SvgPath.Coordinate
+    strokeWidth: number
+    color: string
+  }
+
+  const HorizontalLine: FunctionComponent<HorizontalLineProps> = ({
+    start,
+    end,
+    strokeWidth,
+    color,
+  }) => {
+    const path = SvgPath.toLine(start, end)
+
+    return (
+      <Path d={path} fill="none" stroke={color} strokeWidth={strokeWidth} />
+    )
+  }
+
+  const lineColor = Colors.neutral.shade75
+  const horizontalLinesStartingYPosition = 0
+  const [baseLineY, ...lineCoords] = buildHorizontalLineYPositions(
+    horizontalLinesStartingYPosition,
+  )
+  const baseLineStart: SvgPath.Coordinate = [0, baseLineY]
+  const baseLineEnd: SvgPath.Coordinate = [width, baseLineY]
+
+  return (
+    <>
+      {lineCoords.map((yCoord: number) => {
+        const startPoint: SvgPath.Coordinate = [0, yCoord]
+        const endPoint: SvgPath.Coordinate = [width, yCoord]
+        return (
+          <HorizontalLine
+            start={startPoint}
+            end={endPoint}
+            color={lineColor}
+            strokeWidth={1}
+            key={`hline-${yCoord}`}
+          />
+        )
+      })}
+      <HorizontalLine
+        start={baseLineStart}
+        end={baseLineEnd}
+        color={lineColor}
+        strokeWidth={2}
+      />
+    </>
+  )
+}
+
+export default LineChart

--- a/src/CovidData/SvgPath.ts
+++ b/src/CovidData/SvgPath.ts
@@ -1,0 +1,81 @@
+export type Coordinate = [number, number]
+
+export const toSmoothBezier = (points: Coordinate[]): string => {
+  return points.reduce((acc, point, idx, points) => {
+    if (idx === 0) {
+      return `M ${point[0]},${point[1]}`
+    } else {
+      const command = sbezierCommand(point, idx, points)
+      return `${acc} ${sbezierCommandToString(command)}`
+    }
+  }, "")
+}
+
+export const toLine = (pointA: Coordinate, pointB: Coordinate): string => {
+  const [x1, y1] = pointA
+  const [x2, y2] = pointB
+  return `M ${x1} ${y1} L ${x2} ${y2}`
+}
+
+interface SBezierCommand {
+  endControlPoint: Coordinate
+  endPoint: Coordinate
+}
+
+const sbezierCommand = (
+  endPoint: Coordinate,
+  idx: number,
+  points: Coordinate[],
+): SBezierCommand => {
+  const endControlPoint = controlPoint(
+    endPoint,
+    points[idx - 1],
+    points[idx + 1],
+  )
+  return {
+    endControlPoint,
+    endPoint,
+  }
+}
+
+const sbezierCommandToString = ({
+  endControlPoint: [cpeX, cpeY],
+  endPoint: [x, y],
+}: SBezierCommand): string => {
+  return `S ${cpeX},${cpeY} ${x},${y}`
+}
+
+const controlPoint = (
+  current: Coordinate,
+  previous: Coordinate | undefined,
+  next: Coordinate | undefined,
+): Coordinate => {
+  const p = previous || current
+  const n = next || current
+
+  const smoothing = 0.15
+
+  const { length: opposedLineLength, angle: opposedLineAngle } = line(p, n)
+  const cpAngle = opposedLineAngle + Math.PI
+  const cpLength = opposedLineLength * smoothing
+
+  const x = current[0] + Math.cos(cpAngle) * cpLength
+  const y = current[1] + Math.sin(cpAngle) * cpLength
+  return [x, y]
+}
+
+interface Line {
+  startPoint: Coordinate
+  length: number
+  angle: number
+}
+
+const line = (pointA: Coordinate, pointB: Coordinate): Line => {
+  const lengthX = pointB[0] - pointA[0]
+  const lengthY = pointB[1] - pointA[1]
+  return {
+    startPoint: pointA,
+    length: Math.sqrt(Math.pow(lengthX, 2) + Math.pow(lengthY, 2)),
+    angle: Math.atan2(lengthY, lengthX),
+  }
+}

--- a/src/CovidData/covidData.ts
+++ b/src/CovidData/covidData.ts
@@ -39,3 +39,13 @@ const percentDifference = (a: number, b: number) => {
   const result = Math.round(((a - b) / b) * 100)
   return result
 }
+
+type TrendData = number[]
+
+export const toLineChartCasesNew = (data: CovidData): TrendData => {
+  return data.map(toCasesNew).slice(0, 7)
+}
+
+export const toCasesNew = (datum: CovidDatum): number => {
+  return datum.positiveCasesNew
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -41,8 +41,9 @@
   "covid_data": {
     "apologies_data_unavailable": "Apologies, COVID data is unavailable.",
     "cases_today": "Cases today",
+    "covid_coverage": "Covid Coverage",
     "covid_data": "COVID Data",
-    "covid_stats_in": "COVID Stats in {{location}}",
+    "spread_of_the_virus_in": "Spread of the virus in {{locationName}}",
     "deaths_today": "Deaths today",
     "down_from_last_week": "Down from last week",
     "error_getting_data": "Sorry, we could not fetch the latest COVID cases data for {{location}}.",

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -4,6 +4,7 @@ import * as Colors from "./colors"
 import * as Spacing from "./spacing"
 
 // Font Size
+export const xxSmall = 10
 export const xSmall = 13
 export const small = 14
 export const medium = 16
@@ -13,6 +14,7 @@ export const xxLarge = 26
 export const xxxLarge = 30
 
 // Line Height
+export const xxSmallLineHeight = 18
 export const xSmallLineHeight = 20
 export const smallLineHeight = 20
 export const mediumLineHeight = 24
@@ -70,6 +72,12 @@ export const monospace: TextStyle = {
 }
 
 // Standard Font Types
+export const xxSmallFont: TextStyle = {
+  ...base,
+  fontSize: xxSmall,
+  lineHeight: xxSmallLineHeight,
+}
+
 export const xSmallFont: TextStyle = {
   ...base,
   fontSize: xSmall,


### PR DESCRIPTION
Why:
We would like to show a line chart in the covid data card to indicate to
users the trends of the virus.

This commit:
- Introduces a CovidDataInfo component to render a the set of covid data
analytic info as a set of labeled visual elements.

- Introduces a LineChart component which can render a scaled svg of a
provided data set as a curve.

- Introduced a SvgPath module to handle the building of an svg path
command from a provided set of XYCoordinates.

To-do:
- [ ] Render correct increasing/decreasing text
- [ ] Render correct down/up X% in past Y days text
- [ ] parameterize the data label
- [ ] show the data source
- [ ] Use a different API
    
Co-Authored-By: devin jameson <devin@thoughtbot.com>

<img width="418" alt="Screen Shot 2020-10-28 at 10 28 06 PM" src="https://user-images.githubusercontent.com/39350030/97529315-e12e4380-196c-11eb-867d-eb7371488021.png">