### PR TITLE
isolate -> quarantine, correct medical term

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -117,7 +117,8 @@
       "schedule_callback": "Schedule a call to get support from a contact tracer from the {{healthAuthorityName}}.",
       "speak_with_contact_tracer": "Speak with a contact tracer",
       "wash_your_hands": "Wash your hands",
-      "wear_a_mask": "Wear a mask"
+      "wear_a_mask": "Wear a mask",
+      "quarantine": "Quarantine"
     },
     "exposure_window": {
       "four_to_six_days_ago": "4 to 6 days ago",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -111,7 +111,7 @@
       "general_guidance": "General Guidance",
       "ha_guidance_header": "What should I do?",
       "header": "Someone you were nearby has since tested positive for COVID-19.",
-      "isolate": "Isolate",
+      "isolate": "Quarantine",
       "next_steps": "Next steps",
       "personalize_my_guidance": "Personalize my guidance",
       "schedule_callback": "Schedule a call to get support from a contact tracer from the {{healthAuthorityName}}.",


### PR DESCRIPTION
#### Why:

Noted by Epidemiologist that Isolate is not the correct term, it should be quarantine

#### This commit:

replaces isolate with quarantine. and adds new quarantine term in EN language file.

#### Notes
- I updated the term to quarantine for the isolate key
- added a new quarantine key for future use
- I did not update code to minimize language translation needs. (Ideally switch to new term when we get translations)