### PR TITLE
Improvement: Android get applicationId from .env.bt

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -148,7 +148,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "org.pathcheck.covidsafepaths.bt"
+        applicationId project.env.get("ANDROID_APPLICATION_ID")
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled true


### PR DESCRIPTION
#### Why:
Since it's already filled in the .env files there is no reason to hardcode it in the build.gradle. This way allowing easier fork maintenance for the jurisdictions.