### PR TITLE
Provide recommendation to users for covid related symptoms

### DIFF
--- a/src/CovidRecommendation.tsx
+++ b/src/CovidRecommendation.tsx
@@ -1,0 +1,198 @@
+import React, { FunctionComponent } from "react"
+import {
+  Linking,
+  Image,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native"
+import { useTranslation } from "react-i18next"
+import { SvgXml } from "react-native-svg"
+
+import { useStatusBarEffect } from "./navigation"
+import { Text } from "./components"
+import { useConfigurationContext } from "./ConfigurationContext"
+
+import { Buttons, Outlines, Colors, Spacing, Typography } from "./styles"
+import { Images, Icons } from "./assets"
+
+interface CovidRecommendationProps {
+  onDismiss: () => void
+}
+
+const CovidRecommendation: FunctionComponent<CovidRecommendationProps> = ({
+  onDismiss,
+}) => {
+  useStatusBarEffect("dark-content", Colors.secondary.shade10)
+  const { t } = useTranslation()
+  const { findATestCenterUrl } = useConfigurationContext()
+
+  const handleOnPressDone = () => {
+    onDismiss()
+  }
+
+  const RecommendationContent: FunctionComponent = () => {
+    const { t } = useTranslation()
+
+    return (
+      <>
+        <Text style={style.bullet1}>
+          {t("self_assessment.guidance.stay_home_14_days")}
+        </Text>
+        <Text style={style.bullet2}>
+          {t("self_assessment.guidance.take_temperature")}
+        </Text>
+        <Text style={style.bullet2}>
+          {t("self_assessment.guidance.practice_social_distancing")}
+        </Text>
+        <View style={style.bullet3Container}>
+          <Text style={style.bullet3}>
+            {t("self_assessment.guidance.stay_6_feet_away")}
+          </Text>
+          <Text style={style.bullet3}>
+            {t("self_assessment.guidance.stay_away_from_higher_risk_people")}
+          </Text>
+        </View>
+        <Text style={style.bullet2}>
+          {t("self_assessment.guidance.follow_cdc_guidance")}
+        </Text>
+      </>
+    )
+  }
+
+  const displayFindATestCenter = Boolean(findATestCenterUrl)
+
+  const handleOnPressFindTestCenter = () => {
+    if (findATestCenterUrl) {
+      Linking.openURL(findATestCenterUrl)
+    }
+  }
+
+  return (
+    <>
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
+      >
+        <View style={style.topScrollViewBackground} />
+        <View style={style.headerContainer}>
+          <Image source={Images.SelfAssessment} style={style.image} />
+          <Text style={style.headerText}>
+            {t("self_assessment.guidance.guidance")}
+          </Text>
+          <Text style={style.subheaderText}>
+            {t("self_assessment.guidance.your_symptoms_might_be_related")}
+          </Text>
+        </View>
+        <View style={style.bottomContainer}>
+          <RecommendationContent />
+          {displayFindATestCenter && (
+            <TouchableOpacity
+              style={style.button}
+              onPress={handleOnPressFindTestCenter}
+              accessibilityLabel={t(
+                "self_assessment.guidance.find_a_test_center_nearby",
+              )}
+            >
+              <Text style={style.buttonText}>
+                {t("self_assessment.guidance.find_a_test_center_nearby")}
+              </Text>
+              <SvgXml xml={Icons.Arrow} fill={Colors.background.primaryLight} />
+            </TouchableOpacity>
+          )}
+          <TouchableOpacity
+            style={style.doneButton}
+            onPress={handleOnPressDone}
+            accessibilityLabel={t("common.done")}
+          >
+            <Text style={style.doneButtonText}>{t("common.done")}</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </>
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.background.primaryLight,
+  },
+  contentContainer: {
+    paddingBottom: Spacing.xxxHuge,
+  },
+  topScrollViewBackground: {
+    position: "absolute",
+    top: "-100%",
+    left: 0,
+    right: 0,
+    backgroundColor: Colors.secondary.shade10,
+    height: "100%",
+  },
+  headerContainer: {
+    paddingVertical: Spacing.huge,
+    paddingHorizontal: Spacing.large,
+    marginBottom: Spacing.large,
+    backgroundColor: Colors.secondary.shade10,
+  },
+  image: {
+    width: 70,
+    height: 70,
+    resizeMode: "contain",
+    marginBottom: Spacing.xLarge,
+  },
+  headerText: {
+    ...Typography.header.x60,
+    marginBottom: Spacing.xxSmall,
+  },
+  subheaderText: {
+    ...Typography.header.x30,
+    ...Typography.style.normal,
+    color: Colors.neutral.black,
+  },
+  bottomContainer: {
+    paddingHorizontal: Spacing.large,
+    backgroundColor: Colors.background.primaryLight,
+    marginBottom: Spacing.xxLarge,
+  },
+  bullet1: {
+    ...Typography.header.x30,
+    color: Colors.primary.shade100,
+    marginBottom: Spacing.medium,
+  },
+  bullet2: {
+    ...Typography.body.x30,
+    ...Typography.style.medium,
+    color: Colors.text.primary,
+    marginBottom: Spacing.small,
+  },
+  bullet3Container: {
+    paddingLeft: Spacing.medium,
+    paddingTop: Spacing.xxSmall,
+    marginBottom: Spacing.small,
+    borderLeftWidth: Outlines.hairline,
+    borderLeftColor: Colors.neutral.shade25,
+  },
+  bullet3: {
+    ...Typography.body.x30,
+    marginBottom: Spacing.xxSmall,
+  },
+  button: {
+    ...Buttons.thin.base,
+    marginTop: Spacing.medium,
+  },
+  buttonText: {
+    ...Typography.button.primary,
+    marginRight: Spacing.small,
+  },
+  doneButton: {
+    ...Buttons.outlined.thin,
+    marginTop: Spacing.small,
+  },
+  doneButtonText: {
+    ...Typography.button.secondary,
+  },
+})
+
+export default CovidRecommendation

