### PR TITLE
Use covidactnow api

### DIFF
--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Run script after yarn install
+#
+# Usage
+#
+#   bin/postinstall.sh
+
+
+# Rename ./node_modules/ts.data.json to ./node_modules/ts-data-json
+#
+# Why:
+# Metro bundler does not properly resolve package with the `.` character in the
+# package name.
+#
+# Reference:
+# https://github.com/facebook/metro/issues/330#issuecomment-641644390
+
+FILE=node_modules/ts.data.json
+if [ -d "$FILE" ]; then
+  echo "renaming ts.data.json to ts-data-json"
+  mv $FILE node_modules/ts-data-json
+fi

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "clean": "rm -rf node_modules && yarn",
     "start": "yarn && react-native start",
     "tsc": "tsc --noEmit",
     "prettier": "prettier \"src/**/*.+(js|jsx|ts|tsx|json)\"",
@@ -14,10 +13,11 @@
     "run-android": "react-native run-android --variant=debug --appId=org.pathcheck.covidsafepaths.bt",
     "run-ios": "yarn install:pod && react-native run-ios --scheme \"BT_Development\" --configuration \"Debug-BT\" --simulator \"iPhone 11 (13.5)\"",
     "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('You must use Yarn to install, not NPM')\"",
+    "postinstall": "npx react-native-jetifier && ./bin/postinstall.sh",
     "install:pod": "cd ios && bundle install --quiet && bundle exec pod install --silent",
-    "reset": "yarn cache clean && watchman watch-del-all && rm -rf node_modules && yarn && ./android/gradlew -p ./android clean && rm ios/Podfile.lock && yarn install:pod",
-    "postinstall": "npx react-native-jetifier",
-    "detox-setup": "detox clean-framework-cache && detox build-framework-cache",
+    "clean": "rm -rf node_modules && yarn cache clean && watchman watch-del-all && rm -rf /tmp/metro-bundler-cache-* && rm -rf /tmp/haste-map-react-native-packager-*",
+    "clean-all": "yarn clean && ./android/gradlew -p ./android clean && rm ios/Podfile.lock",
+    "reset": "yarn clean-all && yarn && yarn install:pod",
     "i18n:check": "./src/locales/check.sh",
     "i18n:extract": "i18next",
     "i18n:pull": "./src/locales/pull.sh",
@@ -67,7 +67,8 @@
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.0.3",
     "reanimated-bottom-sheet": "^1.0.0-alpha.19",
-    "regression": "^2.0.1"
+    "regression": "^2.0.1",
+    "ts.data.json": "^1.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/src/CovidData/API/covidActNow.ts
+++ b/src/CovidData/API/covidActNow.ts
@@ -1,0 +1,154 @@
+import { JsonDecoder } from "ts-data-json"
+import env from "react-native-config"
+
+import Logger from "../../logger"
+import { CovidData, CovidDatum } from "../covidData"
+
+const API_KEY = env.COVID_ACT_NOW_API_KEY
+
+const BASE_URL = "https://api.covidactnow.org/v2/"
+const apiParam = `apiKey=${API_KEY}`
+
+const stateHistoryEndpoint = (state: string) => {
+  return BASE_URL + `state/${state}.timeseries.json?` + apiParam
+}
+
+const requestHeaders = {
+  "content-type": "application/json",
+  accept: "application/json",
+}
+
+export type NetworkResponse = RequestSuccess | RequestFailure
+
+export interface RequestSuccess {
+  kind: "success"
+  data: CovidData
+}
+
+type NetworkError =
+  | "BadRequest"
+  | "InternalError"
+  | "JsonDeserialization"
+  | "NetworkConnection"
+  | "Unknown"
+
+export interface RequestFailure {
+  kind: "failure"
+  error: NetworkError
+}
+
+type Actuals = {
+  cases: number
+  newCases: number
+  deaths: number | null
+  positiveTests: number | null
+  negativeTests: number | null
+  contactTracers: number | null
+}
+
+type ActualsDatum = Actuals & WithDate
+
+type WithDate = {
+  date: string
+}
+
+type ActualsTimeseries = Array<ActualsDatum | null>
+
+type StateCovidData = {
+  fips: string
+  country: string
+  actuals: Actuals
+  actualsTimeseries: ActualsTimeseries
+}
+
+const ActualsDecoder = JsonDecoder.object<Actuals>(
+  {
+    cases: JsonDecoder.number,
+    newCases: JsonDecoder.number,
+    deaths: JsonDecoder.nullable(JsonDecoder.number),
+    positiveTests: JsonDecoder.nullable(JsonDecoder.number),
+    negativeTests: JsonDecoder.nullable(JsonDecoder.number),
+    contactTracers: JsonDecoder.nullable(JsonDecoder.number),
+  },
+  "Actuals",
+)
+
+const DateDecoder = JsonDecoder.object<WithDate>(
+  {
+    date: JsonDecoder.string,
+  },
+  "WithData",
+)
+
+const ActualsDatumDecoder = JsonDecoder.combine(ActualsDecoder, DateDecoder)
+
+const StateTimeseriesDecoder = JsonDecoder.object<StateCovidData>(
+  {
+    fips: JsonDecoder.string,
+    country: JsonDecoder.string,
+    actuals: ActualsDecoder,
+    actualsTimeseries: JsonDecoder.array(
+      JsonDecoder.failover(null, ActualsDatumDecoder),
+      "ActualsTimeseries",
+    ),
+  },
+  "StateTimeseriesDecoder",
+)
+
+const toCovidData = (stateData: StateCovidData): CovidData => {
+  const timeseries = stateData.actualsTimeseries
+
+  const compact = <T>(arr: Array<T | null>): T[] => {
+    return arr.reduce<T[]>((acc: T[], el: T | null) => {
+      if (el) {
+        return [el, ...acc]
+      } else {
+        return acc
+      }
+    }, [])
+  }
+
+  const toCovidDatum = (actualsDatum: ActualsDatum): CovidDatum => {
+    return {
+      date: actualsDatum.date,
+      positiveCasesNew: actualsDatum.newCases,
+      positiveCasesTotal: actualsDatum.cases,
+    }
+  }
+
+  return compact(timeseries).map(toCovidDatum)
+}
+
+export const fetchStateTimeseries = async (
+  state: string,
+): Promise<NetworkResponse> => {
+  const endpointUrl = stateHistoryEndpoint(state)
+  try {
+    const response = await fetch(endpointUrl, {
+      method: "GET",
+      headers: requestHeaders,
+    })
+
+    const json = await response.json()
+
+    const stateData = await StateTimeseriesDecoder.decodePromise(json)
+
+    return {
+      kind: "success",
+      data: toCovidData(stateData),
+    }
+  } catch (e) {
+    if (e.contains("decoder failed")) {
+      Logger.error("Failed to desieralize covid api data", { url: endpointUrl })
+      return { kind: "failure", error: "JsonDeserialization" }
+    }
+    switch (e.message) {
+      case "Network request failed": {
+        return { kind: "failure", error: "NetworkConnection" }
+      }
+      default: {
+        return { kind: "failure", error: "Unknown" }
+      }
+    }
+  }
+}

