### PR TITLE
Handle Rate Limiting Gracefully

### DIFF
--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -430,7 +430,6 @@ final class ExposureManager: NSObject {
       case let .failure(error):
         let exposureError = ExposureError.default(error.localizedDescription)
         btSecureStorage.exposureDetectionErrorLocalizedDescription = error.localizedDescription
-        postExposureDetectionErrorNotification(exposureError.errorDescription)
         completionHandler(.failure(exposureError))
       }
     }

--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -8,11 +8,7 @@ import React, {
 } from "react"
 
 import gaenStrategy from "./gaen"
-import {
-  failureResponse,
-  OperationResponse,
-  SUCCESS_RESPONSE,
-} from "./OperationResponse"
+import { failureResponse, OperationResponse } from "./OperationResponse"
 import { ExposureKey } from "./exposureKey"
 import { ExposureInfo } from "./exposure"
 import { checkForNewExposures as detectExposures } from "./gaen/nativeModule"
@@ -54,7 +50,7 @@ const initialState = {
   },
   refreshExposureInfo: () => {},
   checkForNewExposures: () => {
-    return Promise.resolve(SUCCESS_RESPONSE)
+    return Promise.resolve({ kind: "success" as const })
   },
 }
 
@@ -102,9 +98,12 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
 
   const checkForNewExposures = async (): Promise<OperationResponse> => {
     try {
-      await detectExposures()
+      const response = await detectExposures()
+      if (response.kind === "failure") {
+        throw new Error(response.error)
+      }
       await refreshExposureInfo()
-      return SUCCESS_RESPONSE
+      return { kind: "success" }
     } catch (e) {
       return failureResponse(e.message)
     }

--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -7,7 +7,7 @@ import { ExposureDatum } from "../../exposure"
 import { DateTimeUtils } from "../../utils"
 import { factories } from "../../factories"
 import { ExposureContext } from "../../ExposureContext"
-import { failureResponse, SUCCESS_RESPONSE } from "../../OperationResponse"
+import { failureResponse } from "../../OperationResponse"
 
 import History from "./index"
 
@@ -33,7 +33,7 @@ describe("History", () => {
       const exposures: ExposureDatum[] = []
       const checkForNewExposuresSpy = jest
         .fn()
-        .mockResolvedValueOnce(SUCCESS_RESPONSE)
+        .mockResolvedValueOnce({ kind: "success" })
 
       const { getByTestId } = render(
         <ExposureContext.Provider

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -59,10 +59,21 @@ const History: FunctionComponent<HistoryProps> = ({
         ...Affordances.successFlashMessageOptions,
       })
     } else {
-      showMessage({
-        message: t("common.something_went_wrong"),
-        ...Affordances.errorFlashMessageOptions,
-      })
+      switch (checkResult.error) {
+        case "ExceededCheckRateLimit": {
+          showMessage({
+            message: t("common.success"),
+            ...Affordances.successFlashMessageOptions,
+          })
+          break
+        }
+        default: {
+          showMessage({
+            message: t("common.something_went_wrong"),
+            ...Affordances.errorFlashMessageOptions,
+          })
+        }
+      }
     }
     setCheckingForExposures(false)
   }

--- a/src/OperationResponse.ts
+++ b/src/OperationResponse.ts
@@ -1,9 +1,9 @@
 import Logger from "./logger"
 
-export type OperationResult = "success" | "failure"
-export type OperationResponse = { kind: OperationResult }
-export const SUCCESS_RESPONSE: OperationResponse = { kind: "success" }
+export type OperationResponse = OperationSuccess | OperationFailure
+export type OperationSuccess = { kind: "success" }
+export type OperationFailure = { kind: "failure"; error: string }
 export const failureResponse = (errorMessage: string): OperationResponse => {
   Logger.error(errorMessage)
-  return { kind: "failure" }
+  return { kind: "failure", error: errorMessage }
 }

--- a/src/Settings/DeleteConfirmation.spec.tsx
+++ b/src/Settings/DeleteConfirmation.spec.tsx
@@ -4,7 +4,6 @@ import { showMessage } from "react-native-flash-message"
 
 import { SymptomHistoryContext } from "../SymptomHistory/SymptomHistoryContext"
 import { OnboardingProvider } from "../OnboardingContext"
-import { SUCCESS_RESPONSE } from "../OperationResponse"
 import DeleteConfirmation from "./DeleteConfirmation"
 import { factories } from "../factories"
 
@@ -14,7 +13,7 @@ jest.mock("@react-navigation/native")
 describe("DeleteConfirmation", () => {
   it("allows users to delete their data", async () => {
     const deleteAllEntriesSpy = jest.fn()
-    deleteAllEntriesSpy.mockResolvedValueOnce(SUCCESS_RESPONSE)
+    deleteAllEntriesSpy.mockResolvedValueOnce({ kind: "success" })
 
     const { getByLabelText } = render(
       <OnboardingProvider userHasCompletedOnboarding={false}>
@@ -38,7 +37,7 @@ describe("DeleteConfirmation", () => {
     it("presents a success message", async () => {
       const showMessageSpy = showMessage as jest.Mock
       const deleteAllEntriesSpy = jest.fn()
-      deleteAllEntriesSpy.mockResolvedValueOnce(SUCCESS_RESPONSE)
+      deleteAllEntriesSpy.mockResolvedValueOnce({ kind: "success" })
 
       const { getByLabelText } = render(
         <OnboardingProvider userHasCompletedOnboarding={false}>

--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -13,7 +13,6 @@ import { useOnboardingContext } from "../OnboardingContext"
 import { useSymptomHistoryContext } from "../SymptomHistory/SymptomHistoryContext"
 import { Text } from "../components"
 import { useStatusBarEffect } from "../navigation"
-import { SUCCESS_RESPONSE } from "../OperationResponse"
 
 import { Spacing, Buttons, Typography, Colors, Affordances } from "../styles"
 
@@ -25,7 +24,7 @@ const DeleteConfirmation: FunctionComponent = () => {
   const { t } = useTranslation()
   const handleOnPressDeleteAllData = async () => {
     const deleteLogEntriesResult = await deleteAllEntries()
-    if (deleteLogEntriesResult === SUCCESS_RESPONSE) {
+    if (deleteLogEntriesResult.kind === "success") {
       resetOnboarding()
       showMessage({
         message: t("settings.data_deleted"),

--- a/src/SymptomHistory/SymptomHistoryContext.spec.tsx
+++ b/src/SymptomHistory/SymptomHistoryContext.spec.tsx
@@ -136,6 +136,7 @@ describe("SymptomHistoryProvider", () => {
         await waitFor(() => {
           expect(resultSpy).toHaveBeenCalledWith({
             kind: "failure",
+            error: "error",
           })
           expect(loggerSpy).toHaveBeenCalledWith(errorMessage)
         })

--- a/src/SymptomHistory/SymptomHistoryContext.tsx
+++ b/src/SymptomHistory/SymptomHistoryContext.tsx
@@ -13,11 +13,7 @@ import {
 } from "./symptomHistory"
 import { Symptom } from "./symptom"
 import * as NativeModule from "./nativeModule"
-import {
-  failureResponse,
-  OperationResponse,
-  SUCCESS_RESPONSE,
-} from "../OperationResponse"
+import { failureResponse, OperationResponse } from "../OperationResponse"
 
 export type SymptomHistoryState = {
   symptomHistory: SymptomHistory
@@ -30,10 +26,10 @@ export type SymptomHistoryState = {
 const initialState: SymptomHistoryState = {
   symptomHistory: [],
   updateEntry: (_entry: SymptomEntry, _newUserInput: Set<Symptom>) => {
-    return Promise.resolve(SUCCESS_RESPONSE)
+    return Promise.resolve({ kind: "success" })
   },
   deleteAllEntries: () => {
-    return Promise.resolve(SUCCESS_RESPONSE)
+    return Promise.resolve({ kind: "success" })
   },
 }
 
@@ -66,27 +62,27 @@ export const SymptomHistoryProvider: FunctionComponent = ({ children }) => {
   const updateEntry = async (
     entry: SymptomEntry,
     newSymptoms: Set<Symptom>,
-  ) => {
+  ): Promise<OperationResponse> => {
     try {
       if (entry.kind === "UserInput") {
         await NativeModule.updateEntry(entry.id, entry.date, newSymptoms)
         await fetchEntries()
-        return SUCCESS_RESPONSE
+        return { kind: "success" }
       } else {
         await NativeModule.createEntry(entry.date, newSymptoms)
         await fetchEntries()
-        return SUCCESS_RESPONSE
+        return { kind: "success" }
       }
     } catch (e) {
       return failureResponse(e.message)
     }
   }
 
-  const deleteAllEntries = async () => {
+  const deleteAllEntries = async (): Promise<OperationResponse> => {
     try {
       await NativeModule.deleteAllEntries()
       await fetchEntries()
-      return SUCCESS_RESPONSE
+      return { kind: "success" }
     } catch (e) {
       return failureResponse(e.message)
     }

--- a/src/factories/exposureContext.tsx
+++ b/src/factories/exposureContext.tsx
@@ -1,6 +1,5 @@
 import { Factory } from "fishery"
 import { ExposureState } from "../ExposureContext"
-import { SUCCESS_RESPONSE } from "../OperationResponse"
 
 export default Factory.define<ExposureState>(() => ({
   exposureInfo: [],
@@ -10,5 +9,5 @@ export default Factory.define<ExposureState>(() => ({
   storeRevisionToken: (_revisionToken: string) => Promise.resolve(),
   getRevisionToken: () => Promise.resolve(""),
   refreshExposureInfo: () => {},
-  checkForNewExposures: () => Promise.resolve(SUCCESS_RESPONSE),
+  checkForNewExposures: () => Promise.resolve({ kind: "success" }),
 }))


### PR DESCRIPTION
#### Why:
We'd like to handle the case where the daily exposure detection threshold has been exceeded by circumventing the `Failure` UI. Users should be able to press the manual exposure detection button as often as they'd like without being exposed to messaging for this specific error. 

#### This commit:
This commit adds a check for the specific error code representing the case in which a user has exceeded the maximum number of daily calls to the exposure notifications framework, and presents the `Success` UI in that case

co-authored by: John Schoeman <john.schoeman@thoughtbot.com>
co-authored by: Devin Jameson <devin.jameson@thoughtbot.com>