--- a/src/Home/ExposureDetectionStatus/Card.tsx
+++ b/src/Home/ExposureDetectionStatus/Card.tsx
@@ -1,0 +1,221 @@
+import React, {
+  FunctionComponent,
+  useRef,
+  useEffect,
+  useState,
+  useCallback,
+} from "react"
+import {
+  StyleSheet,
+  Easing,
+  Animated,
+  AccessibilityInfo,
+  View,
+  TouchableOpacity,
+} from "react-native"
+import { useTranslation } from "react-i18next"
+import { useNavigation } from "@react-navigation/native"
+import { SvgXml } from "react-native-svg"
+
+import { useExposureDetectionStatus } from "../../Device/useExposureDetectionStatus"
+
+import { HomeStackScreens } from "../../navigation"
+import { Text } from "../../components"
+
+import { Icons } from "../../assets"
+import {
+  Layout,
+  Spacing,
+  Colors,
+  Typography,
+  Outlines,
+  Iconography,
+  Affordances,
+} from "../../styles"
+
+const STATUS_ICON_SIZE = Iconography.small
+
+const ExposureDetectionStatusCard: FunctionComponent = () => {
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+  const { exposureDetectionStatus } = useExposureDetectionStatus()
+
+  const handleOnPressExposureDetectionStatus = () => {
+    navigation.navigate(HomeStackScreens.ExposureDetectionStatus)
+  }
+
+  const statusBackgroundColor = exposureDetectionStatus
+    ? Colors.accent.success25
+    : Colors.accent.danger25
+  const statusBorderColor = exposureDetectionStatus
+    ? Colors.accent.success100
+    : Colors.accent.danger100
+  const statusIcon = exposureDetectionStatus
+    ? Icons.CheckInCircle
+    : Icons.XInCircle
+  const statusIconFill = exposureDetectionStatus
+    ? Colors.accent.success100
+    : Colors.accent.danger100
+  const statusText = exposureDetectionStatus
+    ? t("home.bluetooth.tracing_on_header")
+    : t("home.bluetooth.tracing_off_header")
+  const actionText = exposureDetectionStatus
+    ? t("exposure_scanning_status.learn_more")
+    : t("exposure_scanning_status.fix_this")
+
+  const statusContainerStyle = {
+    ...style.statusContainer,
+    backgroundColor: statusBackgroundColor,
+    borderColor: statusBorderColor,
+  }
+
+  return (
+    <TouchableOpacity
+      style={statusContainerStyle}
+      accessibilityLabel={statusText}
+      testID={"exposure-scanning-status-button"}
+      onPress={handleOnPressExposureDetectionStatus}
+    >
+      <View style={style.statusTopContainer}>
+        <Text style={style.statusText} testID={"home-header"}>
+          {statusText}
+        </Text>
+        <View>
+          <SvgXml
+            xml={statusIcon}
+            width={STATUS_ICON_SIZE}
+            height={STATUS_ICON_SIZE}
+            fill={statusIconFill}
+            style={style.statusIcon}
+          />
+          {exposureDetectionStatus && <ExpandingCircleAnimation />}
+        </View>
+      </View>
+      <View style={style.statusBottomContainer}>
+        <Text style={style.statusActionText}>{actionText}</Text>
+        <SvgXml
+          xml={Icons.ChevronRight}
+          fill={Colors.neutral.black}
+          width={Iconography.tiny}
+          height={Iconography.tiny}
+        />
+      </View>
+    </TouchableOpacity>
+  )
+}
+const ExpandingCircleAnimation: FunctionComponent = () => {
+  const [isReduceMotionEnabled, setIsReduceMotionEnabled] = useState<boolean>(
+    false,
+  )
+
+  const animationTime = 1600
+  const delayTime = 2000
+  const initialCircleSize = 0
+  const endingCircleSize = 600
+  const initialTopValue = STATUS_ICON_SIZE / 2
+  const endingTopValue = endingCircleSize * -0.46
+  const initialOpacity = 0.2
+  const endingOpacity = 0.0
+
+  const sizeAnimatedValue = useRef(new Animated.Value(initialCircleSize))
+    .current
+  const topAnimatedValue = useRef(new Animated.Value(initialTopValue)).current
+  const opacityAnimatedValue = useRef(new Animated.Value(initialOpacity))
+    .current
+
+  const playAnimation = useCallback(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.parallel([
+          Animated.timing(sizeAnimatedValue, {
+            toValue: endingCircleSize,
+            duration: animationTime,
+            easing: Easing.quad,
+            useNativeDriver: false,
+          }),
+          Animated.timing(topAnimatedValue, {
+            toValue: endingTopValue,
+            duration: animationTime,
+            easing: Easing.quad,
+            useNativeDriver: false,
+          }),
+          Animated.timing(opacityAnimatedValue, {
+            toValue: endingOpacity,
+            duration: animationTime,
+            easing: Easing.quad,
+            useNativeDriver: false,
+          }),
+          Animated.delay(delayTime),
+        ]),
+      ]),
+    ).start()
+  }, [
+    endingTopValue,
+    opacityAnimatedValue,
+    sizeAnimatedValue,
+    topAnimatedValue,
+  ])
+
+  useEffect(playAnimation, [playAnimation])
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled()?.then((result) => {
+      setIsReduceMotionEnabled(result)
+    })
+  }, [])
+
+  if (isReduceMotionEnabled) {
+    return null
+  }
+
+  return (
+    <Animated.View
+      style={{
+        position: "absolute",
+        top: topAnimatedValue,
+        alignSelf: "center",
+        width: sizeAnimatedValue,
+        height: sizeAnimatedValue,
+        borderColor: Colors.accent.success100,
+        borderWidth: Outlines.hairline,
+        borderRadius: Outlines.borderRadiusMax,
+        opacity: opacityAnimatedValue,
+      }}
+    />
+  )
+}
+
+const style = StyleSheet.create({
+  statusContainer: {
+    ...Affordances.floatingContainer,
+    paddingVertical: Spacing.small,
+    elevation: 0,
+    borderWidth: Outlines.thin,
+    overflow: "hidden",
+  },
+  statusTopContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: Spacing.xxxSmall,
+  },
+  statusIcon: {
+    zIndex: Layout.zLevel1,
+  },
+  statusText: {
+    ...Typography.header.x40,
+    color: Colors.neutral.black,
+  },
+  statusBottomContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  statusActionText: {
+    ...Typography.body.x20,
+    color: Colors.neutral.black,
+    marginRight: Spacing.xxxSmall,
+    paddingBottom: 2,
+  },
+})
+
+export default ExposureDetectionStatusCard

