### PR TITLE
Refactor typography styles

### DIFF
--- a/src/Activation/AcceptTermsOfService.tsx
+++ b/src/Activation/AcceptTermsOfService.tsx
@@ -142,7 +142,7 @@ const style = StyleSheet.create({
     paddingBottom: Spacing.xxxLarge,
   },
   headerText: {
-    ...Typography.header1,
+    ...Typography.header.x60,
   },
   linksContainer: {
     marginBottom: Spacing.large,
@@ -164,13 +164,13 @@ const style = StyleSheet.create({
     flexWrap: "wrap",
   },
   linkText: {
-    ...Typography.body1,
-    fontSize: Typography.large,
+    ...Typography.body.x30,
+    fontSize: Typography.size.x50,
   },
   link: {
-    ...Typography.anchorLink,
+    ...Typography.button.anchorLink,
     flexWrap: "wrap",
-    fontSize: Typography.large,
+    fontSize: Typography.size.x50,
   },
   linkArrow: {
     flex: 1,
@@ -183,23 +183,23 @@ const style = StyleSheet.create({
     marginHorizontal: Spacing.xLarge,
   },
   checkboxText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     color: Colors.text.primary,
     flex: 1,
     paddingLeft: Spacing.medium,
-    fontSize: Typography.large,
+    fontSize: Typography.size.x50,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
   buttonDisabled: {
     ...Buttons.primary.disabled,
   },
   buttonDisabledText: {
-    ...Typography.buttonPrimaryDisabled,
+    ...Typography.button.primaryDisabled,
   },
 })
 

--- a/src/Activation/ActivateBluetooth.tsx
+++ b/src/Activation/ActivateBluetooth.tsx
@@ -115,28 +115,28 @@ const style = StyleSheet.create({
     marginBottom: Spacing.medium,
   },
   header: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.large,
   },
   subheader: {
-    ...Typography.header5,
+    ...Typography.header.x20,
     marginBottom: Spacing.xSmall,
   },
   body: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxLarge,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
   secondaryButton: {
     ...Buttons.secondary.base,
   },
   secondaryButtonText: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
   },
 })
 

--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -104,28 +104,28 @@ const style = StyleSheet.create({
     marginBottom: Spacing.medium,
   },
   header: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.large,
   },
   subheader: {
-    ...Typography.header5,
+    ...Typography.header.x20,
     marginBottom: Spacing.xSmall,
   },
   body: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxLarge,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
   secondaryButton: {
     ...Buttons.secondary.base,
   },
   secondaryButtonText: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
   },
 })
 

--- a/src/Activation/ActivateLocation.tsx
+++ b/src/Activation/ActivateLocation.tsx
@@ -105,28 +105,28 @@ const style = StyleSheet.create({
     marginBottom: Spacing.medium,
   },
   header: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.large,
   },
   subheader: {
-    ...Typography.header5,
+    ...Typography.header.x20,
     marginBottom: Spacing.xSmall,
   },
   body: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxLarge,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
   secondaryButton: {
     ...Buttons.secondary.base,
   },
   secondaryButtonText: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
   },
 })
 

--- a/src/Activation/ActivationSummary.tsx
+++ b/src/Activation/ActivationSummary.tsx
@@ -145,12 +145,12 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xxLarge,
   },
   headerText: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     textAlign: "center",
     marginBottom: Spacing.medium,
   },
   bodyText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     textAlign: "center",
   },
   button: {
@@ -158,13 +158,13 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xxSmall,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
   secondaryButton: {
     ...Buttons.secondary.base,
   },
   secondaryButtonText: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
   },
 })
 

--- a/src/Activation/NotificationPermissions.tsx
+++ b/src/Activation/NotificationPermissions.tsx
@@ -91,28 +91,28 @@ const style = StyleSheet.create({
     marginBottom: Spacing.medium,
   },
   header: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.large,
   },
   subheader: {
-    ...Typography.header5,
+    ...Typography.header.x20,
     marginBottom: Spacing.xSmall,
   },
   body: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxLarge,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
   secondaryButton: {
     ...Buttons.secondary.base,
   },
   secondaryButtonText: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
   },
 })
 

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -230,14 +230,14 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xxLarge,
   },
   header: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.xxSmall,
   },
   subheader: {
-    ...Typography.body1,
+    ...Typography.body.x30,
   },
   errorSubtitle: {
-    ...Typography.error,
+    ...Typography.utility.error,
     color: Colors.text.error,
     marginTop: Spacing.xxSmall,
     marginBottom: Spacing.small,
@@ -245,8 +245,8 @@ const style = StyleSheet.create({
   },
   codeInput: {
     ...Forms.textInput,
-    ...Typography.mediumBold,
-    fontSize: Typography.xLarge,
+    ...Typography.style.medium,
+    fontSize: Typography.size.x60,
     textAlignVertical: "center",
     textAlign: "center",
     letterSpacing: 4,
@@ -262,11 +262,11 @@ const style = StyleSheet.create({
     ...Buttons.primary.disabled,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
     marginRight: Spacing.small,
   },
   buttonDisabledText: {
-    ...Typography.buttonPrimaryDisabled,
+    ...Typography.button.primaryDisabled,
     marginRight: Spacing.small,
   },
 })

--- a/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
+++ b/src/AffectedUserFlow/CodeInput/EnableExposureNotifications.tsx
@@ -56,17 +56,17 @@ const style = StyleSheet.create({
     marginBottom: Spacing.huge,
   },
   header: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.small,
   },
   subheader: {
-    ...Typography.body2,
+    ...Typography.body.x20,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
 })
 

--- a/src/AffectedUserFlow/Complete.tsx
+++ b/src/AffectedUserFlow/Complete.tsx
@@ -62,12 +62,12 @@ const style = StyleSheet.create({
     resizeMode: "cover",
   },
   header: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     textAlign: "center",
     marginBottom: Spacing.medium,
   },
   contentText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     textAlign: "center",
     marginBottom: Spacing.xxxLarge,
   },
@@ -75,7 +75,7 @@ const style = StyleSheet.create({
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
 })
 

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -225,24 +225,24 @@ const createStyle = (insets: EdgeInsets) => {
       marginBottom: Spacing.small,
     },
     header: {
-      ...Typography.header1,
+      ...Typography.header.x60,
       paddingBottom: Spacing.medium,
     },
     subheaderText: {
-      ...Typography.body1,
-      ...Typography.mediumBold,
+      ...Typography.body.x30,
+      ...Typography.style.medium,
       color: Colors.neutral.black,
       marginBottom: Spacing.xxSmall,
     },
     bodyText: {
-      ...Typography.body1,
+      ...Typography.body.x30,
       marginBottom: Spacing.xxLarge,
     },
     button: {
       ...Buttons.primary.base,
     },
     buttonText: {
-      ...Typography.buttonPrimary,
+      ...Typography.button.primary,
     },
     bottomButtonContainer: {
       backgroundColor: Colors.secondary.shade10,
@@ -253,7 +253,7 @@ const createStyle = (insets: EdgeInsets) => {
       paddingBottom: insets.bottom + Spacing.small,
     },
     bottomButtonText: {
-      ...Typography.header5,
+      ...Typography.header.x20,
       color: Colors.primary.shade100,
       marginRight: Spacing.xSmall,
     },

--- a/src/AffectedUserFlow/Start.tsx
+++ b/src/AffectedUserFlow/Start.tsx
@@ -71,14 +71,14 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
   },
   header: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.xLarge,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
     marginRight: Spacing.small,
   },
 })

