### PR TITLE
fix About text sentence structure

### DIFF
--- a/src/Settings/index.spec.tsx
+++ b/src/Settings/index.spec.tsx
@@ -85,7 +85,7 @@ describe("Settings", () => {
     )
 
     expect(
-      getByText(/The applicationName app is made available by authorityName/),
+      getByText(/The applicationName app is made available by the authorityName/),
     ).toBeDefined()
   })
 

--- a/src/Settings/index.spec.tsx
+++ b/src/Settings/index.spec.tsx
@@ -85,7 +85,9 @@ describe("Settings", () => {
     )
 
     expect(
-      getByText(/The applicationName app is made available by the authorityName/),
+      getByText(
+        /The applicationName app is made available by the authorityName/,
+      ),
     ).toBeDefined()
   })
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,7 +1,7 @@
 {
   "_display_name": "English",
   "about": {
-    "description": "The {{applicationName}} app is made available by {{healthAuthorityName}}.",
+    "description": "The {{applicationName}} app is made available by the {{healthAuthorityName}}.",
     "operating_system_abbr": "OS:",
     "version": "Version:"
   },


### PR DESCRIPTION
#### Why:

Updated default About Text. The grammar was incorrect.

#### This commit:

- Adds correct grammar for about text in english text
- Updates test case

#### Notes:

If my suggestion is not valid, please do correct.