--- a/src/Home/ExposureDetectionStatus/Screen.spec.tsx
+++ b/src/Home/ExposureDetectionStatus/Screen.spec.tsx
@@ -9,20 +9,21 @@ import {
 import { useNavigation } from "@react-navigation/native"
 import "@testing-library/jest-native/extend-expect"
 
-import ExposureDetectionStatus from "./ExposureDetectionStatus"
-import { HomeStackScreens } from "../navigation"
+import { HomeStackScreens } from "../../navigation"
 import {
   PermissionsContext,
   ENPermissionStatus,
   PermissionStatus,
-} from "../Device/PermissionsContext"
-import { LocationPermissions } from "../Device/useLocationPermissions"
-import { factories } from "../factories"
+} from "../../Device/PermissionsContext"
+import { LocationPermissions } from "../../Device/useLocationPermissions"
+import { factories } from "../../factories"
+
+import ExposureDetectionStatusScreen from "./Screen"
 
 jest.mock("@react-navigation/native")
 
 const mockedApplicationName = "applicationName"
-jest.mock("../Device/useApplicationInfo", () => {
+jest.mock("../../Device/useApplicationInfo", () => {
   return {
     useApplicationName: () => {
       return {
@@ -32,7 +33,7 @@ jest.mock("../Device/useApplicationInfo", () => {
   }
 })
 
-describe("ExposureDetectionStatus", () => {
+describe("ExposureDetectionStatusScreen", () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
@@ -51,7 +52,7 @@ describe("ExposureDetectionStatus", () => {
 
       const { getByTestId, getByText } = render(
         <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatus />
+          <ExposureDetectionStatusScreen />
         </PermissionsContext.Provider>,
       )
 
@@ -82,7 +83,7 @@ describe("ExposureDetectionStatus", () => {
 
       const { getByTestId } = render(
         <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatus />
+          <ExposureDetectionStatusScreen />
         </PermissionsContext.Provider>,
       )
 
@@ -116,7 +117,7 @@ describe("ExposureDetectionStatus", () => {
 
       const { getByTestId } = render(
         <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatus />
+          <ExposureDetectionStatusScreen />
         </PermissionsContext.Provider>,
       )
 
@@ -138,7 +139,7 @@ describe("ExposureDetectionStatus", () => {
 
       const { getByTestId, getByText } = render(
         <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatus />
+          <ExposureDetectionStatusScreen />
         </PermissionsContext.Provider>,
       )
 
@@ -169,7 +170,7 @@ describe("ExposureDetectionStatus", () => {
 
       const { getByTestId } = render(
         <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatus />
+          <ExposureDetectionStatusScreen />
         </PermissionsContext.Provider>,
       )
 
@@ -206,7 +207,7 @@ describe("ExposureDetectionStatus", () => {
 
       const { getByTestId } = render(
         <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatus />
+          <ExposureDetectionStatusScreen />
         </PermissionsContext.Provider>,
       )
 
@@ -231,7 +232,7 @@ describe("ExposureDetectionStatus", () => {
 
       const { getByTestId } = render(
         <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatus />
+          <ExposureDetectionStatusScreen />
         </PermissionsContext.Provider>,
       )
 
@@ -252,7 +253,7 @@ describe("ExposureDetectionStatus", () => {
 
         const { getByTestId } = render(
           <PermissionsContext.Provider value={permissionsState}>
-            <ExposureDetectionStatus />
+            <ExposureDetectionStatusScreen />
           </PermissionsContext.Provider>,
         )
 
@@ -271,7 +272,7 @@ describe("ExposureDetectionStatus", () => {
 
         const { getByTestId } = render(
           <PermissionsContext.Provider value={permissionsState}>
-            <ExposureDetectionStatus />
+            <ExposureDetectionStatusScreen />
           </PermissionsContext.Provider>,
         )
 
@@ -288,7 +289,7 @@ describe("ExposureDetectionStatus", () => {
         })
         const { getByTestId, getByText } = render(
           <PermissionsContext.Provider value={permissionsState}>
-            <ExposureDetectionStatus />
+            <ExposureDetectionStatusScreen />
           </PermissionsContext.Provider>,
         )
 
@@ -313,7 +314,7 @@ describe("ExposureDetectionStatus", () => {
 
       const { queryByTestId } = render(
         <PermissionsContext.Provider value={permissionsState}>
-          <ExposureDetectionStatus />
+          <ExposureDetectionStatusScreen />
         </PermissionsContext.Provider>,
       )
 

--- a/src/Home/ExposureDetectionStatus/Screen.tsx
+++ b/src/Home/ExposureDetectionStatus/Screen.tsx
@@ -3,18 +3,19 @@ import { Alert, Platform, ScrollView, StyleSheet } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
-import { useApplicationName } from "../Device/useApplicationInfo"
-import { useExposureDetectionStatus } from "../Device/useExposureDetectionStatus"
+import { useApplicationName } from "../../Device/useApplicationInfo"
+import { useExposureDetectionStatus } from "../../Device/useExposureDetectionStatus"
 import {
   usePermissionsContext,
   ENPermissionStatus,
-} from "../Device/PermissionsContext"
-import { openAppSettings } from "../Device"
-import ActivationStatusView from "./ActivationStatusView"
-import { useStatusBarEffect, HomeStackScreens } from "../navigation"
-import { Text } from "../components"
+} from "../../Device/PermissionsContext"
+import { openAppSettings } from "../../Device"
+import { useStatusBarEffect, HomeStackScreens } from "../../navigation"
+import { Text } from "../../components"
 
-import { Colors, Spacing, Typography } from "../styles"
+import ActivationStatusView from "../ActivationStatusView"
+
+import { Colors, Spacing, Typography } from "../../styles"
 
 const ExposureDetectionStatus: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -1,14 +1,5 @@
-import React, {
-  FunctionComponent,
-  useRef,
-  useEffect,
-  useState,
-  useCallback,
-} from "react"
+import React, { FunctionComponent } from "react"
 import {
-  Easing,
-  Animated,
-  AccessibilityInfo,
   ScrollView,
   Linking,
   TouchableOpacity,
@@ -28,14 +19,13 @@ import {
 import { useConfigurationContext } from "../ConfigurationContext"
 import { StatusBar, Text } from "../components"
 
+import ExposureDetectionStatusCard from "./ExposureDetectionStatus/Card"
 import SectionButton from "./SectionButton"
 import ShareLink from "./ShareLink"
 import CovidDataCard from "../CovidData/Card"
-import { useExposureDetectionStatus } from "../Device/useExposureDetectionStatus"
 
 import { Icons, Images } from "../assets"
 import {
-  Layout,
   Spacing,
   Colors,
   Typography,
@@ -45,199 +35,18 @@ import {
   Affordances,
 } from "../styles"
 
-const STATUS_ICON_SIZE = Iconography.small
 const IMAGE_HEIGHT = 170
 
 const Home: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()
-  const navigation = useNavigation()
-  const { exposureDetectionStatus } = useExposureDetectionStatus()
   const {
     displaySelfAssessment,
     displayCovidData,
     displayCallbackForm,
+    displaySymptomHistory,
     emergencyPhoneNumber,
   } = useConfigurationContext()
-
-  const ExposureDetectionStatus: FunctionComponent = () => {
-    const handleOnPressExposureDetectionStatus = () => {
-      navigation.navigate(HomeStackScreens.ExposureDetectionStatus)
-    }
-
-    const statusBackgroundColor = exposureDetectionStatus
-      ? Colors.accent.success25
-      : Colors.accent.danger25
-    const statusBorderColor = exposureDetectionStatus
-      ? Colors.accent.success100
-      : Colors.accent.danger100
-    const statusIcon = exposureDetectionStatus
-      ? Icons.CheckInCircle
-      : Icons.XInCircle
-    const statusIconFill = exposureDetectionStatus
-      ? Colors.accent.success100
-      : Colors.accent.danger100
-    const statusText = exposureDetectionStatus
-      ? t("home.bluetooth.tracing_on_header")
-      : t("home.bluetooth.tracing_off_header")
-    const actionText = exposureDetectionStatus
-      ? t("exposure_scanning_status.learn_more")
-      : t("exposure_scanning_status.fix_this")
-
-    const statusContainerStyle = {
-      ...style.statusContainer,
-      backgroundColor: statusBackgroundColor,
-      borderColor: statusBorderColor,
-    }
-
-    return (
-      <TouchableOpacity
-        style={statusContainerStyle}
-        accessibilityLabel={statusText}
-        testID={"exposure-scanning-status-button"}
-        onPress={handleOnPressExposureDetectionStatus}
-      >
-        <View style={style.statusTopContainer}>
-          <Text style={style.statusText} testID={"home-header"}>
-            {statusText}
-          </Text>
-          <View>
-            <SvgXml
-              xml={statusIcon}
-              width={STATUS_ICON_SIZE}
-              height={STATUS_ICON_SIZE}
-              fill={statusIconFill}
-              style={style.statusIcon}
-            />
-            {exposureDetectionStatus && <ExpandingCircleAnimation />}
-          </View>
-        </View>
-        <View style={style.statusBottomContainer}>
-          <Text style={style.statusActionText}>{actionText}</Text>
-          <SvgXml
-            xml={Icons.ChevronRight}
-            fill={Colors.neutral.black}
-            width={Iconography.tiny}
-            height={Iconography.tiny}
-          />
-        </View>
-      </TouchableOpacity>
-    )
-  }
-  const TalkToContactTracer: FunctionComponent = () => {
-    const handleOnPressTalkToContactTracer = () => {
-      navigation.navigate(ModalStackScreens.CallbackStack)
-    }
-
-    return (
-      <TouchableOpacity
-        onPress={handleOnPressTalkToContactTracer}
-        style={style.floatingContainer}
-      >
-        <Image
-          source={Images.HowItWorksValueProposition}
-          style={style.image}
-          width={200}
-          height={IMAGE_HEIGHT}
-        />
-        <Text style={style.sectionHeaderText}>
-          {t("home.did_you_test_positive")}
-        </Text>
-        <Text style={style.sectionBodyText}>
-          {t("home.to_submit_your_test")}
-        </Text>
-        <SectionButton text={t("home.request_call")} />
-      </TouchableOpacity>
-    )
-  }
-
-  const ReportTestResult: FunctionComponent = () => {
-    const handleOnPressReportTestResult = () => {
-      navigation.navigate(HomeStackScreens.AffectedUserStack)
-    }
-
-    return (
-      <TouchableOpacity
-        onPress={handleOnPressReportTestResult}
-        style={style.floatingContainer}
-      >
-        <Image
-          source={Images.ProtectPrivacySubmitKeys}
-          style={style.image}
-          width={130}
-          height={IMAGE_HEIGHT}
-        />
-        <Text style={style.sectionHeaderText}>
-          {t("home.have_a_positive_test")}
-        </Text>
-        <Text style={style.sectionBodyText}>
-          {t("home.if_you_have_a_code")}
-        </Text>
-        <SectionButton text={t("home.report_result")} />
-      </TouchableOpacity>
-    )
-  }
-
-  const SelfAssessment: FunctionComponent = () => {
-    const handleOnPressTakeSelfAssessment = () => {
-      navigation.navigate(ModalStackScreens.SelfAssessmentFromHome)
-    }
-
-    return (
-      <TouchableOpacity
-        onPress={handleOnPressTakeSelfAssessment}
-        style={style.floatingContainer}
-      >
-        <Image
-          source={Images.SelfAssessment}
-          style={style.image}
-          width={150}
-          height={IMAGE_HEIGHT}
-        />
-        <Text style={style.sectionHeaderText}>
-          {t("home.not_feeling_well")}
-        </Text>
-        <Text style={style.sectionBodyText}>
-          {t("home.check_if_your_symptoms")}
-        </Text>
-        <SectionButton text={t("home.take_assessment")} />
-      </TouchableOpacity>
-    )
-  }
-
-  const CallEmergencyServices: FunctionComponent = () => {
-    const handleOnPressCallEmergencyServices = () => {
-      Linking.openURL(`tel:${emergencyPhoneNumber}`)
-    }
-
-    return (
-      <View style={style.emergencyButtonOuterContainer}>
-        <TouchableOpacity
-          onPress={handleOnPressCallEmergencyServices}
-          accessibilityLabel={t(
-            "self_assessment.call_emergency_services.call_emergencies",
-            {
-              emergencyPhoneNumber,
-            },
-          )}
-          accessibilityRole="button"
-          style={style.emergencyButtonContainer}
-        >
-          <SvgXml
-            xml={Icons.Phone}
-            fill={Colors.neutral.white}
-            width={Iconography.xSmall}
-            height={Iconography.xSmall}
-          />
-          <Text style={style.emergencyButtonText}>
-            {t("home.call_emergency_services", {
-              emergencyPhoneNumber,
-            })}
-          </Text>
-        </TouchableOpacity>
-      </View>
-    )
-  }
 
   return (
     <>
@@ -247,15 +56,167 @@ const Home: FunctionComponent = () => {
         contentContainerStyle={style.contentContainer}
       >
         <Text style={style.headerText}>{t("screen_titles.home")}</Text>
-        <ExposureDetectionStatus />
+        <ExposureDetectionStatusCard />
         <ShareLink />
         {displayCovidData && <CovidDataCard />}
         {displayCallbackForm && <TalkToContactTracer />}
         <ReportTestResult />
         {displaySelfAssessment && <SelfAssessment />}
-        <CallEmergencyServices />
+        {displaySymptomHistory && <SymptomHistory />}
+        <CallEmergencyServices phoneNumber={emergencyPhoneNumber} />
       </ScrollView>
     </>
+  )
+}
+
+const TalkToContactTracer: FunctionComponent = () => {
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+
+  const handleOnPressTalkToContactTracer = () => {
+    navigation.navigate(ModalStackScreens.CallbackStack)
+  }
+
+  return (
+    <TouchableOpacity
+      onPress={handleOnPressTalkToContactTracer}
+      style={style.floatingContainer}
+    >
+      <Image
+        source={Images.HowItWorksValueProposition}
+        style={style.image}
+        width={200}
+        height={IMAGE_HEIGHT}
+      />
+      <Text style={style.sectionHeaderText}>
+        {t("home.did_you_test_positive")}
+      </Text>
+      <Text style={style.sectionBodyText}>{t("home.to_submit_your_test")}</Text>
+      <SectionButton text={t("home.request_call")} />
+    </TouchableOpacity>
+  )
+}
+
+const ReportTestResult: FunctionComponent = () => {
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+
+  const handleOnPressReportTestResult = () => {
+    navigation.navigate(HomeStackScreens.AffectedUserStack)
+  }
+
+  return (
+    <TouchableOpacity
+      onPress={handleOnPressReportTestResult}
+      style={style.floatingContainer}
+    >
+      <Image
+        source={Images.ProtectPrivacySubmitKeys}
+        style={style.image}
+        width={130}
+        height={IMAGE_HEIGHT}
+      />
+      <Text style={style.sectionHeaderText}>
+        {t("home.have_a_positive_test")}
+      </Text>
+      <Text style={style.sectionBodyText}>{t("home.if_you_have_a_code")}</Text>
+      <SectionButton text={t("home.report_result")} />
+    </TouchableOpacity>
+  )
+}
+
+const SelfAssessment: FunctionComponent = () => {
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+
+  const handleOnPressTakeSelfAssessment = () => {
+    navigation.navigate(ModalStackScreens.SelfAssessmentFromHome)
+  }
+
+  return (
+    <TouchableOpacity
+      onPress={handleOnPressTakeSelfAssessment}
+      style={style.floatingContainer}
+    >
+      <Image
+        source={Images.SelfAssessment}
+        style={style.image}
+        width={150}
+        height={IMAGE_HEIGHT}
+      />
+      <Text style={style.sectionHeaderText}>{t("home.not_feeling_well")}</Text>
+      <Text style={style.sectionBodyText}>
+        {t("home.check_if_your_symptoms")}
+      </Text>
+      <SectionButton text={t("home.take_assessment")} />
+    </TouchableOpacity>
+  )
+}
+
+const SymptomHistory: FunctionComponent = () => {
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+
+  const handleOnPressSymptomHistory = () => {
+    navigation.navigate(HomeStackScreens.EnterSymptoms)
+  }
+
+  return (
+    <TouchableOpacity
+      onPress={handleOnPressSymptomHistory}
+      style={style.floatingContainer}
+    >
+      <Image
+        source={Images.SelfAssessment}
+        style={style.image}
+        width={150}
+        height={IMAGE_HEIGHT}
+      />
+      <Text style={style.sectionHeaderText}>{t("home.not_feeling_well")}</Text>
+      <Text style={style.sectionBodyText}>
+        {t("home.check_if_your_symptoms")}
+      </Text>
+      <SectionButton text={t("home.enter_symptoms")} />
+    </TouchableOpacity>
+  )
+}
+
+interface CallEmergencyServicesProps {
+  phoneNumber: string
+}
+
+const CallEmergencyServices: FunctionComponent<CallEmergencyServicesProps> = ({
+  phoneNumber,
+}) => {
+  const { t } = useTranslation()
+  const handleOnPressCallEmergencyServices = () => {
+    Linking.openURL(`tel:${phoneNumber}`)
+  }
+
+  return (
+    <View style={style.emergencyButtonOuterContainer}>
+      <TouchableOpacity
+        onPress={handleOnPressCallEmergencyServices}
+        accessibilityLabel={t(
+          "self_assessment.call_emergency_services.call_emergencies",
+          {
+            phoneNumber,
+          },
+        )}
+        accessibilityRole="button"
+        style={style.emergencyButtonContainer}
+      >
+        <SvgXml
+          xml={Icons.Phone}
+          fill={Colors.neutral.white}
+          width={Iconography.xSmall}
+          height={Iconography.xSmall}
+        />
+        <Text style={style.emergencyButtonText}>
+          {t("home.call_emergency_services", { phoneNumber })}
+        </Text>
+      </TouchableOpacity>
+    </View>
   )
 }
 
@@ -273,36 +234,6 @@ const style = StyleSheet.create({
     ...Typography.header.x60,
     ...Typography.style.bold,
     marginBottom: Spacing.medium,
-  },
-  statusContainer: {
-    ...Affordances.floatingContainer,
-    paddingVertical: Spacing.small,
-    elevation: 0,
-    borderWidth: Outlines.thin,
-    overflow: "hidden",
-  },
-  statusTopContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    marginBottom: Spacing.xxxSmall,
-  },
-  statusIcon: {
-    zIndex: Layout.zLevel1,
-  },
-  statusText: {
-    ...Typography.header.x40,
-    color: Colors.neutral.black,
-  },
-  statusBottomContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  statusActionText: {
-    ...Typography.body.x20,
-    color: Colors.neutral.black,
-    marginRight: Spacing.xxxSmall,
-    paddingBottom: 2,
   },
   floatingContainer: {
     ...Affordances.floatingContainer,
@@ -326,7 +257,6 @@ const style = StyleSheet.create({
   emergencyButtonOuterContainer: {
     borderTopWidth: Outlines.hairline,
     borderColor: Colors.neutral.shade25,
-
     paddingTop: Spacing.large,
   },
   emergencyButtonContainer: {
@@ -339,87 +269,5 @@ const style = StyleSheet.create({
     marginLeft: Spacing.small,
   },
 })
-
-const ExpandingCircleAnimation: FunctionComponent = () => {
-  const [isReduceMotionEnabled, setIsReduceMotionEnabled] = useState<boolean>(
-    false,
-  )
-
-  const animationTime = 1600
-  const delayTime = 2000
-  const initialCircleSize = 0
-  const endingCircleSize = 600
-  const initialTopValue = STATUS_ICON_SIZE / 2
-  const endingTopValue = endingCircleSize * -0.46
-  const initialOpacity = 0.2
-  const endingOpacity = 0.0
-
-  const sizeAnimatedValue = useRef(new Animated.Value(initialCircleSize))
-    .current
-  const topAnimatedValue = useRef(new Animated.Value(initialTopValue)).current
-  const opacityAnimatedValue = useRef(new Animated.Value(initialOpacity))
-    .current
-
-  const playAnimation = useCallback(() => {
-    Animated.loop(
-      Animated.sequence([
-        Animated.parallel([
-          Animated.timing(sizeAnimatedValue, {
-            toValue: endingCircleSize,
-            duration: animationTime,
-            easing: Easing.quad,
-            useNativeDriver: false,
-          }),
-          Animated.timing(topAnimatedValue, {
-            toValue: endingTopValue,
-            duration: animationTime,
-            easing: Easing.quad,
-            useNativeDriver: false,
-          }),
-          Animated.timing(opacityAnimatedValue, {
-            toValue: endingOpacity,
-            duration: animationTime,
-            easing: Easing.quad,
-            useNativeDriver: false,
-          }),
-          Animated.delay(delayTime),
-        ]),
-      ]),
-    ).start()
-  }, [
-    endingTopValue,
-    opacityAnimatedValue,
-    sizeAnimatedValue,
-    topAnimatedValue,
-  ])
-
-  useEffect(playAnimation, [playAnimation])
-
-  useEffect(() => {
-    AccessibilityInfo.isReduceMotionEnabled()?.then((result) => {
-      setIsReduceMotionEnabled(result)
-    })
-  }, [])
-
-  if (isReduceMotionEnabled) {
-    return null
-  }
-
-  return (
-    <Animated.View
-      style={{
-        position: "absolute",
-        top: topAnimatedValue,
-        alignSelf: "center",
-        width: sizeAnimatedValue,
-        height: sizeAnimatedValue,
-        borderColor: Colors.accent.success100,
-        borderWidth: Outlines.hairline,
-        borderRadius: Outlines.borderRadiusMax,
-        opacity: opacityAnimatedValue,
-      }}
-    />
-  )
-}
 
 export default Home

--- a/src/SelfAssessment/Guidance.tsx
+++ b/src/SelfAssessment/Guidance.tsx
@@ -77,7 +77,6 @@ const Guidance: FunctionComponent<GuidanceProps> = ({
 
   const StayHomeExceptForMedicalCare: FunctionComponent = () => {
     const { t } = useTranslation()
-
     return (
       <>
         <Text style={style.bullet1}>

--- a/src/SymptomHistory/Form/SelectSymptoms.spec.tsx
+++ b/src/SymptomHistory/Form/SelectSymptoms.spec.tsx
@@ -6,7 +6,7 @@ import { factories } from "../../factories"
 import { SymptomEntry } from "../symptomHistory"
 import { Symptom } from "../symptom"
 import { SymptomHistoryContext } from "../SymptomHistoryContext"
-import { SelectSymptomsForm } from "./SelectSymptoms"
+import SelectSymptomsForm from "./SelectSymptoms"
 
 jest.mock("react-native-flash-message")
 jest.mock("@react-navigation/native")
@@ -34,7 +34,12 @@ describe("SelectSymptomsForm", () => {
             updateEntry: updateEntrySpy,
           })}
         >
-          <SelectSymptomsForm entry={entry} />
+          <SelectSymptomsForm
+            entry={entry}
+            onSubmitEmergencySymptoms={() => {}}
+            onSubmitCovidSympotoms={() => {}}
+            onSubmitNoSymptoms={() => {}}
+          />
         </SymptomHistoryContext.Provider>,
       )
 
@@ -64,7 +69,12 @@ describe("SelectSymptomsForm", () => {
             updateEntry: updateEntrySpy,
           })}
         >
-          <SelectSymptomsForm entry={entry} />
+          <SelectSymptomsForm
+            entry={entry}
+            onSubmitEmergencySymptoms={() => {}}
+            onSubmitCovidSympotoms={() => {}}
+            onSubmitNoSymptoms={() => {}}
+          />
         </SymptomHistoryContext.Provider>,
       )
 

--- a/src/SymptomHistory/symptomHistory.ts
+++ b/src/SymptomHistory/symptomHistory.ts
@@ -3,6 +3,8 @@ import { Posix, isSameDay } from "../utils/dateTime"
 
 import * as Symptom from "./symptom"
 
+export type SymptomEntry = NoUserInput | UserInput
+
 export interface NoUserInput {
   kind: "NoUserInput"
   date: Posix
@@ -14,8 +16,6 @@ export interface UserInput {
   date: Posix
   symptoms: Set<Symptom.Symptom>
 }
-
-export type SymptomEntry = NoUserInput | UserInput
 
 export type SymptomHistory = SymptomEntry[]
 
@@ -148,6 +148,16 @@ export const hasEmergencySymptoms = (
   return Boolean(
     Symptom.emergencySymptoms.find((emergencySymptom) => {
       return loggedSymptoms.has(emergencySymptom)
+    }),
+  )
+}
+
+export const hasCovidSymptoms = (
+  loggedSymptoms: Set<Symptom.Symptom>,
+): boolean => {
+  return Boolean(
+    Symptom.covidSymptoms.find((symptom) => {
+      return loggedSymptoms.has(symptom)
     }),
   )
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -172,6 +172,7 @@
     "call_emergency_services": "Call Emergency Services",
     "check_if_your_symptoms": "Enter your symptoms and get an instant recommendation on how to stay safe.",
     "did_you_test_positive": "Did you test positive for COVID-19?",
+    "enter_symptoms": "Enter symptoms",
     "fix": "Fix issues with {{technology}}",
     "get_more_info": "Get more info on {{technology}}",
     "have_a_positive_test": "Have a positive test result code?",

--- a/src/navigation/HomeStack.tsx
+++ b/src/navigation/HomeStack.tsx
@@ -1,16 +1,100 @@
 import React, { FunctionComponent } from "react"
-import { createStackNavigator } from "@react-navigation/stack"
+import {
+  createStackNavigator,
+  TransitionPresets,
+} from "@react-navigation/stack"
+import { useNavigation } from "@react-navigation/native"
+import { useTranslation } from "react-i18next"
 
-import { HomeStackScreens } from "./index"
+import { Stacks, HomeStackScreens } from "./index"
 import Home from "../Home"
+import SelectSymptomsForm from "../SymptomHistory/Form/SelectSymptoms"
+import { applyModalHeader } from "./ModalHeader"
+import { useSymptomHistoryContext } from "../SymptomHistory/SymptomHistoryContext"
+import CovidRecommendation from "../CovidRecommendation"
+import CallEmergencyServices from "../CallEmergencyServices"
 
 const Stack = createStackNavigator()
 
 const HomeStack: FunctionComponent = () => {
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+
   return (
-    <Stack.Navigator headerMode="none">
-      <Stack.Screen name={HomeStackScreens.Home} component={Home} />
+    <Stack.Navigator headerMode="screen">
+      <Stack.Screen
+        name={HomeStackScreens.Home}
+        component={Home}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={HomeStackScreens.EnterSymptoms}
+        component={EnterSymptomsScreen}
+        options={{
+          ...TransitionPresets.ModalTransition,
+          gestureEnabled: false,
+          header: applyModalHeader(t("screen_titles.select_symptoms")),
+        }}
+      />
+      <Stack.Screen
+        name={HomeStackScreens.EmergencyRecommendation}
+        component={EmergencyRecommendationScreen}
+        options={{
+          gestureEnabled: false,
+          header: applyModalHeader("", () => {
+            navigation.navigate(Stacks.Home, {
+              screen: HomeStackScreens.Home,
+            })
+          }),
+        }}
+      />
+      <Stack.Screen
+        name={HomeStackScreens.CovidRecommendation}
+        component={CovidRecommendationScreen}
+        options={{
+          gestureEnabled: false,
+          header: applyModalHeader("", () => {
+            navigation.navigate(Stacks.Home, {
+              screen: HomeStackScreens.Home,
+            })
+          }),
+        }}
+      />
     </Stack.Navigator>
+  )
+}
+
+const EnterSymptomsScreen: FunctionComponent = () => {
+  const navigation = useNavigation()
+  const { symptomHistory } = useSymptomHistoryContext()
+  const todaysEntry = symptomHistory[0]
+
+  return (
+    <SelectSymptomsForm
+      showNoSymptoms={false}
+      entry={todaysEntry}
+      onSubmitEmergencySymptoms={() =>
+        navigation.navigate(HomeStackScreens.EmergencyRecommendation)
+      }
+      onSubmitCovidSympotoms={() =>
+        navigation.navigate(HomeStackScreens.CovidRecommendation)
+      }
+      onSubmitNoSymptoms={() => navigation.goBack()}
+    />
+  )
+}
+
+const EmergencyRecommendationScreen: FunctionComponent = () => {
+  return <CallEmergencyServices />
+}
+
+const CovidRecommendationScreen: FunctionComponent = () => {
+  const navigation = useNavigation()
+
+  return (
+    <CovidRecommendation
+      onDismiss={() => navigation.navigate(HomeStackScreens.Home)}
+    />
   )
 }
 

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -28,7 +28,7 @@ import ProtectPrivacy from "../modals/ProtectPrivacy"
 import AffectedUserStack from "../AffectedUserFlow/"
 import AnonymizedDataConsentScreen from "../ProductAnalytics/AnonymizedDataConsentScreen"
 import SelfAssessmentStack from "./SelfAssessmentStack"
-import ExposureDetectionStatus from "../Home/ExposureDetectionStatus"
+import ExposureDetectionStatusScreen from "../Home/ExposureDetectionStatus/Screen"
 import BluetoothInfo from "../Home/BluetoothInfo"
 import ExposureNotificationsInfo from "../Home/ExposureNotificationsInfo"
 import LocationInfo from "../Home/LocationInfo"
@@ -185,7 +185,7 @@ const MainNavigator: FunctionComponent = () => {
         </Stack.Screen>
         <Stack.Screen
           name={HomeStackScreens.ExposureDetectionStatus}
-          component={ExposureDetectionStatus}
+          component={ExposureDetectionStatusScreen}
           options={{
             ...Headers.headerMinimalOptions,
             headerLeft: applyHeaderLeftBackButton(),

--- a/src/navigation/ModalHeader.tsx
+++ b/src/navigation/ModalHeader.tsx
@@ -14,11 +14,6 @@ import {
   Outlines,
 } from "../styles"
 
-interface ModalHeaderProps {
-  headerTitle: string
-  handleOnDismiss?: () => void
-}
-
 export const applyModalHeader = (
   headerTitle: string,
   handleOnDismiss?: () => void,
@@ -31,6 +26,11 @@ export const applyModalHeader = (
       />
     )
   }
+}
+
+interface ModalHeaderProps {
+  headerTitle: string
+  handleOnDismiss?: () => void
 }
 
 const ModalHeader: FunctionComponent<ModalHeaderProps> = ({

--- a/src/navigation/SymptomHistoryStack.tsx
+++ b/src/navigation/SymptomHistoryStack.tsx
@@ -4,21 +4,24 @@ import {
   TransitionPresets,
 } from "@react-navigation/stack"
 import { useTranslation } from "react-i18next"
-import { useNavigation } from "@react-navigation/native"
+import { useNavigation, useRoute, RouteProp } from "@react-navigation/native"
 
 import SymptomHistoryScreen from "../SymptomHistory/"
-import SelectSymptomsScreen from "../SymptomHistory/Form/SelectSymptoms"
-import CallEmergencyServices from "../CallEmergencyServices"
+import SelectSymptomsForm from "../SymptomHistory/Form/SelectSymptoms"
 import { Stacks, SymptomHistoryStackScreens } from "./index"
 import { applyModalHeader } from "./ModalHeader"
 import { SymptomEntry } from "../SymptomHistory/symptomHistory"
+import CovidRecommendation from "../CovidRecommendation"
+import CallEmergencyServices from "../CallEmergencyServices"
 
 export type SymptomHistoryStackParams = {
   SymptomHistory: undefined
   AtRiskRecommendation: undefined
   SelectSymptoms: { symptomEntry: SymptomEntry }
-  CallEmergencyServices: undefined
+  EmergencyRecommendation: undefined
+  CovidRecommendation: undefined
 }
+
 const Stack = createStackNavigator<SymptomHistoryStackParams>()
 
 const SymptomHistoryStack: FunctionComponent = () => {
@@ -42,8 +45,21 @@ const SymptomHistoryStack: FunctionComponent = () => {
         }}
       />
       <Stack.Screen
-        name={SymptomHistoryStackScreens.CallEmergencyServices}
-        component={CallEmergencyServices}
+        name={SymptomHistoryStackScreens.EmergencyRecommendation}
+        component={EmergencyRecommendationScreen}
+        options={{
+          ...TransitionPresets.ModalTransition,
+          gestureEnabled: false,
+          header: applyModalHeader("", () => {
+            navigation.navigate(Stacks.SymptomHistory, {
+              screen: SymptomHistoryStackScreens.SymptomHistory,
+            })
+          }),
+        }}
+      />
+      <Stack.Screen
+        name={SymptomHistoryStackScreens.CovidRecommendation}
+        component={CovidRecommendationScreen}
         options={{
           ...TransitionPresets.ModalTransition,
           gestureEnabled: false,
@@ -55,6 +71,49 @@ const SymptomHistoryStack: FunctionComponent = () => {
         }}
       />
     </Stack.Navigator>
+  )
+}
+
+const SelectSymptomsScreen: FunctionComponent = () => {
+  const navigation = useNavigation()
+
+  const route = useRoute<
+    RouteProp<SymptomHistoryStackParams, "SelectSymptoms">
+  >()
+
+  const entry = route.params?.symptomEntry || {
+    kind: "NoUserInput",
+    date: Date.now(),
+  }
+
+  return (
+    <SelectSymptomsForm
+      entry={entry}
+      showNoSymptoms
+      onSubmitEmergencySymptoms={() =>
+        navigation.navigate(SymptomHistoryStackScreens.EmergencyRecommendation)
+      }
+      onSubmitCovidSympotoms={() =>
+        navigation.navigate(SymptomHistoryStackScreens.CovidRecommendation)
+      }
+      onSubmitNoSymptoms={() => navigation.goBack()}
+    />
+  )
+}
+
+const EmergencyRecommendationScreen: FunctionComponent = () => {
+  return <CallEmergencyServices />
+}
+
+const CovidRecommendationScreen: FunctionComponent = () => {
+  const navigation = useNavigation()
+
+  return (
+    <CovidRecommendation
+      onDismiss={() =>
+        navigation.navigate(SymptomHistoryStackScreens.SymptomHistory)
+      }
+    />
   )
 }
 

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -43,6 +43,9 @@ export type HomeStackScreen =
   | "ExposureNotificationsInfo"
   | "Home"
   | "LocationInfo"
+  | "EnterSymptoms"
+  | "EmergencyRecommendation"
+  | "CovidRecommendation"
 
 export const HomeStackScreens: {
   [key in HomeStackScreen]: HomeStackScreen
@@ -54,6 +57,9 @@ export const HomeStackScreens: {
   ExposureNotificationsInfo: "ExposureNotificationsInfo",
   Home: "Home",
   LocationInfo: "LocationInfo",
+  EnterSymptoms: "EnterSymptoms",
+  EmergencyRecommendation: "EmergencyRecommendation",
+  CovidRecommendation: "CovidRecommendation",
 }
 
 export type HowItWorksStackScreen =
@@ -187,14 +193,16 @@ export const WelcomeStackScreens: {
 export type SymptomHistoryStackScreen =
   | "SymptomHistory"
   | "SelectSymptoms"
-  | "CallEmergencyServices"
+  | "EmergencyRecommendation"
+  | "CovidRecommendation"
 
 export const SymptomHistoryStackScreens: {
   [key in SymptomHistoryStackScreen]: SymptomHistoryStackScreen
 } = {
   SymptomHistory: "SymptomHistory",
   SelectSymptoms: "SelectSymptoms",
-  CallEmergencyServices: "CallEmergencyServices",
+  EmergencyRecommendation: "EmergencyRecommendation",
+  CovidRecommendation: "CovidRecommendation",
 }
 
 export type SelfAssessmentStackScreen =


### PR DESCRIPTION
Why:
When a user enters symptoms to the symptom log that indicate they may
have Covid-19, we would like to show recommended guidance. We would also
like to prompt users to enter their symptom log for the current day on
the app's Dashboard.

This commit:
- Introduces a recommendation screen that will be navigated to if a user
has logged covid related symptoms.
- Introduces a module on the dashboard that will show a similar form to
the add symptoms form in the symptom history flow. Note that new screens
were added to the HomeStack so that the form can be open in a modal
directly from the home screen.
- Refactored the exposure detection component from the home screen to a
separate folder.

| Dashboard CTA | SymptomHistory |
|----|----|
|![covid-recommendation-cta](https://user-images.githubusercontent.com/16049495/98039727-27f8bf00-1ded-11eb-8866-de02c3b62a52.gif)|![covid-recommendation](https://user-images.githubusercontent.com/16049495/98039733-2929ec00-1ded-11eb-8bfb-8980ab39ec45.gif)|
