### PR TITLE
Update symptom history date format

### DIFF
--- a/src/SymptomHistory/Form/Checkbox.tsx
+++ b/src/SymptomHistory/Form/Checkbox.tsx
@@ -2,10 +2,10 @@ import React, { FunctionComponent, useState } from "react"
 import { View, StyleSheet, TouchableWithoutFeedback } from "react-native"
 import { SvgXml } from "react-native-svg"
 
-import { Text } from "../components"
+import { Text } from "../../components"
 
-import { Colors, Iconography, Forms } from "../styles"
-import { Icons } from "../assets"
+import { Colors, Iconography, Forms } from "../../styles"
+import { Icons } from "../../assets"
 
 interface CheckboxProps {
   label: string

--- a/src/SymptomHistory/Form/SelectSymptoms.spec.tsx
+++ b/src/SymptomHistory/Form/SelectSymptoms.spec.tsx
@@ -2,11 +2,11 @@ import React from "react"
 import { showMessage } from "react-native-flash-message"
 import { render, fireEvent, waitFor } from "@testing-library/react-native"
 
+import { factories } from "../../factories"
+import { SymptomEntry } from "../symptomHistory"
+import { Symptom } from "../symptom"
+import { SymptomHistoryContext } from "../SymptomHistoryContext"
 import { SelectSymptomsForm } from "./SelectSymptoms"
-import { SymptomEntry } from "./symptomHistory"
-import { Symptom } from "./symptom"
-import { SymptomHistoryContext } from "./SymptomHistoryContext"
-import { factories } from "../factories"
 
 jest.mock("react-native-flash-message")
 jest.mock("@react-navigation/native")

--- a/src/SymptomHistory/Form/SelectSymptoms.tsx
+++ b/src/SymptomHistory/Form/SelectSymptoms.tsx
@@ -7,14 +7,18 @@ import {
   Text,
 } from "react-native"
 import { useTranslation } from "react-i18next"
+import { showMessage } from "react-native-flash-message"
 import { useNavigation, useRoute, RouteProp } from "@react-navigation/native"
 
-import { useStatusBarEffect, SymptomHistoryStackScreens } from "../navigation"
-import { useSymptomHistoryContext } from "./SymptomHistoryContext"
-import * as Symptom from "./symptom"
-import { hasEmergencySymptoms, SymptomEntry } from "./symptomHistory"
-import { showMessage } from "react-native-flash-message"
-import { posixToDayjs } from "../utils/dateTime"
+import {
+  useStatusBarEffect,
+  SymptomHistoryStackScreens,
+} from "../../navigation"
+import { SymptomHistoryStackParams } from "../../navigation/SymptomHistoryStack"
+import { posixToDayjs } from "../../utils/dateTime"
+import { useSymptomHistoryContext } from "../SymptomHistoryContext"
+import * as Symptom from "../symptom"
+import { hasEmergencySymptoms, SymptomEntry } from "../symptomHistory"
 import Checkbox from "./Checkbox"
 
 import {
@@ -24,8 +28,7 @@ import {
   Outlines,
   Spacing,
   Typography,
-} from "../styles"
-import { SymptomHistoryStackParams } from "../navigation/SymptomHistoryStack"
+} from "../../styles"
 
 const SelectSymptomsScreen: FunctionComponent = () => {
   const route = useRoute<

--- a/src/SymptomHistory/Share/SymptomHistoryFormatter.spec.ts
+++ b/src/SymptomHistory/Share/SymptomHistoryFormatter.spec.ts
@@ -1,0 +1,56 @@
+import { TFunction } from "i18next"
+
+import { Symptom } from "../symptom"
+import { SymptomHistory } from "../symptomHistory"
+
+import SymptomHistoryFormatter from "./SymptomHistoryFormatter"
+
+describe("SymptomHistoryFormatter::forSharing", () => {
+  describe("When initialized with a sympotom history", () => {
+    it("returns the correct serialization", () => {
+      const today = Date.parse("2020-1-3")
+      const oneDayAgo = Date.parse("2020-1-2")
+      const twoDaysAgo = Date.parse("2020-1-1")
+      const history: SymptomHistory = [
+        {
+          kind: "NoUserInput",
+          date: today,
+        },
+        {
+          id: "a",
+          kind: "UserInput",
+          date: oneDayAgo,
+          symptoms: new Set<Symptom>(),
+        },
+        {
+          id: "b",
+          kind: "UserInput",
+          date: twoDaysAgo,
+          symptoms: new Set<Symptom>(["cough", "fever"]),
+        },
+      ]
+
+      const t: TFunction = (
+        translationString: string,
+        args: string | undefined,
+      ) => {
+        let argsText = ""
+        if (args) {
+          argsText = Object.values(args).join("")
+        }
+        return translationString + argsText
+      }
+
+      const result = SymptomHistoryFormatter.forSharing(t, history)
+
+      const expected = [
+        "symptom_history.sharing.headerFri Jan 3, 2020Wed Jan 1, 2020",
+        "Fri Jan 3, 2020\nsymptom_history.sharing.no_symptoms_were_logged",
+        "Thu Jan 2, 2020\nsymptom_history.sharing.you_felt_well",
+        "Wed Jan 1, 2020\nsymptom_history.sharing.you_did_not_feel_wellsymptoms.cough, symptoms.fever",
+      ].join("\n\n")
+
+      expect(result).toEqual(expected)
+    })
+  })
+})

--- a/src/SymptomHistory/Share/SymptomHistoryFormatter.ts
+++ b/src/SymptomHistory/Share/SymptomHistoryFormatter.ts
@@ -1,11 +1,12 @@
 import { TFunction } from "i18next"
 
-import { posixToDayjs } from "../utils/dateTime"
-import { SymptomHistory, SymptomEntry } from "./symptomHistory"
-import * as Symptom from "./symptom"
+import { posixToDayjs } from "../../utils/dateTime"
+import { DATE_FORMAT } from "../index"
+import { SymptomHistory, SymptomEntry } from "../symptomHistory"
+import * as Symptom from "../symptom"
 
 class SymptomHistoryFormatter {
-  private DATE_FORMAT = "MMM D, 'YY"
+  private DATE_FORMAT = DATE_FORMAT
   private t: TFunction
   private symptomHistory: SymptomHistory
 

--- a/src/SymptomHistory/SymptomEntryListItem.spec.tsx
+++ b/src/SymptomHistory/SymptomEntryListItem.spec.tsx
@@ -72,7 +72,7 @@ describe("SymptomEntryListItem", () => {
         <SymptomEntryListItem entry={symptomEntry} />,
       )
 
-      const editButton = getByLabelText("Edit - Jan 1, '20")
+      const editButton = getByLabelText("Edit - Wed Jan 1, 2020")
       fireEvent.press(editButton)
 
       const expectedScreen = SymptomHistoryStackScreens.SelectSymptoms

--- a/src/SymptomHistory/SymptomEntryListItem.tsx
+++ b/src/SymptomHistory/SymptomEntryListItem.tsx
@@ -9,6 +9,7 @@ import { SymptomHistoryStackParams } from "../navigation/SymptomHistoryStack"
 import { SymptomHistoryStackScreens } from "../navigation"
 import { Text } from "../components"
 import { posixToDayjs } from "../utils/dateTime"
+import { DATE_FORMAT } from "./index"
 import * as Symptom from "./symptom"
 import { SymptomEntry } from "./symptomHistory"
 
@@ -47,7 +48,7 @@ const SymptomEntryListItem: FunctionComponent<SymptomEntryListItemProps> = ({
     })
   }
 
-  const dateText = dayJsDate.local().format("MMM D, 'YY")
+  const dateText = dayJsDate.local().format(DATE_FORMAT)
 
   const toSymptomText = (symptom: Symptom.Symptom) => {
     const translatedSymptom = Symptom.toTranslation(t, symptom)

--- a/src/SymptomHistory/index.spec.tsx
+++ b/src/SymptomHistory/index.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render } from "@testing-library/react-native"
 import { Share } from "react-native"
 import dayjs from "dayjs"
 
+import { DATE_FORMAT } from "./index"
 import { SymptomHistoryContext } from "./SymptomHistoryContext"
 import { SymptomHistory } from "./symptomHistory"
 import { Symptom } from "./symptom"
@@ -45,13 +46,11 @@ describe("SymptomHistory", () => {
         </SymptomHistoryContext.Provider>,
       )
 
-      const expectedTodayText = dayjs(today).local().format("MMM D, 'YY")
-      const expectedOneDayAgoText = dayjs(oneDayAgo)
-        .local()
-        .format("MMM D, 'YY")
+      const expectedTodayText = dayjs(today).local().format(DATE_FORMAT)
+      const expectedOneDayAgoText = dayjs(oneDayAgo).local().format(DATE_FORMAT)
       const expectedTwoDaysAgoText = dayjs(twoDaysAgo)
         .local()
-        .format("MMM D, 'YY")
+        .format(DATE_FORMAT)
       expect(getByText(expectedTodayText)).toBeDefined()
       expect(getAllByText("No entry")).toHaveLength(1)
       expect(getByText(expectedOneDayAgoText)).toBeDefined()
@@ -61,28 +60,14 @@ describe("SymptomHistory", () => {
     })
 
     it("allows the user to share their symptom history", () => {
-      const today = Date.parse("2020-1-3")
-      const oneDayAgo = Date.parse("2020-1-2")
-      const twoDaysAgo = Date.parse("2020-1-1")
       const history: SymptomHistory = [
         {
           kind: "NoUserInput",
-          date: today,
-        },
-        {
-          id: "a",
-          kind: "UserInput",
-          date: oneDayAgo,
-          symptoms: new Set<Symptom>(),
-        },
-        {
-          id: "b",
-          kind: "UserInput",
-          date: twoDaysAgo,
-          symptoms: new Set<Symptom>(["cough", "fever"]),
+          date: Date.now(),
         },
       ]
       const shareSpy = jest.spyOn(Share, "share")
+
       const { getByTestId } = render(
         <SymptomHistoryContext.Provider
           value={factories.symptomHistoryContext.build({
@@ -96,10 +81,7 @@ describe("SymptomHistory", () => {
       const shareButton = getByTestId("shareButton")
       fireEvent.press(shareButton)
 
-      expect(shareSpy).toHaveBeenCalledWith({
-        message:
-          "Symptom history from Jan 3, '20 to Jan 1, '20\n\nJan 3, '20\nNo symptoms were logged\n\nJan 2, '20\nYou felt well\n\nJan 1, '20\nYou did not feel well, symptoms included: Cough, Fever",
-      })
+      expect(shareSpy).toHaveBeenCalled()
     })
   })
 })

--- a/src/SymptomHistory/index.tsx
+++ b/src/SymptomHistory/index.tsx
@@ -16,9 +16,11 @@ import { SymptomEntry } from "./symptomHistory"
 import { Text, StatusBar } from "../components"
 import { useStatusBarEffect } from "../navigation"
 import SymptomEntryListItem from "./SymptomEntryListItem"
-import SymptomHistoryFormatter from "./SymptomHistoryFormatter"
+import SymptomHistoryFormatter from "./Share/SymptomHistoryFormatter"
 
 import { Buttons, Colors, Spacing, Typography } from "../styles"
+
+export const DATE_FORMAT = "ddd MMM D, YYYY"
 
 const SymptomHistory: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)

--- a/src/navigation/SymptomHistoryStack.tsx
+++ b/src/navigation/SymptomHistoryStack.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
 import SymptomHistoryScreen from "../SymptomHistory/"
-import SelectSymptomsScreen from "../SymptomHistory/SelectSymptoms"
+import SelectSymptomsScreen from "../SymptomHistory/Form/SelectSymptoms"
 import CallEmergencyServices from "../CallEmergencyServices"
 import { Stacks, SymptomHistoryStackScreens } from "./index"
 import { applyModalHeader } from "./ModalHeader"


### PR DESCRIPTION
Why:
As a contact tracer speaking with a user it is helpful to be able to
refer to the day of the week for a given symptom history entry. We would
like to show the day of week in addition to the calendar date on each
symptom history entry.

This commit:
Updates the symptom history date format and also opportunistically
organizes some of the components into sub features in the SymptomHistory
module.

|Before|After|
|-------|------|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-02 at 11 55 34](https://user-images.githubusercontent.com/16049495/97902189-37074080-1d0b-11eb-8f2b-e05181fbed51.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-02 at 11 58 05](https://user-images.githubusercontent.com/16049495/97902183-366eaa00-1d0b-11eb-9ddb-0dbac3ca0a19.png)|