--- a/src/CallEmergencyServices.tsx
+++ b/src/CallEmergencyServices.tsx
@@ -89,11 +89,11 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
   },
   headerText: {
-    ...Typography.header2,
+    ...Typography.header.x50,
     marginBottom: Spacing.medium,
   },
   bodyText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xLarge,
   },
   buttonContainer: {
@@ -103,7 +103,7 @@ const style = StyleSheet.create({
     backgroundColor: Colors.accent.danger100,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
 })
 

--- a/src/Callback/Form.tsx
+++ b/src/Callback/Form.tsx
@@ -197,22 +197,22 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
   },
   header: {
-    ...Typography.header2,
+    ...Typography.header.x50,
     marginBottom: Spacing.xxSmall,
   },
   subheader: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxSmall,
   },
   errorSubtitle: {
-    ...Typography.error,
+    ...Typography.utility.error,
     height: Spacing.huge,
   },
   inputContainer: {
     marginBottom: Spacing.medium,
   },
   inputLabel: {
-    ...Typography.formInputLabel,
+    ...Typography.form.inputLabel,
     paddingBottom: Spacing.xxSmall,
   },
   textInput: {
@@ -225,10 +225,10 @@ const style = StyleSheet.create({
     ...Buttons.primary.disabled,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
   buttonDisabledText: {
-    ...Typography.buttonPrimaryDisabled,
+    ...Typography.button.primaryDisabled,
   },
 })
 

--- a/src/Callback/Success.tsx
+++ b/src/Callback/Success.tsx
@@ -69,11 +69,11 @@ const style = StyleSheet.create({
     justifyContent: "center",
   },
   header: {
-    ...Typography.header2,
+    ...Typography.header.x50,
     marginBottom: Spacing.medium,
   },
   body: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.large,
   },
   image: {
@@ -85,7 +85,7 @@ const style = StyleSheet.create({
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
 })
 

--- a/src/CovidData/Card/CovidDataCard.tsx
+++ b/src/CovidData/Card/CovidDataCard.tsx
@@ -102,7 +102,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xSmall,
   },
   errorMessageText: {
-    ...Typography.error,
+    ...Typography.utility.error,
   },
   activityIndicatorContainer: {
     flex: 1,

--- a/src/CovidData/Card/CovidDataInfo.tsx
+++ b/src/CovidData/Card/CovidDataInfo.tsx
@@ -71,7 +71,7 @@ const CovidDataInfo: FunctionComponent<CovidDataInfoProps> = ({
 
 const style = StyleSheet.create({
   headerText: {
-    ...Typography.body2,
+    ...Typography.body.x20,
   },
   dataContainer: {
     flexDirection: "row",
@@ -84,16 +84,16 @@ const style = StyleSheet.create({
     flex: 3,
   },
   legendText: {
-    ...Typography.body2,
+    ...Typography.body.x20,
   },
   trendText: {
-    ...Typography.header3,
-    ...Typography.semiBold,
-    lineHeight: Typography.mediumLineHeight,
+    ...Typography.header.x30,
+    ...Typography.style.semibold,
+    lineHeight: Typography.lineHeight.x40,
   },
   sourceText: {
-    ...Typography.body3,
-    ...Typography.xxSmallFont,
+    ...Typography.body.x30,
+    ...Typography.base.x10,
   },
 })
 

--- a/src/CovidData/Dashboard/StateData.tsx
+++ b/src/CovidData/Dashboard/StateData.tsx
@@ -52,8 +52,8 @@ const style = StyleSheet.create({
     borderBottomColor: Colors.neutral.shade30,
   },
   headerText: {
-    ...Typography.header4,
-    ...Typography.bold,
+    ...Typography.header.x30,
+    ...Typography.style.bold,
     paddingBottom: Spacing.xSmall,
   },
   labelAndDataContainer: {
@@ -62,7 +62,7 @@ const style = StyleSheet.create({
     paddingTop: Spacing.xxSmall,
   },
   dataText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
   },
 })
 

--- a/src/CovidData/PercentageChart.tsx
+++ b/src/CovidData/PercentageChart.tsx
@@ -72,13 +72,13 @@ const style = StyleSheet.create({
     paddingRight: Spacing.xxSmall,
   },
   percentageText: {
-    ...Typography.body1,
-    ...Typography.bold,
+    ...Typography.body.x30,
+    ...Typography.style.bold,
     color: Colors.neutral.black,
   },
   headerText: {
-    ...Typography.header4,
-    ...Typography.base,
+    ...Typography.header.x30,
+    ...Typography.style.normal,
   },
 })
 

--- a/src/ErrorScreen.tsx
+++ b/src/ErrorScreen.tsx
@@ -58,21 +58,21 @@ const style = StyleSheet.create({
     paddingBottom: Spacing.large,
   },
   title: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.small,
   },
   subtitle: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxSmall,
   },
   error: {
-    ...Typography.error,
+    ...Typography.utility.error,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
     textAlign: "center",
   },
 })

--- a/src/ExposureHistory/ExposureDetail.tsx
+++ b/src/ExposureHistory/ExposureDetail.tsx
@@ -82,13 +82,13 @@ const style = StyleSheet.create({
     alignItems: "center",
   },
   exposureWindowText: {
-    ...Typography.header6,
+    ...Typography.header.x10,
     textTransform: "uppercase",
     color: Colors.neutral.shade110,
     marginLeft: Spacing.xSmall,
   },
   headerText: {
-    ...Typography.header2,
+    ...Typography.header.x50,
     color: Colors.primary.shade125,
     marginBottom: Spacing.medium,
   },

--- a/src/ExposureHistory/History/DateInfoHeader.tsx
+++ b/src/ExposureHistory/History/DateInfoHeader.tsx
@@ -43,7 +43,7 @@ const DateInfoHeader: FunctionComponent<DateInfoHeaderProps> = ({
 
 const style = StyleSheet.create({
   subHeaderText: {
-    ...Typography.header6,
+    ...Typography.header.x10,
     textTransform: "uppercase",
     color: Colors.neutral.shade140,
   },

--- a/src/ExposureHistory/History/ExposureListItem.tsx
+++ b/src/ExposureHistory/History/ExposureListItem.tsx
@@ -88,13 +88,13 @@ const style = StyleSheet.create({
     alignItems: "center",
   },
   primaryText: {
-    ...Typography.header6,
+    ...Typography.header.x10,
   },
   secondaryText: {
-    ...Typography.body3,
+    ...Typography.body.x10,
     textTransform: "uppercase",
     marginTop: Spacing.xxSmall,
-    letterSpacing: Typography.mediumLetterSpacing,
+    letterSpacing: Typography.letterSpacing.x20,
   },
 })
 

--- a/src/ExposureHistory/History/NoExposures.tsx
+++ b/src/ExposureHistory/History/NoExposures.tsx
@@ -119,12 +119,12 @@ const style = StyleSheet.create({
     marginHorizontal: Spacing.medium,
   },
   headerText: {
-    ...Typography.header5,
+    ...Typography.header.x20,
     paddingBottom: Spacing.xxxSmall,
     color: Colors.neutral.white,
   },
   subheaderText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     color: Colors.secondary.shade10,
   },
   card: {
@@ -132,11 +132,11 @@ const style = StyleSheet.create({
     marginHorizontal: Spacing.medium,
   },
   cardHeaderText: {
-    ...Typography.header3,
+    ...Typography.header.x40,
     paddingBottom: Spacing.xSmall,
   },
   cardSubheaderText: {
-    ...Typography.body2,
+    ...Typography.body.x20,
     paddingBottom: Spacing.large,
   },
   learnMoreCtaContainer: {
@@ -145,14 +145,14 @@ const style = StyleSheet.create({
     paddingBottom: Spacing.large,
   },
   learnMoreCta: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
     color: Colors.primary.shade125,
   },
   ctaArrow: {
     marginLeft: Spacing.xxSmall,
   },
   listHeading: {
-    ...Typography.header5,
+    ...Typography.header.x20,
     paddingBottom: Spacing.medium,
   },
   listItem: {
@@ -165,7 +165,7 @@ const style = StyleSheet.create({
     width: Spacing.huge,
   },
   listItemText: {
-    ...Typography.body2,
+    ...Typography.body.x20,
   },
 })
 

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -147,8 +147,8 @@ const style = StyleSheet.create({
     marginHorizontal: Spacing.medium,
   },
   headerText: {
-    ...Typography.header1,
-    ...Typography.bold,
+    ...Typography.header.x60,
+    ...Typography.style.bold,
     marginRight: Spacing.medium,
   },
   moreInfoButton: {
@@ -175,7 +175,7 @@ const style = StyleSheet.create({
     ...Buttons.fixedBottom.base,
   },
   buttonText: {
-    ...Typography.buttonFixedBottom,
+    ...Typography.button.fixedBottom,
   },
 })
 

--- a/src/ExposureHistory/MoreInfo.tsx
+++ b/src/ExposureHistory/MoreInfo.tsx
@@ -47,13 +47,13 @@ const style = StyleSheet.create({
     paddingBottom: Spacing.xLarge,
   },
   headerText: {
-    ...Typography.header5,
+    ...Typography.header.x20,
   },
   section: {
     paddingBottom: Spacing.xLarge,
   },
   contentText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     paddingTop: Spacing.small,
   },
   backIconContainer: {

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -173,11 +173,11 @@ const RecommendationBubble: FunctionComponent<RecommendationBubbleProps> = ({
 
 const style = StyleSheet.create({
   bottomHeaderText: {
-    ...Typography.header4,
+    ...Typography.header.x30,
     marginBottom: Spacing.xxSmall,
   },
   bottomSubheaderText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     color: Colors.neutral.shade100,
     marginBottom: Spacing.medium,
   },
@@ -200,10 +200,10 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xSmall,
   },
   recommendationText: {
-    ...Typography.body3,
+    ...Typography.body.x10,
   },
   connectivityWarningText: {
-    ...Typography.error,
+    ...Typography.utility.error,
     marginTop: Spacing.small,
   },
   button: {
@@ -211,7 +211,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
     marginRight: Spacing.small,
   },
   buttonOutlined: {
@@ -219,7 +219,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
   },
   buttonOutlinedText: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
     marginRight: Spacing.small,
   },
 })

--- a/src/Home/ActivationStatusView.tsx
+++ b/src/Home/ActivationStatusView.tsx
@@ -140,9 +140,9 @@ const style = StyleSheet.create({
     borderColor: Colors.neutral.shade10,
   },
   systemServiceText: {
-    ...Typography.header3,
+    ...Typography.header.x40,
     color: Colors.neutral.black,
-    lineHeight: Typography.smallLineHeight,
+    lineHeight: Typography.lineHeight.x30,
     marginBottom: Spacing.xSmall,
   },
   statusTextContainer: {
@@ -152,17 +152,17 @@ const style = StyleSheet.create({
     borderRadius: Outlines.baseBorderRadius,
   },
   statusText: {
-    ...Typography.body2,
-    ...Typography.bold,
+    ...Typography.body.x20,
+    ...Typography.style.bold,
     color: Colors.neutral.white,
-    lineHeight: Typography.xSmallLineHeight,
+    lineHeight: Typography.lineHeight.x20,
   },
   bottomContainer: {
     flexDirection: "row",
     alignItems: "center",
   },
   actionText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     color: Colors.neutral.black,
     marginRight: Spacing.xxSmall,
     paddingBottom: 2,

--- a/src/Home/BluetoothInfo.tsx
+++ b/src/Home/BluetoothInfo.tsx
@@ -45,7 +45,7 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
   },
   bodyText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
   },
 })
 export default BluetoothInfo

--- a/src/Home/ExposureDetectionStatus.tsx
+++ b/src/Home/ExposureDetectionStatus.tsx
@@ -198,12 +198,12 @@ const style = StyleSheet.create({
     backgroundColor: Colors.background.primaryLight,
   },
   headerText: {
-    ...Typography.header1,
-    ...Typography.bold,
+    ...Typography.header.x60,
+    ...Typography.style.bold,
     marginBottom: Spacing.xSmall,
   },
   subheaderText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xLarge,
   },
 })

--- a/src/Home/ExposureNotificationsInfo.tsx
+++ b/src/Home/ExposureNotificationsInfo.tsx
@@ -46,13 +46,13 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
   },
   subheaderText: {
-    ...Typography.body1,
-    ...Typography.mediumBold,
+    ...Typography.body.x30,
+    ...Typography.style.medium,
     color: Colors.text.primary,
     marginBottom: Spacing.medium,
   },
   bodyText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxLarge,
   },
 })

--- a/src/Home/LocationInfo.tsx
+++ b/src/Home/LocationInfo.tsx
@@ -38,13 +38,13 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
   },
   subheaderText: {
-    ...Typography.body1,
-    ...Typography.mediumBold,
+    ...Typography.body.x30,
+    ...Typography.style.medium,
     color: Colors.text.primary,
     marginBottom: Spacing.medium,
   },
   bodyText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxLarge,
   },
 })

