### PR TITLE
Add more link to covid data feature

### DIFF
--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -16,6 +16,7 @@ export interface Configuration {
   emergencyPhoneNumber: string
   findATestCenterUrl: string | null
   healthAuthorityAdviceUrl: string
+  healthAuthorityCovidDataUrl: string | null
   healthAuthorityEulaUrl: string | null
   healthAuthorityLearnMoreUrl: string
   healthAuthorityLegalPrivacyPolicyUrl: string | null
@@ -40,6 +41,7 @@ const initialState: Configuration = {
   emergencyPhoneNumber: "",
   findATestCenterUrl: null,
   healthAuthorityAdviceUrl: "",
+  healthAuthorityCovidDataUrl: null,
   healthAuthorityEulaUrl: null,
   healthAuthorityLearnMoreUrl: "",
   healthAuthorityLegalPrivacyPolicyUrl: "",
@@ -57,6 +59,7 @@ const ConfigurationContext = createContext<Configuration>(initialState)
 const ConfigurationProvider: FunctionComponent = ({ children }) => {
   const {
     AUTHORITY_ADVICE_URL: healthAuthorityAdviceUrl,
+    AUTHORITY_COVID_DATA_URL: healthAuthorityCovidDataUrl,
     EMERGENCY_PHONE_NUMBER: emergencyPhoneNumber,
     EULA_URL: eulaUrl,
     FIND_A_TEST_CENTER_URL: findATestCenterUrl,
@@ -105,6 +108,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         emergencyPhoneNumber,
         findATestCenterUrl,
         healthAuthorityAdviceUrl,
+        healthAuthorityCovidDataUrl,
         healthAuthorityEulaUrl: eulaUrl || null,
         healthAuthorityLearnMoreUrl,
         healthAuthorityLegalPrivacyPolicyUrl: legalPrivacyPolicyUrl || null,

--- a/src/CovidData/Dashboard/index.tsx
+++ b/src/CovidData/Dashboard/index.tsx
@@ -1,31 +1,63 @@
 import React, { FunctionComponent } from "react"
-import { ScrollView, StyleSheet } from "react-native"
+import {
+  View,
+  Linking,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from "react-native"
+import { useTranslation } from "react-i18next"
 
+import { useConfigurationContext } from "../../ConfigurationContext"
+import { Text } from "../../components"
 import { useCovidDataContext } from "../Context"
 import StateData from "./StateData"
 
-import { Colors, Spacing } from "../../styles"
+import { Typography, Buttons, Colors, Spacing } from "../../styles"
 
 const CovidDataDashboard: FunctionComponent = () => {
+  const { t } = useTranslation()
+
   const {
     request: { status, data },
   } = useCovidDataContext()
+  const { healthAuthorityCovidDataUrl } = useConfigurationContext()
 
   if (status === "MISSING_INFO") {
     return null
   }
 
+  const handleOnPressLearnMore = () => {
+    if (healthAuthorityCovidDataUrl) {
+      Linking.openURL(healthAuthorityCovidDataUrl)
+    }
+  }
+
   return (
-    <ScrollView
-      style={style.container}
-      contentContainerStyle={style.contentContainer}
-    >
-      <StateData data={data} />
-    </ScrollView>
+    <View style={style.outerContainer}>
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+      >
+        <StateData data={data} />
+      </ScrollView>
+      {healthAuthorityCovidDataUrl ? (
+        <TouchableOpacity
+          style={style.button}
+          onPress={handleOnPressLearnMore}
+          testID="shareButton"
+        >
+          <Text style={style.buttonText}>{t("common.learn_more")}</Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
   )
 }
 
 const style = StyleSheet.create({
+  outerContainer: {
+    flex: 1,
+  },
   container: {
     backgroundColor: Colors.background.primaryLight,
   },
@@ -34,6 +66,13 @@ const style = StyleSheet.create({
     paddingBottom: Spacing.xxxLarge,
     paddingHorizontal: Spacing.medium,
     backgroundColor: Colors.background.primaryLight,
+  },
+  button: {
+    ...Buttons.fixedBottom.base,
+    paddingBottom: Spacing.xLarge,
+  },
+  buttonText: {
+    ...Typography.button.fixedBottom,
   },
 })
 

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -13,6 +13,7 @@ export default Factory.define<Configuration>(() => ({
   emergencyPhoneNumber: "emergencyPhoneNumber",
   findATestCenterUrl: "findATestCenterUrl",
   healthAuthorityAdviceUrl: "authorityAdviceUrl",
+  healthAuthorityCovidDataUrl: "authorityCovidDataUrl",
   healthAuthorityLearnMoreUrl: "authorityLearnMoreUrl",
   healthAuthorityEulaUrl: "healthAuthorityEulaUrl",
   healthAuthorityName: "authorityName",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -22,6 +22,7 @@
     "continue": "Continue",
     "done": "Done",
     "edit": "Edit",
+    "learn_more": "Learn more",
     "maybe_later": "Maybe later",
     "more": "More",
     "next": "Next",


### PR DESCRIPTION
Why:
We would like for authorities to be able to provide a 'learn more' link
to bespoke covid data dashboards.

This commit:
Adds a button with a link to an external website on the covid data
details screen.

![Simulator Screen Shot - iPhone 11 - 2020-11-05 at 17 21 15](https://user-images.githubusercontent.com/16049495/98303683-84deab80-1f8c-11eb-96b4-bcd449f4b2a7.png)
