### PR TITLE
Track number of exposure notifications preceding positive diagnosis

### DIFF
--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -39,20 +39,12 @@ const ActivateExposureNotifications: FunctionComponent = () => {
 
   const handleOnPressActivateExposureNotifications = async () => {
     await exposureNotifications.request()
-    trackEvent(
-      "product_analytics",
-      "button_tap",
-      "onboarding_en_permissions_accept",
-    )
+    trackEvent("product_analytics", "onboarding_en_permissions_accept")
     navigateToNextScreen()
   }
 
   const handleOnPressDontEnable = () => {
-    trackEvent(
-      "product_analytics",
-      "button_tap",
-      "onboarding_en_permissions_denied",
-    )
+    trackEvent("product_analytics", "onboarding_en_permissions_denied")
     navigateToNextScreen()
   }
 

--- a/src/Activation/ActivationSummary.tsx
+++ b/src/Activation/ActivationSummary.tsx
@@ -37,7 +37,7 @@ const ActivationSummary: FunctionComponent = () => {
   const isLocationRequired = locationPermissions !== "NotRequired"
 
   const handleOnPressGoToHome = () => {
-    trackEvent("product_analytics", "button_tap", "onboarding_completed")
+    trackEvent("product_analytics", "onboarding_completed")
     completeOnboarding()
   }
 

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -70,7 +70,7 @@ const CodeInputForm: FunctionComponent = () => {
   const handleOnPressSubmit = async () => {
     setIsLoading(true)
     setErrorMessage(defaultErrorMessage)
-    trackEvent("product_analytics", "button_tap", "verification_code_submitted")
+    trackEvent("product_analytics", "verification_code_submitted")
     try {
       const response = await API.postCode(code)
 

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -89,7 +89,8 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
     trackEvent(
       "epi_analytics",
       "ens_preceding_positive_diagnosis_count",
-      currentExposures.length.toString(),
+      undefined,
+      currentExposures.length,
     )
   }
 

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -18,6 +18,7 @@ import {
   AffectedUserFlowStackScreens,
   ModalStackScreens,
 } from "../../navigation"
+import { useExposureContext } from "../../ExposureContext"
 import { useProductAnalyticsContext } from "../../ProductAnalytics/Context"
 import { Icons } from "../../assets"
 import { Colors, Spacing, Iconography, Typography, Buttons } from "../../styles"
@@ -53,6 +54,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
   const navigation = useNavigation()
   const { t } = useTranslation()
   const { trackEvent } = useProductAnalyticsContext()
+  const { getCurrentExposures } = useExposureContext()
   const [isLoading, setIsLoading] = useState(false)
   const insets = useSafeAreaInsets()
   const style = createStyle(insets)
@@ -79,6 +81,16 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
           ),
       },
     ])