--- a/src/Home/SectionButton.tsx
+++ b/src/Home/SectionButton.tsx
@@ -29,7 +29,7 @@ const style = StyleSheet.create({
     ...Buttons.card.base,
   },
   sectionButtonText: {
-    ...Typography.buttonCard,
+    ...Typography.button.card,
   },
 })
 

--- a/src/Home/ShareLink.tsx
+++ b/src/Home/ShareLink.tsx
@@ -87,8 +87,8 @@ const style = StyleSheet.create({
     marginLeft: Spacing.medium,
   },
   shareText: {
-    ...Typography.body1,
-    ...Typography.mediumBold,
+    ...Typography.body.x30,
+    ...Typography.style.medium,
     color: Colors.text.primary,
   },
 })

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -270,8 +270,8 @@ const style = StyleSheet.create({
     backgroundColor: Colors.background.primaryLight,
   },
   headerText: {
-    ...Typography.header1,
-    ...Typography.bold,
+    ...Typography.header.x60,
+    ...Typography.style.bold,
     marginBottom: Spacing.medium,
   },
   statusContainer: {
@@ -291,7 +291,7 @@ const style = StyleSheet.create({
     zIndex: Layout.zLevel1,
   },
   statusText: {
-    ...Typography.header3,
+    ...Typography.header.x40,
     color: Colors.neutral.black,
   },
   statusBottomContainer: {
@@ -299,7 +299,7 @@ const style = StyleSheet.create({
     alignItems: "center",
   },
   statusActionText: {
-    ...Typography.body2,
+    ...Typography.body.x20,
     color: Colors.neutral.black,
     marginRight: Spacing.xxxSmall,
     paddingBottom: 2,
@@ -312,14 +312,14 @@ const style = StyleSheet.create({
     marginBottom: Spacing.small,
   },
   sectionHeaderText: {
-    ...Typography.header3,
+    ...Typography.header.x40,
     color: Colors.neutral.black,
     marginBottom: Spacing.xSmall,
   },
   sectionBodyText: {
-    ...Typography.header5,
-    ...Typography.base,
-    lineHeight: Typography.mediumLineHeight,
+    ...Typography.header.x20,
+    ...Typography.style.normal,
+    lineHeight: Typography.lineHeight.x40,
     color: Colors.neutral.shade100,
     marginBottom: Spacing.xLarge,
   },
@@ -335,7 +335,7 @@ const style = StyleSheet.create({
     backgroundColor: Colors.accent.danger100,
   },
   emergencyButtonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
     marginLeft: Spacing.small,
   },
 })

--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -127,7 +127,7 @@ const createStyle = (insets: EdgeInsets) => {
       marginBottom: Spacing.medium,
     },
     headerText: {
-      ...Typography.header2,
+      ...Typography.header.x50,
       marginBottom: Spacing.xLarge,
       paddingHorizontal: Spacing.large,
     },
@@ -136,7 +136,7 @@ const createStyle = (insets: EdgeInsets) => {
       marginBottom: Spacing.small,
     },
     buttonText: {
-      ...Typography.buttonPrimary,
+      ...Typography.button.primary,
       marginRight: Spacing.small,
     },
     bottomButtonContainer: {
@@ -146,7 +146,7 @@ const createStyle = (insets: EdgeInsets) => {
       backgroundColor: Colors.background.primaryLight,
     },
     bottomButtonText: {
-      ...Typography.header5,
+      ...Typography.header.x20,
       color: Colors.primary.shade100,
       paddingHorizontal: Spacing.large,
       textAlign: "center",

--- a/src/SelfAssessment/AgeRangeQuestion.tsx
+++ b/src/SelfAssessment/AgeRangeQuestion.tsx
@@ -138,7 +138,7 @@ const createStyle = (insets: EdgeInsets) => {
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     headerText: {
-      ...Typography.header1,
+      ...Typography.header.x60,
       marginBottom: Spacing.medium,
     },
     radioContainer: {
@@ -156,11 +156,11 @@ const createStyle = (insets: EdgeInsets) => {
       paddingBottom: insets.bottom + Spacing.small,
     },
     buttonText: {
-      ...Typography.buttonFixedBottom,
+      ...Typography.button.fixedBottom,
       marginRight: Spacing.small,
     },
     buttonDisabledText: {
-      ...Typography.buttonFixedBottomDisabled,
+      ...Typography.button.fixedBottomDisabled,
       marginRight: Spacing.small,
     },
     pressing: {

--- a/src/SelfAssessment/EmergencySymptomsQuestions.tsx
+++ b/src/SelfAssessment/EmergencySymptomsQuestions.tsx
@@ -102,12 +102,12 @@ const createStyle = (insets: EdgeInsets) => {
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     headerText: {
-      ...Typography.header1,
+      ...Typography.header.x60,
       marginBottom: Spacing.medium,
     },
     subheaderText: {
-      ...Typography.header4,
-      ...Typography.base,
+      ...Typography.header.x30,
+      ...Typography.style.normal,
       marginBottom: Spacing.huge,
     },
     button: {
@@ -115,7 +115,7 @@ const createStyle = (insets: EdgeInsets) => {
       paddingBottom: insets.bottom + Spacing.small,
     },
     buttonText: {
-      ...Typography.buttonFixedBottom,
+      ...Typography.button.fixedBottom,
       marginRight: Spacing.small,
     },
   })

--- a/src/SelfAssessment/GeneralSymptoms.tsx
+++ b/src/SelfAssessment/GeneralSymptoms.tsx
@@ -144,12 +144,12 @@ const createStyle = (insets: EdgeInsets) => {
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     headerText: {
-      ...Typography.header1,
+      ...Typography.header.x60,
       marginBottom: Spacing.medium,
     },
     subheaderText: {
-      ...Typography.header4,
-      ...Typography.base,
+      ...Typography.header.x30,
+      ...Typography.style.normal,
       marginBottom: Spacing.huge,
     },
     button: {
@@ -161,11 +161,11 @@ const createStyle = (insets: EdgeInsets) => {
       paddingBottom: insets.bottom + Spacing.small,
     },
     buttonText: {
-      ...Typography.buttonFixedBottom,
+      ...Typography.button.fixedBottom,
       marginRight: Spacing.small,
     },
     buttonDisabledText: {
-      ...Typography.buttonFixedBottomDisabled,
+      ...Typography.button.fixedBottomDisabled,
       marginRight: Spacing.small,
     },
   })

--- a/src/SelfAssessment/Guidance.tsx
+++ b/src/SelfAssessment/Guidance.tsx
@@ -275,12 +275,12 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xLarge,
   },
   headerText: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.xxSmall,
   },
   subheaderText: {
-    ...Typography.header4,
-    ...Typography.base,
+    ...Typography.header.x30,
+    ...Typography.style.normal,
     color: Colors.neutral.black,
   },
   bottomContainer: {
@@ -289,13 +289,13 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xxLarge,
   },
   bullet1: {
-    ...Typography.header4,
+    ...Typography.header.x30,
     color: Colors.primary.shade100,
     marginBottom: Spacing.medium,
   },
   bullet2: {
-    ...Typography.body1,
-    ...Typography.mediumBold,
+    ...Typography.body.x30,
+    ...Typography.style.medium,
     color: Colors.text.primary,
     marginBottom: Spacing.small,
   },
@@ -307,7 +307,7 @@ const style = StyleSheet.create({
     borderLeftColor: Colors.neutral.shade25,
   },
   bullet3: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxSmall,
   },
   button: {
@@ -315,7 +315,7 @@ const style = StyleSheet.create({
     marginTop: Spacing.medium,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
     marginRight: Spacing.small,
   },
   doneButton: {
@@ -323,7 +323,7 @@ const style = StyleSheet.create({
     marginTop: Spacing.small,
   },
   doneButtonText: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
   },
 })
 

--- a/src/SelfAssessment/HowAreYouFeeling.tsx
+++ b/src/SelfAssessment/HowAreYouFeeling.tsx
@@ -83,7 +83,7 @@ const feelingButtonHeight = 120
 
 const style = StyleSheet.create({
   headerText: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.medium,
   },
   contentContainer: {
@@ -109,8 +109,8 @@ const style = StyleSheet.create({
     alignItems: "center",
   },
   feelingButtonText: {
-    ...Typography.body1,
-    fontSize: Typography.large,
+    ...Typography.body.x30,
+    fontSize: Typography.size.x50,
   },
   feelingButtonImage: {
     resizeMode: "contain",

--- a/src/SelfAssessment/SelfAssessmentIntro.tsx
+++ b/src/SelfAssessment/SelfAssessmentIntro.tsx
@@ -89,12 +89,12 @@ const style = StyleSheet.create({
     marginBottom: Spacing.large,
   },
   headerText: {
-    ...Typography.header1,
-    ...Typography.bold,
+    ...Typography.header.x60,
+    ...Typography.style.bold,
     marginBottom: Spacing.xSmall,
   },
   subheaderText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     color: Colors.text.primary,
     marginBottom: Spacing.large,
   },
@@ -105,18 +105,18 @@ const style = StyleSheet.create({
     borderTopWidth: Outlines.hairline,
   },
   bulletText: {
-    ...Typography.body2,
+    ...Typography.body.x20,
     marginBottom: Spacing.medium,
   },
   emergencyText: {
-    ...Typography.error,
-    ...Typography.mediumBold,
+    ...Typography.utility.error,
+    ...Typography.style.medium,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
     marginRight: Spacing.small,
   },
 })

--- a/src/SelfAssessment/UnderlyingConditions.tsx
+++ b/src/SelfAssessment/UnderlyingConditions.tsx
@@ -158,12 +158,12 @@ const createStyle = (insets: EdgeInsets) => {
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     headerText: {
-      ...Typography.header1,
+      ...Typography.header.x60,
       marginBottom: Spacing.medium,
     },
     subheaderText: {
-      ...Typography.header4,
-      ...Typography.base,
+      ...Typography.header.x30,
+      ...Typography.style.normal,
       marginBottom: Spacing.huge,
     },
     button: {
@@ -171,7 +171,7 @@ const createStyle = (insets: EdgeInsets) => {
       paddingBottom: insets.bottom + Spacing.small,
     },
     buttonText: {
-      ...Typography.buttonFixedBottom,
+      ...Typography.button.fixedBottom,
       marginRight: Spacing.small,
     },
   })

--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -79,16 +79,16 @@ const style = StyleSheet.create({
     paddingHorizontal: Spacing.large,
   },
   headerText: {
-    ...Typography.header2,
-    ...Typography.semiBold,
+    ...Typography.header.x50,
+    ...Typography.style.semibold,
     marginBottom: Spacing.medium,
   },
   bodyText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxxLarge,
   },
   subheaderText: {
-    ...Typography.header4,
+    ...Typography.header.x30,
     marginBottom: Spacing.xxSmall,
   },
   buttonContainer: {
@@ -96,7 +96,7 @@ const style = StyleSheet.create({
     backgroundColor: Colors.accent.danger100,
   },
   buttonText: {
-    ...Typography.buttonFixedBottom,
+    ...Typography.button.fixedBottom,
   },
 })
 

--- a/src/Settings/ENDebugMenu.tsx
+++ b/src/Settings/ENDebugMenu.tsx
@@ -196,7 +196,7 @@ const style = StyleSheet.create({
     borderColor: Colors.secondary.shade75,
   },
   listItemText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
   },
   lastListItem: {
     borderBottomWidth: 0,

--- a/src/Settings/ENLocalDiagnosisKeyScreen.tsx
+++ b/src/Settings/ENLocalDiagnosisKeyScreen.tsx
@@ -88,7 +88,7 @@ const style = StyleSheet.create({
     borderColor: "#999999",
   },
   itemText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     padding: 10,
     maxWidth: "90%",
   },

--- a/src/Settings/ExposureListDebugScreen.tsx
+++ b/src/Settings/ExposureListDebugScreen.tsx
@@ -52,12 +52,12 @@ const style = StyleSheet.create({
     borderColor: Colors.neutral.shade75,
   },
   itemText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     padding: Spacing.xSmall,
     maxWidth: "90%",
   },
   noExposureText: {
-    ...Typography.header5,
+    ...Typography.header.x20,
     padding: Spacing.medium,
   },
 })

--- a/src/Settings/ExternalLink.tsx
+++ b/src/Settings/ExternalLink.tsx
@@ -23,7 +23,7 @@ const ExternalLink: FunctionComponent<ExternalLinkProps> = ({ url, label }) => {
 
 const style = StyleSheet.create({
   externalLinkText: {
-    ...Typography.anchorLink,
+    ...Typography.button.anchorLink,
   },
 })
 

--- a/src/Settings/Legal.tsx
+++ b/src/Settings/Legal.tsx
@@ -68,12 +68,12 @@ const style = StyleSheet.create({
     paddingHorizontal: Spacing.small,
   },
   headerContent: {
-    ...Typography.header2,
+    ...Typography.header.x50,
     marginBottom: Spacing.small,
     color: Colors.primary.shade150,
   },
   contentText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.medium,
   },
 })

--- a/src/Settings/ShareAnonymizedDataListItem.tsx
+++ b/src/Settings/ShareAnonymizedDataListItem.tsx
@@ -79,7 +79,7 @@ const style = StyleSheet.create({
     flexDirection: "row",
   },
   listItemText: {
-    ...Typography.tappableListItem,
+    ...Typography.button.listItem,
   },
   rightIcon: {
     paddingRight: Spacing.medium,

--- a/src/Settings/index.tsx
+++ b/src/Settings/index.tsx
@@ -186,8 +186,8 @@ const style = StyleSheet.create({
     paddingHorizontal: Spacing.medium,
   },
   aboutContent: {
-    ...Typography.body1,
-    fontSize: Typography.large,
+    ...Typography.body.x30,
+    fontSize: Typography.size.x50,
   },
   infoRowContainer: {
     marginTop: Spacing.small,
@@ -197,13 +197,13 @@ const style = StyleSheet.create({
     flexDirection: "row",
   },
   infoRowLabel: {
-    ...Typography.header5,
+    ...Typography.header.x20,
     color: Colors.primary.shade150,
     width: 100,
     marginTop: Spacing.small,
   },
   infoRowValue: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginTop: Spacing.small,
   },
 })

--- a/src/SymptomHistory/SelectSymptoms.tsx
+++ b/src/SymptomHistory/SelectSymptoms.tsx
@@ -161,7 +161,7 @@ const style = StyleSheet.create({
     paddingHorizontal: Spacing.large,
   },
   dateText: {
-    ...Typography.header3,
+    ...Typography.header.x40,
     marginBottom: Spacing.small,
   },
   symptomButtonsContainer: {
@@ -177,7 +177,7 @@ const style = StyleSheet.create({
     ...Buttons.fixedBottom.base,
   },
   buttonText: {
-    ...Typography.buttonFixedBottom,
+    ...Typography.button.fixedBottom,
   },
 })
 

--- a/src/SymptomHistory/SymptomEntryListItem.tsx
+++ b/src/SymptomHistory/SymptomEntryListItem.tsx
@@ -144,7 +144,7 @@ const style = StyleSheet.create({
     zIndex: Layout.zLevel1,
   },
   headerText: {
-    ...Typography.header3,
+    ...Typography.header.x40,
     paddingRight: Spacing.xLarge,
   },
   symptomsContainer: {
@@ -152,7 +152,7 @@ const style = StyleSheet.create({
     marginTop: Spacing.small,
   },
   symptomText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.xxxSmall,
   },
   dateTextContainer: {
@@ -161,7 +161,7 @@ const style = StyleSheet.create({
     marginTop: Spacing.small,
   },
   dateText: {
-    ...Typography.monospace,
+    ...Typography.style.monospace,
     color: Colors.neutral.shade100,
     paddingTop: Spacing.xxSmall,
   },

--- a/src/SymptomHistory/index.tsx
+++ b/src/SymptomHistory/index.tsx
@@ -85,19 +85,19 @@ const style = StyleSheet.create({
     paddingHorizontal: Spacing.medium,
   },
   headerText: {
-    ...Typography.header1,
-    ...Typography.bold,
+    ...Typography.header.x60,
+    ...Typography.style.bold,
     marginBottom: Spacing.xxxSmall,
   },
   subHeaderText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.large,
   },
   shareButton: {
     ...Buttons.fixedBottom.base,
   },
   shareButtonText: {
-    ...Typography.buttonFixedBottom,
+    ...Typography.button.fixedBottom,
   },
 })
 

--- a/src/Welcome.tsx
+++ b/src/Welcome.tsx
@@ -123,8 +123,8 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xSmall,
   },
   languageButtonText: {
-    ...Typography.body3,
-    letterSpacing: Typography.largeLetterSpacing,
+    ...Typography.body.x10,
+    letterSpacing: Typography.letterSpacing.x30,
     color: Colors.primary.shade125,
     textAlign: "center",
     textTransform: "uppercase",
@@ -139,12 +139,12 @@ const style = StyleSheet.create({
     marginBottom: Spacing.huge,
   },
   welcomeToText: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     color: Colors.text.primary,
     textAlign: "center",
   },
   nameText: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     color: Colors.text.primary,
     textAlign: "center",
     marginBottom: Spacing.huge,
@@ -153,7 +153,7 @@ const style = StyleSheet.create({
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
     marginRight: Spacing.small,
   },
 })

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -46,7 +46,7 @@ const style = StyleSheet.create({
     paddingVertical: Spacing.large,
   },
   listItemText: {
-    ...Typography.tappableListItem,
+    ...Typography.button.listItem,
   },
 })
 

--- a/src/components/SwitchListItem.tsx
+++ b/src/components/SwitchListItem.tsx
@@ -40,7 +40,7 @@ const style = StyleSheet.create({
     alignItems: "center",
   },
   toggleText: {
-    ...Typography.tappableListItem,
+    ...Typography.button.listItem,
   },
 })
 

--- a/src/modals/AgeVerification.tsx
+++ b/src/modals/AgeVerification.tsx
@@ -62,12 +62,12 @@ const style = StyleSheet.create({
     alignItems: "center",
   },
   headerText: {
-    ...Typography.header2,
+    ...Typography.header.x50,
     textAlign: "center",
     marginBottom: Spacing.medium,
   },
   subheaderText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     textAlign: "center",
     marginBottom: Spacing.huge,
   },
@@ -76,13 +76,13 @@ const style = StyleSheet.create({
     marginBottom: Spacing.xSmall,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
   buttonSecondary: {
     ...Buttons.secondary.base,
   },
   buttonSecondaryText: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
   },
 })
 

--- a/src/modals/AnonymizedDataConsentScreen.tsx
+++ b/src/modals/AnonymizedDataConsentScreen.tsx
@@ -115,36 +115,36 @@ const style = StyleSheet.create({
     paddingHorizontal: Spacing.large,
   },
   headerText: {
-    ...Typography.header1,
+    ...Typography.header.x60,
     marginBottom: Spacing.large,
   },
   paragraph: {
-    ...Typography.body1,
+    ...Typography.body.x30,
   },
   privacyPolicyContainer: {
     flexDirection: "row",
     marginVertical: Spacing.small,
   },
   privacyPolicy: {
-    ...Typography.body1,
-    ...Typography.mediumBold,
+    ...Typography.body.x30,
+    ...Typography.style.medium,
     marginRight: Spacing.xxxSmall,
   },
   button: {
     ...Buttons.primary.base,
   },
   buttonText: {
-    ...Typography.buttonPrimary,
+    ...Typography.button.primary,
   },
   secondaryButton: {
     ...Buttons.secondary.base,
   },
   secondaryButtonText: {
-    ...Typography.buttonSecondary,
+    ...Typography.button.secondary,
   },
   disclaimer: {
     marginTop: Spacing.huge,
-    ...Typography.body2,
+    ...Typography.body.x20,
   },
 })
 

--- a/src/modals/LanguageSelection.tsx
+++ b/src/modals/LanguageSelection.tsx
@@ -83,10 +83,10 @@ const style = StyleSheet.create({
     paddingHorizontal: Spacing.large,
   },
   languageButtonText: {
-    ...Typography.tappableListItem,
+    ...Typography.button.listItem,
   },
   languageButtonTextSelected: {
-    ...Typography.semiBold,
+    ...Typography.style.semibold,
   },
 })
 

--- a/src/modals/ProtectPrivacy.tsx
+++ b/src/modals/ProtectPrivacy.tsx
@@ -108,11 +108,11 @@ const sectionStyle = StyleSheet.create({
     marginBottom: Spacing.huge,
   },
   subheaderText: {
-    ...Typography.header5,
+    ...Typography.header.x20,
     marginBottom: Spacing.medium,
   },
   bodyText: {
-    ...Typography.body1,
+    ...Typography.body.x30,
     marginBottom: Spacing.medium,
   },
 })

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -160,7 +160,7 @@ const ActivationStack: FunctionComponent = () => {
 
 const style = StyleSheet.create({
   headerTitle: {
-    ...Typography.header4,
+    ...Typography.header.x30,
     color: Colors.neutral.shade100,
     maxWidth: Layout.halfWidth,
   },

--- a/src/navigation/HowItWorksStack.tsx
+++ b/src/navigation/HowItWorksStack.tsx
@@ -159,7 +159,7 @@ const style = StyleSheet.create({
     padding: Spacing.xSmall,
   },
   skipButtonText: {
-    ...Typography.body2,
+    ...Typography.body.x20,
     color: Colors.neutral.shade100,
   },
 })

--- a/src/navigation/ModalHeader.tsx
+++ b/src/navigation/ModalHeader.tsx
@@ -83,7 +83,7 @@ const style = StyleSheet.create({
     borderColor: Colors.neutral.shade10,
   },
   headerText: {
-    ...Typography.header2,
+    ...Typography.header.x50,
     color: Colors.text.primary,
     maxWidth: Layout.screenWidth * 0.75,
   },

--- a/src/styles/affordances.ts
+++ b/src/styles/affordances.ts
@@ -21,7 +21,7 @@ export const iconBadge: ViewStyle = {
 type FlashMessageOptions = Omit<MessageOptions, "message">
 
 export const flashMessageOptions: FlashMessageOptions = {
-  titleStyle: { ...Typography.header3, color: Colors.neutral.black },
+  titleStyle: { ...Typography.header.x40, color: Colors.neutral.black },
   animationDuration: 100,
   floating: true,
   position: { top: Spacing.huge },

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -124,6 +124,7 @@ export const fixedBottomThin: Record<FixedBottomThin, ViewStyle> = {
 type Card = "base"
 const cardBase: ViewStyle = {
   ...base,
+  width: "auto",
   alignSelf: "flex-start",
   paddingVertical: Spacing.xxSmall,
   paddingHorizontal: Spacing.medium,

--- a/src/styles/forms.ts
+++ b/src/styles/forms.ts
@@ -12,7 +12,7 @@ export const textInputFormField: TextStyle = {
   borderColor: Colors.neutral.shade10,
   borderWidth: Outlines.hairline,
   justifyContent: "center",
-  fontSize: Typography.medium,
+  fontSize: Typography.size.x40,
   paddingTop: Spacing.small,
   paddingRight: Spacing.medium,
   paddingBottom: Spacing.small,
@@ -21,13 +21,13 @@ export const textInputFormField: TextStyle = {
 }
 
 export const required: TextStyle = {
-  fontSize: Typography.xSmall,
+  fontSize: Typography.size.x20,
   color: Colors.text.primary,
   marginTop: Spacing.xSmall,
 }
 
 export const textInput: TextStyle = {
-  ...Typography.formInputText,
+  ...Typography.form.inputText,
   borderRadius: Outlines.baseBorderRadius,
   borderColor: Colors.neutral.shade10,
   borderWidth: Outlines.hairline,
@@ -61,8 +61,8 @@ export const radioOrCheckboxContainer: ViewStyle = {
 }
 
 export const radioOrCheckboxText: TextStyle = {
-  ...Typography.body1,
-  ...Typography.largeFont,
+  ...Typography.body.x30,
+  ...Typography.base.x50,
   color: Colors.text.primary,
   width: "80%",
   marginLeft: Spacing.medium,

--- a/src/styles/headers.ts
+++ b/src/styles/headers.ts
@@ -9,9 +9,9 @@ export const headerStyle: ViewStyle = {
 }
 
 export const headerTitleStyle: TextStyle = {
-  ...Typography.mediumBold,
+  ...Typography.style.medium,
   color: Colors.header.text,
-  letterSpacing: Typography.mediumLetterSpacing,
+  letterSpacing: Typography.letterSpacing.x20,
   textTransform: "uppercase",
 }
 

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -3,239 +3,248 @@ import { TextStyle } from "react-native"
 import * as Colors from "./colors"
 import * as Spacing from "./spacing"
 
-// Font Size
-export const xxSmall = 10
-export const xSmall = 13
-export const small = 14
-export const medium = 16
-export const large = 18
-export const xLarge = 20
-export const xxLarge = 26
-export const xxxLarge = 30
-
-// Line Height
-export const xxSmallLineHeight = 18
-export const xSmallLineHeight = 20
-export const smallLineHeight = 20
-export const mediumLineHeight = 24
-export const largeLineHeight = 28
-export const xLargeLineHeight = 30
-export const xxLargeLineHeight = 32
-export const xxxLargeLineHeight = 34
-
-// Letter Spacing
-export const baseLetterSpacing = 0.25
-export const mediumLetterSpacing = 0.5
-export const largeLetterSpacing = 1
-export const xLargeLetterSpacing = 3
-
-// Font Weights
-export const baseWeight = "400"
-export const mediumWeight = "500"
-export const semiBoldWeight = "600"
-export const boldWeight = "700"
-
-// Font Family
-export const baseFontFamily = "IBMPlexSans"
-export const mediumFontFamily = "IBMPlexSans-Medium"
-export const semiBoldFontFamily = "IBMPlexSans-SemiBold"
-export const boldFontFamily = "IBMPlexSans-Bold"
-export const monospaceFontFamily = "IBMPlexMono"
-
-export const base: TextStyle = {
-  fontFamily: baseFontFamily,
-  fontWeight: baseWeight,
-  letterSpacing: baseLetterSpacing,
+type Size = "x10" | "x20" | "x30" | "x40" | "x50" | "x60" | "x70" | "x80"
+export const size: Record<Size, number> = {
+  x10: 10,
+  x20: 13,
+  x30: 14,
+  x40: 16,
+  x50: 18,
+  x60: 20,
+  x70: 26,
+  x80: 30,
 }
 
-export const mediumBold: TextStyle = {
-  fontFamily: mediumFontFamily,
-  fontWeight: mediumWeight,
-  letterSpacing: baseLetterSpacing,
+type LineHeight = "x10" | "x20" | "x30" | "x40" | "x50" | "x60" | "x70" | "x80"
+export const lineHeight: Record<LineHeight, number> = {
+  x10: 18,
+  x20: 20,
+  x30: 20,
+  x40: 24,
+  x50: 28,
+  x60: 30,
+  x70: 32,
+  x80: 34,
 }
 
-export const semiBold: TextStyle = {
-  fontFamily: semiBoldFontFamily,
-  fontWeight: semiBoldWeight,
-  letterSpacing: baseLetterSpacing,
+type LetterSpacing = "x10" | "x20" | "x30" | "x40"
+export const letterSpacing: Record<LetterSpacing, number> = {
+  x10: 0.25,
+  x20: 0.5,
+  x30: 1,
+  x40: 3,
 }
 
-export const bold: TextStyle = {
-  fontFamily: boldFontFamily,
-  fontWeight: boldWeight,
-  letterSpacing: baseLetterSpacing,
+type Weight = "base" | "medium" | "semibold" | "bold"
+type WeightOptions = "400" | "500" | "600" | "700"
+const weight: Record<Weight, WeightOptions> = {
+  base: "400",
+  medium: "500",
+  semibold: "600",
+  bold: "700",
 }
 
-export const monospace: TextStyle = {
-  fontFamily: monospaceFontFamily,
-  letterSpacing: baseLetterSpacing,
+type Family = "base" | "medium" | "semibold" | "bold" | "monospace"
+const family: Record<Family, string> = {
+  base: "IBMPlexSans",
+  medium: "IBMPlexSans-Medium",
+  semibold: "IBMPlexSans-SemiBold",
+  bold: "IBMPlexSans-Bold",
+  monospace: "IBMPlexMono",
 }
 
-// Standard Font Types
-export const xxSmallFont: TextStyle = {
-  ...base,
-  fontSize: xxSmall,
-  lineHeight: xxSmallLineHeight,
+type Style = "normal" | "medium" | "semibold" | "bold" | "monospace"
+export const style: Record<Style, TextStyle> = {
+  normal: {
+    fontFamily: family.base,
+    fontWeight: weight.base,
+    letterSpacing: letterSpacing.x10,
+  },
+  medium: {
+    fontFamily: family.medium,
+    fontWeight: weight.medium,
+    letterSpacing: letterSpacing.x10,
+  },
+  semibold: {
+    fontFamily: family.semibold,
+    fontWeight: weight.semibold,
+    letterSpacing: letterSpacing.x10,
+  },
+  bold: {
+    fontFamily: family.bold,
+    fontWeight: weight.bold,
+    letterSpacing: letterSpacing.x10,
+  },
+  monospace: {
+    fontFamily: family.monospace,
+    letterSpacing: letterSpacing.x10,
+  },
 }
 
-export const xSmallFont: TextStyle = {
-  ...base,
-  fontSize: xSmall,
-  lineHeight: xSmallLineHeight,
+type Base = "x10" | "x20" | "x30" | "x40" | "x50" | "x60" | "x70" | "x80"
+export const base: Record<Base, TextStyle> = {
+  x10: {
+    ...style.normal,
+    fontSize: size.x10,
+    lineHeight: lineHeight.x10,
+    color: Colors.text.primary,
+  },
+  x20: {
+    ...style.normal,
+    fontSize: size.x20,
+    lineHeight: lineHeight.x20,
+    color: Colors.text.primary,
+  },
+  x30: {
+    ...style.normal,
+    fontSize: size.x30,
+    lineHeight: lineHeight.x30,
+    color: Colors.text.primary,
+  },
+  x40: {
+    ...style.normal,
+    fontSize: size.x40,
+    lineHeight: lineHeight.x40,
+    color: Colors.text.primary,
+  },
+  x50: {
+    ...style.normal,
+    fontSize: size.x50,
+    lineHeight: lineHeight.x50,
+    color: Colors.text.primary,
+  },
+  x60: {
+    ...style.normal,
+    fontSize: size.x60,
+    lineHeight: lineHeight.x60,
+    color: Colors.text.primary,
+  },
+  x70: {
+    ...style.normal,
+    fontSize: size.x70,
+    lineHeight: lineHeight.x70,
+    color: Colors.text.primary,
+  },
+  x80: {
+    ...style.normal,
+    fontSize: size.x80,
+    lineHeight: lineHeight.x80,
+    color: Colors.text.primary,
+  },
 }
 
-export const smallFont: TextStyle = {
-  ...base,
-  fontSize: small,
-  lineHeight: smallLineHeight,
+type Header = "x10" | "x20" | "x30" | "x40" | "x50" | "x60"
+export const header: Record<Header, TextStyle> = {
+  x10: {
+    ...base.x30,
+    ...style.medium,
+    letterSpacing: letterSpacing.x20,
+  },
+  x20: {
+    ...base.x40,
+    ...style.semibold,
+    color: Colors.neutral.shade100,
+  },
+  x30: {
+    ...base.x50,
+    ...style.medium,
+  },
+  x40: {
+    ...base.x60,
+    ...style.medium,
+  },
+  x50: {
+    ...base.x70,
+    ...style.semibold,
+  },
+  x60: {
+    ...base.x80,
+    ...style.semibold,
+  },
 }
 
-export const mediumFont: TextStyle = {
-  ...base,
-  fontSize: medium,
-  lineHeight: mediumLineHeight,
+type Body = "x10" | "x20" | "x30"
+export const body: Record<Body, TextStyle> = {
+  x10: {
+    ...base.x20,
+    color: Colors.neutral.shade100,
+  },
+  x20: {
+    ...base.x30,
+    color: Colors.neutral.shade100,
+  },
+  x30: {
+    ...base.x40,
+    color: Colors.neutral.shade100,
+  },
 }
 
-export const largeFont: TextStyle = {
-  ...base,
-  fontSize: large,
-  lineHeight: largeLineHeight,
+type Form = "inputLabel" | "inputText"
+export const form: Record<Form, TextStyle> = {
+  inputLabel: {
+    ...base.x30,
+  },
+  inputText: {
+    ...base.x40,
+  },
 }
 
-export const xLargeFont: TextStyle = {
-  ...base,
-  fontSize: xLarge,
-  lineHeight: xLargeLineHeight,
+type Utility = "error"
+export const utility: Record<Utility, TextStyle> = {
+  error: {
+    ...header.x20,
+    color: Colors.accent.danger100,
+  },
 }
 
-export const xxLargeFont: TextStyle = {
-  ...base,
-  fontSize: xxLarge,
-  lineHeight: xxLargeLineHeight,
-}
-
-export const xxxLargeFont: TextStyle = {
-  ...base,
-  fontSize: xxxLarge,
-  lineHeight: xxxLargeLineHeight,
-}
-
-// Headers
-export const header1: TextStyle = {
-  ...xxxLargeFont,
-  ...semiBold,
-  color: Colors.text.primary,
-}
-
-export const header2: TextStyle = {
-  ...xxLargeFont,
-  ...semiBold,
-  color: Colors.text.primary,
-}
-
-export const header3: TextStyle = {
-  ...xLargeFont,
-  ...mediumBold,
-  color: Colors.text.primary,
-}
-
-export const header4: TextStyle = {
-  ...largeFont,
-  ...mediumBold,
-  color: Colors.text.primary,
-}
-
-export const header5: TextStyle = {
-  ...mediumFont,
-  ...semiBold,
-  color: Colors.neutral.shade100,
-}
-
-export const header6: TextStyle = {
-  ...smallFont,
-  ...mediumBold,
-  letterSpacing: mediumLetterSpacing,
-  color: Colors.text.primary,
-}
-
-// Content
-export const body1: TextStyle = {
-  ...mediumFont,
-  color: Colors.neutral.shade100,
-}
-
-export const body2: TextStyle = {
-  ...smallFont,
-  color: Colors.neutral.shade100,
-}
-
-export const body3: TextStyle = {
-  ...xSmallFont,
-  color: Colors.neutral.shade100,
-}
-
-// Forms
-export const formInputLabel: TextStyle = {
-  ...smallFont,
-  color: Colors.text.primary,
-}
-
-export const formInputText: TextStyle = {
-  ...mediumFont,
-  color: Colors.text.primary,
-}
-
-export const error: TextStyle = {
-  ...mediumFont,
-  ...semiBold,
-  color: Colors.accent.danger100,
-}
-
-// Tappables
 const baseButtonText: TextStyle = {
-  ...mediumFont,
-  ...semiBold,
+  ...header.x20,
   textAlign: "center",
 }
-
-export const buttonPrimary: TextStyle = {
-  ...baseButtonText,
-  color: Colors.neutral.white,
-}
-
-export const buttonPrimaryDisabled: TextStyle = {
-  ...baseButtonText,
-  color: Colors.neutral.shade140,
-}
-
-export const buttonFixedBottom: TextStyle = {
-  ...buttonPrimary,
-}
-
-export const buttonFixedBottomDisabled: TextStyle = {
-  ...buttonPrimaryDisabled,
-}
-
-export const buttonSecondary: TextStyle = {
-  ...baseButtonText,
-  color: Colors.primary.shade100,
-}
-
-export const buttonCard: TextStyle = {
-  ...body2,
-  ...bold,
-  textTransform: "uppercase",
-  color: Colors.primary.shade110,
-  marginRight: Spacing.xSmall,
-}
-
-export const tappableListItem: TextStyle = {
-  ...body1,
-  fontSize: large,
-}
-
-export const anchorLink: TextStyle = {
-  ...body1,
-  color: Colors.text.anchorLink,
-  textDecorationLine: "underline",
+type Button =
+  | "primary"
+  | "primaryDisabled"
+  | "fixedBottom"
+  | "fixedBottomDisabled"
+  | "secondary"
+  | "card"
+  | "listItem"
+  | "anchorLink"
+export const button: Record<Button, TextStyle> = {
+  primary: {
+    ...baseButtonText,
+    color: Colors.neutral.white,
+  },
+  primaryDisabled: {
+    ...baseButtonText,
+    color: Colors.neutral.shade140,
+  },
+  fixedBottom: {
+    ...baseButtonText,
+    color: Colors.neutral.white,
+  },
+  fixedBottomDisabled: {
+    ...baseButtonText,
+    color: Colors.neutral.shade140,
+  },
+  secondary: {
+    ...baseButtonText,
+    color: Colors.primary.shade100,
+  },
+  card: {
+    ...body.x20,
+    ...style.bold,
+    textTransform: "uppercase",
+    color: Colors.primary.shade110,
+    marginRight: Spacing.xSmall,
+  },
+  listItem: {
+    ...body.x30,
+    fontSize: size.x50,
+  },
+  anchorLink: {
+    ...body.x30,
+    color: Colors.text.anchorLink,
+    textDecorationLine: "underline",
+  },
 }


### PR DESCRIPTION
Why: we would like for our typography styles to be more organized and easier to use.

This commit:
- Refactors `typography.ts` and updates all the places where the `Typography` module is used

Note:
- Calling font sizes, line heights, etc. "small", "medium", "large", etc. becomes hard to maintain. For this reason, this commit shifts to using "x10", "x20", "x30", etc., with "x10" being the smallest size.
- This also enables us to use the same patterns for sizing across different font properties, e.g. `size.x10` and `lineHeight.x10`. This ends up being easier to use and more readable than `smallFontSize` and `mediumLineHeight`.
- In the future we can pull this pattern into other styling modules, e.g. `Sizing.layout.x10`.