--- a/src/CovidData/API/localCovidData.ts
+++ b/src/CovidData/API/localCovidData.ts
@@ -1,6 +1,5 @@
-import Logger from "../logger"
-
-import { CovidData, CovidDatum } from "./covidData"
+import Logger from "../../logger"
+import { CovidData, CovidDatum } from "../covidData"
 
 const COVID_DATA_ENDPOINT =
   "https://localcoviddata.com/covid19/v1/cases/covidTracking?state="
@@ -65,16 +64,12 @@ export const toCovidData = (networkModel: NetworkModel): CovidData => {
       date,
       peoplePositiveNewCasesCt: positiveCasesNew,
       peoplePositiveCasesCt: positiveCasesTotal,
-      peopleDeathCt: deathsTotal,
-      peopleDeathNewCt: deathsNew,
     } = networkDatum
 
     return {
       date,
       positiveCasesNew,
       positiveCasesTotal,
-      deathsTotal,
-      deathsNew,
     }
   }
 

--- a/src/CovidData/Card/CovidDataInfo.tsx
+++ b/src/CovidData/Card/CovidDataInfo.tsx
@@ -38,7 +38,7 @@ const CovidDataInfo: FunctionComponent<CovidDataInfoProps> = ({
   const trendColor =
     trend > 0 ? Colors.accent.warning100 : Colors.accent.success100
 
-  const source = "localcoviddata.com"
+  const source = "covidactnow.org"
   const sourceText = t("covid_data.source", { source })
   const labelText = t("covid_data.new_cases")
 

--- a/src/CovidData/Context.spec.tsx
+++ b/src/CovidData/Context.spec.tsx
@@ -5,9 +5,9 @@ import { render, waitFor } from "@testing-library/react-native"
 import { factories } from "../factories"
 import { ConfigurationContext } from "../ConfigurationContext"
 import { useCovidDataContext, CovidDataContextProvider } from "./Context"
-import { fetchCovidDataForState } from "./covidDataAPI"
+import { fetchStateTimeseries } from "./API/covidActNow"
 
-jest.mock("./covidDataAPI.ts")
+jest.mock("./API/covidActNow.ts")
 describe("CovidDataContextProvider", () => {
   it("doesn't start the request if it should not be requested", async () => {
     const configurationContext = factories.configurationContext.build({
@@ -55,7 +55,7 @@ describe("CovidDataContextProvider", () => {
 
     const data = factories.covidData.build()
 
-    ;(fetchCovidDataForState as jest.Mock).mockResolvedValueOnce({
+    ;(fetchStateTimeseries as jest.Mock).mockResolvedValueOnce({
       kind: "success",
       data,
     })
@@ -82,7 +82,7 @@ describe("CovidDataContextProvider", () => {
       stateAbbreviation: "state",
     })
 
-    ;(fetchCovidDataForState as jest.Mock).mockResolvedValueOnce({
+    ;(fetchStateTimeseries as jest.Mock).mockResolvedValueOnce({
       kind: "failure",
     })
 

--- a/src/CovidData/Context.tsx
+++ b/src/CovidData/Context.tsx
@@ -9,7 +9,7 @@ import React, {
 import { useConfigurationContext } from "../ConfigurationContext"
 
 import * as CovidData from "./covidData"
-import { fetchCovidDataForState, NetworkResponse } from "./covidDataAPI"
+import { fetchStateTimeseries, NetworkResponse } from "./API/covidActNow"
 
 export type RequestStatus = "SUCCESS" | "LOADING" | "ERROR" | "MISSING_INFO"
 
@@ -43,7 +43,7 @@ export const CovidDataContextProvider: FunctionComponent = ({ children }) => {
 
   const fetchCovidData = useCallback((): Promise<NetworkResponse> => {
     if (stateAbbreviation && displayCovidData) {
-      return fetchCovidDataForState(stateAbbreviation)
+      return fetchStateTimeseries(stateAbbreviation)
     } else {
       return Promise.resolve({ kind: "failure", error: "BadRequest" })
     }

--- a/src/CovidData/Dashboard/StateData.tsx
+++ b/src/CovidData/Dashboard/StateData.tsx
@@ -29,16 +29,8 @@ const StateData: FunctionComponent<StateDataProps> = ({
         <Text style={style.dataText}>{todayCovidData.positiveCasesNew}</Text>
       </View>
       <View style={style.labelAndDataContainer}>
-        <Text style={style.dataText}>{t("covid_data.deaths_today")}</Text>
-        <Text style={style.dataText}>{todayCovidData.deathsNew}</Text>
-      </View>
-      <View style={style.labelAndDataContainer}>
         <Text style={style.dataText}>{t("covid_data.total_cases")}</Text>
         <Text style={style.dataText}>{todayCovidData.positiveCasesTotal}</Text>
-      </View>
-      <View style={style.labelAndDataContainer}>
-        <Text style={style.dataText}>{t("covid_data.total_deaths")}</Text>
-        <Text style={style.dataText}>{todayCovidData.deathsTotal}</Text>
       </View>
     </View>
   )

--- a/src/CovidData/covidData.ts
+++ b/src/CovidData/covidData.ts
@@ -4,8 +4,6 @@ export const empty: CovidDatum = {
   date: "2020-01-01",
   positiveCasesTotal: 0,
   positiveCasesNew: 0,
-  deathsTotal: 0,
-  deathsNew: 0,
 }
 
 type Date = string
@@ -14,8 +12,6 @@ export type CovidDatum = {
   date: Date
   positiveCasesTotal: number
   positiveCasesNew: number
-  deathsTotal: number
-  deathsNew: number
 }
 
 export const toNewCasesPercentage = (data: CovidData): number | null => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,6 +1186,7 @@
 "@react-native-community/cli@^4.7.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-4.13.0.tgz#04d5032f9b2b423c61ceef6be83b1bcc8a37db75"
+  integrity sha512-R+1VehIQ6VTLf+e7YOwzJk0F9tstfeSC4xy7oT6GSgB3FnXbTJGHFUp4siyO68Ae/gzGqt8SiUO145teWkP+ZA==
   dependencies:
     "@hapi/joi" "^15.0.3"
     "@react-native-community/cli-debugger-ui" "^4.9.0"
@@ -8069,6 +8070,11 @@ truncate-utf8-bytes@^1.0.0:
   resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
   dependencies:
     utf8-byte-length "^1.0.1"
+
+ts.data.json@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/ts.data.json/-/ts.data.json-1.5.0.tgz#fe6484546974d0787f5a3224a91187355699db52"
+  integrity sha512-LLC8b4un4sRtWBA47MYaBF+JxsDYq/dUDQrl1Y2l7+RZLBbZvQpIEmr2vCCo6Tegg+hay3sBFYiQHxtTknSDtA==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
Why:
We would like to use the covidactnow.org api as it has a data set that
will allow us to show covid statistic and metrics for both states and
counties.

This commit:
Introduces an api fetch that consumes the covidactnow.org data. We also
introduced the `ts.data.json` package to use json decoders for decoding
the response json.

Note that the package name includes several `.` characters with metro
bundler does not handle correctly when calculating the sha1 hash for the
cache key in the bundler haste map. We resolved this issue by
introducing a postinstall script for yarn that will rename the package
within nodemodules.

Co-Authored-By: matt buckley <matt@nicethings.io>

![Simulator Screen Shot - iPhone 11 - 2020-11-05 at 10 43 43](https://user-images.githubusercontent.com/16049495/98266344-2e577a00-1f58-11eb-8215-3ef6c886aa41.png)