+  }
+
+  const trackEvents = async () => {
+    const currentExposures = await getCurrentExposures()
+    trackEvent("product_analytics", "key_submission_consented_to")
+    trackEvent(
+      "epi_analytics",
+      "ens_preceding_positive_diagnosis_count",
+      currentExposures.length.toString(),
+    )
   }
 
   const noOpAlertContent = ({ reason, newKeysInserted }: PostKeysNoOp) => {
@@ -149,11 +161,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
     setIsLoading(false)
     if (response.kind === "success") {
       storeRevisionToken(response.revisionToken)
-      trackEvent(
-        "product_analytics",
-        "button_tap",
-        "key_submission_consented_to",
-      )
+      trackEvents()
       navigation.navigate(AffectedUserFlowStackScreens.AffectedUserComplete)
     } else if (response.kind === "no-op") {
       handleNoOpResponse(response)

--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -88,7 +88,7 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
   useEffect(() => {
     const subscription = exposureInfoSubscription(
       (exposureInfo: ExposureInfo) => {
-        trackEvent("epi_analytics", "event_emitted", "en_notification_received")
+        trackEvent("epi_analytics", "en_notification_received")
         setExposureInfo(exposureInfo)
         getLastExposureDetectionDate()
       },

--- a/src/Home/ExposureDetectionStatus/Screen.tsx
+++ b/src/Home/ExposureDetectionStatus/Screen.tsx
@@ -109,11 +109,7 @@ const ExposureDetectionStatus: FunctionComponent = () => {
         if (status !== ENPermissionStatus.ENABLED) {
           showNotAuthorizedAlert()
         } else {
-          trackEvent(
-            "product_analytics",
-            "button_tap",
-            "exposure_notifications_enabled",
-          )
+          trackEvent("product_analytics", "exposure_notifications_enabled")
         }
       } catch {
         showNotAuthorizedAlert()

--- a/src/ProductAnalytics/AnonymizedDataConsentScreen.tsx
+++ b/src/ProductAnalytics/AnonymizedDataConsentScreen.tsx
@@ -33,18 +33,10 @@ const AnonymizedDataConsentScreen: FunctionComponent = () => {
     const nextConsentState = !userConsentedToAnalytics
     updateUserConsent(nextConsentState)
     if (inOnboardingFlow) {
-      trackEvent(
-        "product_analytics",
-        "button_tap",
-        "onboarding_consented_to_analytics",
-      )
+      trackEvent("product_analytics", "onboarding_consented_to_analytics")
       navigation.navigate(ActivationStackScreens.ActivationSummary)
     } else {
-      trackEvent(
-        "product_analytics",
-        "button_tap",
-        "settings_consented_to_analytics",
-      )
+      trackEvent("product_analytics", "settings_consented_to_analytics")
       navigation.goBack()
     }
   }

--- a/src/ProductAnalytics/Context.spec.tsx
+++ b/src/ProductAnalytics/Context.spec.tsx
@@ -71,7 +71,7 @@ describe("ProductAnalyticsContext", () => {
             category: "product_analytics",
             action: "event_action",
             name: "event_name",
-            value: "event_value",
+            value: 1,
           }
 
           const analyticsClient = testAnalyticsClient()
@@ -110,7 +110,7 @@ describe("ProductAnalyticsContext", () => {
             category: "product_analytics",
             action: "event_action",
             name: "event_name",
-            value: "event_value",
+            value: 1,
           }
 
           const analyticsClient = testAnalyticsClient()
@@ -141,7 +141,7 @@ describe("ProductAnalyticsContext", () => {
           category: "product_analytics",
           action: "event_action",
           name: "event_name",
-          value: "event_value",
+          value: 1,
         }
 
         const analyticsClient = testAnalyticsClient()
@@ -290,7 +290,7 @@ type Event = {
   category: EventCategory
   action: string
   name?: string
-  value?: string
+  value?: number
 }
 
 const TrackEvent: FunctionComponent<{

--- a/src/ProductAnalytics/Context.spec.tsx
+++ b/src/ProductAnalytics/Context.spec.tsx
@@ -8,7 +8,6 @@ import { factories } from "../factories"
 import {
   ProductAnalyticsContext,
   ProductAnalyticsProvider,
-  EventAction,
   EventCategory,
   ProductAnalyticsClient,
 } from "./Context"
@@ -70,8 +69,9 @@ describe("ProductAnalyticsContext", () => {
             .mockResolvedValueOnce(true)
           const expectedEvent: Event = {
             category: "product_analytics",
-            action: "button_tap",
+            action: "event_action",
             name: "event_name",
+            value: "event_value",
           }
 
           const analyticsClient = testAnalyticsClient()
@@ -93,6 +93,7 @@ describe("ProductAnalyticsContext", () => {
               expectedEvent.category,
               expectedEvent.action,
               expectedEvent.name,
+              expectedEvent.value,
             )
           })
         })
@@ -107,8 +108,9 @@ describe("ProductAnalyticsContext", () => {
 
           const expectedEvent: Event = {
             category: "product_analytics",
-            action: "button_tap",
+            action: "event_action",
             name: "event_name",
+            value: "event_value",
           }
 
           const analyticsClient = testAnalyticsClient()
@@ -137,8 +139,9 @@ describe("ProductAnalyticsContext", () => {
 
         const expectedEvent: Event = {
           category: "product_analytics",
-          action: "button_tap",
+          action: "event_action",
           name: "event_name",
+          value: "event_value",
         }
 
         const analyticsClient = testAnalyticsClient()
@@ -285,17 +288,18 @@ const UpdateConsent: FunctionComponent = () => {
 
 type Event = {
   category: EventCategory
-  action: EventAction
-  name: string
+  action: string
+  name?: string
+  value?: string
 }
 
 const TrackEvent: FunctionComponent<{
   event: Event
-}> = ({ event: { category, action, name } }) => {
+}> = ({ event: { category, action, name, value } }) => {
   const context = useContext(ProductAnalyticsContext)
 
   useEffect(() => {
-    context.trackEvent(category, action, name)
+    context.trackEvent(category, action, name, value)
   }, [context])
   return <Text> User consent status: {context.userConsentedToAnalytics}</Text>
 }

--- a/src/ProductAnalytics/Context.tsx
+++ b/src/ProductAnalytics/Context.tsx
@@ -16,7 +16,7 @@ export type ProductAnalyticsContextState = {
     category: EventCategory,
     action: string,
     name?: string,
-    value?: string,
+    value?: number,
   ) => Promise<void>
   trackScreenView: (screen: string) => Promise<void>
 }
@@ -34,7 +34,7 @@ export type ProductAnalyticsClient = {
     category: EventCategory,
     action: string,
     name?: string,
-    value?: string,
+    value?: number,
   ) => Promise<void>
   trackView: (route: string[]) => Promise<void>
 }
@@ -66,7 +66,7 @@ const ProductAnalyticsProvider: FunctionComponent<{
     category: EventCategory,
     action: string,
     name?: string,
-    value?: string,
+    value?: number,
   ): Promise<void> => {
     if (supportAnalyticsTracking) {
       productAnalyticsClient.trackEvent(category, action, name, value)

--- a/src/ProductAnalytics/Context.tsx
+++ b/src/ProductAnalytics/Context.tsx
@@ -14,8 +14,9 @@ export type ProductAnalyticsContextState = {
   updateUserConsent: (consent: boolean) => Promise<void>
   trackEvent: (
     category: EventCategory,
-    action: EventAction,
-    name: string,
+    action: string,
+    name?: string,
+    value?: string,
   ) => Promise<void>
   trackScreenView: (screen: string) => Promise<void>
 }
@@ -28,12 +29,12 @@ const initialContext = {
 }
 
 export type EventCategory = "product_analytics" | "epi_analytics"
-export type EventAction = "button_tap" | "event_emitted"
 export type ProductAnalyticsClient = {
   trackEvent: (
     category: EventCategory,
-    action: EventAction,
-    name: string,
+    action: string,
+    name?: string,
+    value?: string,
   ) => Promise<void>
   trackView: (route: string[]) => Promise<void>
 }
@@ -63,11 +64,12 @@ const ProductAnalyticsProvider: FunctionComponent<{
 
   const trackEvent = async (
     category: EventCategory,
-    action: EventAction,
-    name: string,
+    action: string,
+    name?: string,
+    value?: string,
   ): Promise<void> => {
     if (supportAnalyticsTracking) {
-      productAnalyticsClient.trackEvent(category, action, name)
+      productAnalyticsClient.trackEvent(category, action, name, value)
     }
   }
 


### PR DESCRIPTION
#### Why:
For users who have consented to share anonymized data, we'd like to track the number of exposure notifications received prior to submission of a positive diagnosis. 

#### This commit:
This commit sends an event to the analytics server at the time of key submission that includes the number of exposure notifications received up until that time. This commit also adjusts the naming schema for events, eliminating the `EventAction` type 