### PR TITLE
en translations typos, minor updates

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -158,7 +158,7 @@
     "your_device_is_scanning": "Your device is scanning for exposures and will continue to do so even if you close the app."
   },
   "home": {
-    "bluetooth_info_body": "Your phone detects other phones you spend time in close proximity with using Bluetooth Low Energy. This allows the app to log your log daily encounters anonymously, even when you don’t have the app open on your device.",
+    "bluetooth_info_body": "Your phone detects other phones you spend time in close proximity with using Bluetooth Low Energy. This allows the app to log your daily encounters anonymously, even when you don’t have the app open on your device.",
     "bluetooth": {
       "all_services_on_subheader": "{{applicationName}} will remain active after the app has been closed",
       "bluetooth_disabled_error_message": "Go to the Settings app and enable Bluetooth to fix this error",
@@ -223,9 +223,9 @@
     "activation_header_title": "App Setup",
     "app_setup_complete_body": "{{applicationName}} is active. Thank you for helping break the chain of infection.",
     "app_setup_complete_header": "App Setup Complete!",
-    "app_setup_incomplete_body": "{{applicationName}} requires Exposure Notifications and Bluetooth permissions to know when  and where you have been exposed to COVID 19. You can authorize this in Settings.",
+    "app_setup_incomplete_body": "{{applicationName}} requires Exposure Notifications and Bluetooth permissions to know when and where you have been exposed to COVID-19. You can authorize this in Settings.",
     "app_setup_incomplete_header": "App Setup Incomplete",
-    "app_setup_incomplete_location_body": "{{applicationName}} requires Exposure Notifications, Bluetooth, and Location permissions to know when and where you have been exposed to COVID 19. You can authorize this in Settings.",
+    "app_setup_incomplete_location_body": "{{applicationName}} requires Exposure Notifications, Bluetooth, and Location permissions to know when and where you have been exposed to COVID-19. You can authorize this in Settings.",
     "bluetooth_alert_body": "To use Bluetooth scanning, the device Bluetooth setting needs to be turned on.",
     "bluetooth_alert_header": "Activate Bluetooth",
     "bluetooth_body": "To use Bluetooth scanning, the device Bluetooth setting needs to be turned on.",
@@ -262,7 +262,7 @@
       "subheader_5": "You will be notified if {{applicationName}} finds a positive match with a flagged ID"
     },
     "proximity_tracing_body1": "If smartphones with the app installed are turned on, have bluetooth enabled, and are near each other for a period of time, an encounter is registered on your device.",
-    "proximity_tracing_body2": "In the event of an encounter, your data, and information remain anonymous. The app doesn’t store any personal data. Only random IDs are exchanged. These are deleted within 14 days.",
+    "proximity_tracing_body2": "In the event of an encounter, your data, and information remain anonymous. The app doesn’t store any personal data. Only random IDs are exchanged. These are deleted after 14 days.",
     "proximity_tracing_button": "Activate Exposure Notifications",
     "proximity_tracing_header": "Activate Exposure Notifications",
     "proximity_tracing_subheader1": "How does it work?",
@@ -278,7 +278,7 @@
     "screen3_header": "No personally identifiable information ever leaves your phone.",
     "screen3_image_label": "A person in front of a locked phone",
     "screen4_button": "Get started",
-    "screen4_header": "The app will notify you if you may have been exposed to COVID 19",
+    "screen4_header": "The app will notify you if you may have been exposed to COVID-19",
     "screen4_image_label": "A person getting a notification on their phone",
     "terms_header_title": "Terms of use",
     "verify_your_age": "Verify Your Age",


### PR DESCRIPTION
#### Why:

clean up english translations

#### This commit:

- fix typos
- consistent use of COVID-19
- minor phrase updates
