### PR TITLE
Add trend info to covid data widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "react-native-simple-crypto": "^0.2.12",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.0.3",
-    "reanimated-bottom-sheet": "^1.0.0-alpha.19"
+    "reanimated-bottom-sheet": "^1.0.0-alpha.19",
+    "regression": "^2.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",
@@ -80,6 +81,7 @@
     "@types/react-native": "^0.63.20",
     "@types/react-navigation": "^3.4.0",
     "@types/react-test-renderer": "^16.9.2",
+    "@types/regression": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "babel-jest": "^26.2.2",

--- a/src/CovidData/Card/CovidDataCard.tsx
+++ b/src/CovidData/Card/CovidDataCard.tsx
@@ -61,15 +61,12 @@ const CovidDataCard: FunctionComponent<CovidDataCardProps> = ({
     }
   }
 
-  const headerText = t("covid_data.covid_coverage")
-
   return (
     <TouchableOpacity
       accessibilityLabel={t("covid_data.see_more")}
       onPress={handleOnPressCard}
       style={style.container}
     >
-      <Text style={style.sectionHeaderText}>{headerText}</Text>
       <View style={style.contentContainer}>{determineContent()}</View>
       <SectionButton text={t("common.more")} />
     </TouchableOpacity>
@@ -102,15 +99,10 @@ const style = StyleSheet.create({
     ...Affordances.floatingContainer,
   },
   contentContainer: {
-    marginVertical: Spacing.medium,
+    marginBottom: Spacing.xSmall,
   },
   errorMessageText: {
     ...Typography.error,
-  },
-  sectionHeaderText: {
-    ...Typography.header5,
-    marginBottom: Spacing.xxSmall,
-    color: Colors.neutral.black,
   },
   activityIndicatorContainer: {
     flex: 1,

--- a/src/CovidData/LineChart.tsx
+++ b/src/CovidData/LineChart.tsx
@@ -26,21 +26,17 @@ const LineChart: FunctionComponent<LineChartProps> = ({
   // Scale Data
   const max = Math.max(...lineData)
   const min = Math.min(...lineData)
-  const shrinkPathBy = 2
-  const scaleFactor = height / (max - min) / shrinkPathBy
+  const shrinkYScaleBy = 1.25
+  const scaleFactor = height / (max - min) / shrinkYScaleBy
   const toScale = (datum: number) => {
     return (datum - min) * scaleFactor
   }
 
   // Fit Path
-  const offset = height / 3
   const xPadding = 10
-  const firstXPosition = xPadding / 2
   const pathWidth = width - xPadding
   const xStepWidth = pathWidth / (lineData.length - 1)
-  const toOffset = (datum: number) => {
-    return datum + offset
-  }
+  const firstXPosition = xPadding / 2
   const toCoordinate = (datum: number, idx: number): SvgPath.Coordinate => {
     const xCoordinate = idx === 0 ? firstXPosition : idx * xStepWidth
     return [xCoordinate, height - datum]
@@ -49,8 +45,7 @@ const LineChart: FunctionComponent<LineChartProps> = ({
   const viewBox = `0 0 ${width} ${height}`
 
   const scaledData = lineData.map(toScale)
-  const offsetData = scaledData.map(toOffset)
-  const coordinates = offsetData.map(toCoordinate)
+  const coordinates = scaledData.map(toCoordinate)
   const trendLinePath = SvgPath.toSmoothBezier(coordinates)
 
   return (
@@ -107,7 +102,8 @@ const HorizontalLines: FunctionComponent<HorizontalLinesProps> = ({
     )
   }
 
-  const lineColor = Colors.neutral.shade75
+  const lineColor = Colors.neutral.shade25
+  const baseLineColor = Colors.neutral.shade75
   const horizontalLinesStartingYPosition = 0
   const [baseLineY, ...lineCoords] = buildHorizontalLineYPositions(
     horizontalLinesStartingYPosition,
@@ -133,7 +129,7 @@ const HorizontalLines: FunctionComponent<HorizontalLinesProps> = ({
       <HorizontalLine
         start={baseLineStart}
         end={baseLineEnd}
-        color={lineColor}
+        color={baseLineColor}
         strokeWidth={2}
       />
     </>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,10 +47,14 @@
     "deaths_today": "Deaths today",
     "down_from_last_week": "Down from last week",
     "error_getting_data": "Sorry, we could not fetch the latest COVID cases data for {{location}}.",
+    "past_7_days": "Past 7 days",
     "new_cases": "New Cases",
     "see_more": "See more",
+    "source": "source: {{source}}",
     "total_cases": "Total cases",
     "total_deaths": "Total deaths",
+    "trending_up": "Trending up",
+    "trending_down": "Trending down",
     "up_from_last_week": "Up from last week"
   },
   "errors": {

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -75,7 +75,7 @@ export const accent: Record<Accent, string> = {
   success100: "#24a36c",
   warning25: "#f9edcc",
   warning50: "#ffdc6f",
-  warning100: "#ffc000",
+  warning100: "#cf8321",
 }
 
 type Background = "primaryLight" | "primaryDark" | "secondaryLight"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,6 +1582,11 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/regression@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/regression/-/regression-2.0.0.tgz#0677ea78d7bdb37039c02ebbccf062042f756ae3"
+  integrity sha512-Ch2FD53M1HpFLL6zSTc/sfuyqQcIPy+/PV3xFT6QYtk9EOiMI29XOYmLNxBb1Y0lfMOR/NNa86J1gRc/1jGLyw==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -7050,6 +7055,11 @@ regjsparser@^0.6.4:
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.4.tgz#a769f8684308401a66e9b529d2436ff4d0666272"
   dependencies:
     jsesc "~0.5.0"
+
+regression@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regression/-/regression-2.0.1.tgz#8d29c3e8224a10850c35e337e85a8b2fac3b0c87"
+  integrity sha1-jSnD6CJKEIUMNeM36FqLL6w7DIc=
 
 remove-bom-buffer@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Why:
We would like to show the trend info for the new cases covid data line
chart.

This commit:
Introduces the regression library to calculate the trend in the data
array. We also added better styling of the text and showed the source. A
future commit would likely remove the regression library if we can
change the api we are consuming to one that has this data already
calculated.

Co-Authored-By: devin jameson <devin@thoughtbot.com>

----

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-29 at 15 09 57](https://user-images.githubusercontent.com/16049495/97621502-59dae180-19f9-11eb-99a2-b36007a6eb40.png)
