### PR TITLE
posixToDayjs test not handling UTC properly

### DIFF
--- a/src/utils/dateTime.spec.ts
+++ b/src/utils/dateTime.spec.ts
@@ -35,9 +35,10 @@ describe("isToday", () => {
 
 describe("posixToDayjs", () => {
   it("converts a valid posix timestamp into a Dayjs instance", () => {
-    const posixTimeStamp = new Date("2020/07/01").getTime()
+    const date = new Date("2020/07/01")
+    const posixTimeStamp = date.getTime()
     expect(posixToDayjs(posixTimeStamp)?.format("YYYY-MM-DD")).toEqual(
-      "2020-07-01",
+      date.toISOString().split("T")[0],
     )
   })
 


### PR DESCRIPTION
#### Why:
Tests fail because posixToDayjs test is not handling the UTC date properly

#### This commit:
Changed the test to take into consideration the UTC date.

#### Screenshots:
![image](https://user-images.githubusercontent.com/4215699/97968615-9460c780-1dc7-11eb-9e32-01b22c8cf52b.png)

#### How to test:
```yarn test```