### PR TITLE
Fix text overflow issue on en status card

### DIFF
--- a/src/Home/ExposureDetectionStatus/AnimatedCircle.tsx
+++ b/src/Home/ExposureDetectionStatus/AnimatedCircle.tsx
@@ -1,0 +1,100 @@
+import React, {
+  FunctionComponent,
+  useRef,
+  useEffect,
+  useState,
+  useCallback,
+} from "react"
+import { Easing, Animated, AccessibilityInfo } from "react-native"
+
+import { Outlines, Colors } from "../../styles"
+
+interface AnimatedCircleProps {
+  iconSize: number
+}
+
+const AnimatedCircle: FunctionComponent<AnimatedCircleProps> = ({
+  iconSize,
+}) => {
+  const [isReduceMotionEnabled, setIsReduceMotionEnabled] = useState<boolean>(
+    false,
+  )
+
+  const animationTime = 1600
+  const delayTime = 2000
+  const initialCircleSize = 0
+  const endingCircleSize = 600
+  const initialTopValue = iconSize / 2
+  const endingTopValue = endingCircleSize * -0.46
+  const initialOpacity = 0.2
+  const endingOpacity = 0.0
+
+  const sizeAnimatedValue = useRef(new Animated.Value(initialCircleSize))
+    .current
+  const topAnimatedValue = useRef(new Animated.Value(initialTopValue)).current
+  const opacityAnimatedValue = useRef(new Animated.Value(initialOpacity))
+    .current
+
+  const playAnimation = useCallback(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.parallel([
+          Animated.timing(sizeAnimatedValue, {
+            toValue: endingCircleSize,
+            duration: animationTime,
+            easing: Easing.quad,
+            useNativeDriver: false,
+          }),
+          Animated.timing(topAnimatedValue, {
+            toValue: endingTopValue,
+            duration: animationTime,
+            easing: Easing.quad,
+            useNativeDriver: false,
+          }),
+          Animated.timing(opacityAnimatedValue, {
+            toValue: endingOpacity,
+            duration: animationTime,
+            easing: Easing.quad,
+            useNativeDriver: false,
+          }),
+          Animated.delay(delayTime),
+        ]),
+      ]),
+    ).start()
+  }, [
+    endingTopValue,
+    opacityAnimatedValue,
+    sizeAnimatedValue,
+    topAnimatedValue,
+  ])
+
+  useEffect(playAnimation, [playAnimation])
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled()?.then((result) => {
+      setIsReduceMotionEnabled(result)
+    })
+  }, [])
+
+  if (isReduceMotionEnabled) {
+    return null
+  }
+
+  return (
+    <Animated.View
+      style={{
+        position: "absolute",
+        top: topAnimatedValue,
+        alignSelf: "center",
+        width: sizeAnimatedValue,
+        height: sizeAnimatedValue,
+        borderColor: Colors.accent.success100,
+        borderWidth: Outlines.hairline,
+        borderRadius: Outlines.borderRadiusMax,
+        opacity: opacityAnimatedValue,
+      }}
+    />
+  )
+}
+
+export default AnimatedCircle

--- a/src/Home/ExposureDetectionStatus/Card.tsx
+++ b/src/Home/ExposureDetectionStatus/Card.tsx
@@ -1,23 +1,11 @@
-import React, {
-  FunctionComponent,
-  useRef,
-  useEffect,
-  useState,
-  useCallback,
-} from "react"
-import {
-  StyleSheet,
-  Easing,
-  Animated,
-  AccessibilityInfo,
-  View,
-  TouchableOpacity,
-} from "react-native"
+import React, { FunctionComponent } from "react"
+import { TouchableOpacity, StyleSheet, View } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
 import { useExposureDetectionStatus } from "../../Device/useExposureDetectionStatus"
+import AnimatedCircle from "./AnimatedCircle"
 
 import { HomeStackScreens } from "../../navigation"
 import { Text } from "../../components"
@@ -33,8 +21,6 @@ import {
   Affordances,
 } from "../../styles"
 
-const STATUS_ICON_SIZE = Iconography.small
-
 const ExposureDetectionStatusCard: FunctionComponent = () => {
   const navigation = useNavigation()
   const { t } = useTranslation()
@@ -44,30 +30,44 @@ const ExposureDetectionStatusCard: FunctionComponent = () => {
     navigation.navigate(HomeStackScreens.ExposureDetectionStatus)
   }
 
-  const statusBackgroundColor = exposureDetectionStatus
-    ? Colors.accent.success25
-    : Colors.accent.danger25
-  const statusBorderColor = exposureDetectionStatus
-    ? Colors.accent.success100
-    : Colors.accent.danger100
-  const statusIcon = exposureDetectionStatus
-    ? Icons.CheckInCircle
-    : Icons.XInCircle
-  const statusIconFill = exposureDetectionStatus
-    ? Colors.accent.success100
-    : Colors.accent.danger100
-  const statusText = exposureDetectionStatus
-    ? t("home.bluetooth.tracing_on_header")
-    : t("home.bluetooth.tracing_off_header")
-  const actionText = exposureDetectionStatus
-    ? t("exposure_scanning_status.learn_more")
-    : t("exposure_scanning_status.fix_this")
+  const enabledConfig = {
+    statusBackgroundColor: Colors.accent.success25,
+    statusBorderColor: Colors.accent.success100,
+    statusIcon: Icons.CheckInCircle,
+    statusIconFill: Colors.accent.success100,
+    statusText: t("home.bluetooth.tracing_on_header"),
+    actionText: t("exposure_scanning_status.learn_more"),
+  }
+
+  const disabledConfig = {
+    statusBackgroundColor: Colors.accent.danger25,
+    statusBorderColor: Colors.accent.danger100,
+    statusIcon: Icons.XInCircle,
+    statusIconFill: Colors.accent.danger100,
+    statusText: t("home.bluetooth.tracing_off_header"),
+    actionText: t("exposure_scanning_status.fix_this"),
+  }
+
+  const determineConfig = () => {
+    return exposureDetectionStatus ? enabledConfig : disabledConfig
+  }
+
+  const {
+    statusBackgroundColor,
+    statusBorderColor,
+    statusIcon,
+    statusIconFill,
+    statusText,
+    actionText,
+  } = determineConfig()
 
   const statusContainerStyle = {
     ...style.statusContainer,
     backgroundColor: statusBackgroundColor,
     borderColor: statusBorderColor,
   }
+
+  const iconSize = Iconography.small
 
   return (
     <TouchableOpacity
@@ -77,18 +77,20 @@ const ExposureDetectionStatusCard: FunctionComponent = () => {
       onPress={handleOnPressExposureDetectionStatus}
     >
       <View style={style.statusTopContainer}>
-        <Text style={style.statusText} testID={"home-header"}>
-          {statusText}
-        </Text>
-        <View>
+        <View style={style.statusTextContainer}>
+          <Text style={style.statusText} testID="home-header">
+            {statusText}
+          </Text>
+        </View>
+        <View style={style.iconContainer}>
           <SvgXml
             xml={statusIcon}
-            width={STATUS_ICON_SIZE}
-            height={STATUS_ICON_SIZE}
+            width={iconSize}
+            height={iconSize}
             fill={statusIconFill}
             style={style.statusIcon}
           />
-          {exposureDetectionStatus && <ExpandingCircleAnimation />}
+          {exposureDetectionStatus && <AnimatedCircle iconSize={iconSize} />}
         </View>
       </View>
       <View style={style.statusBottomContainer}>
@@ -103,101 +105,28 @@ const ExposureDetectionStatusCard: FunctionComponent = () => {
     </TouchableOpacity>
   )
 }
-const ExpandingCircleAnimation: FunctionComponent = () => {
-  const [isReduceMotionEnabled, setIsReduceMotionEnabled] = useState<boolean>(
-    false,
-  )
-
-  const animationTime = 1600
-  const delayTime = 2000
-  const initialCircleSize = 0
-  const endingCircleSize = 600
-  const initialTopValue = STATUS_ICON_SIZE / 2
-  const endingTopValue = endingCircleSize * -0.46
-  const initialOpacity = 0.2
-  const endingOpacity = 0.0
-
-  const sizeAnimatedValue = useRef(new Animated.Value(initialCircleSize))
-    .current
-  const topAnimatedValue = useRef(new Animated.Value(initialTopValue)).current
-  const opacityAnimatedValue = useRef(new Animated.Value(initialOpacity))
-    .current
-
-  const playAnimation = useCallback(() => {
-    Animated.loop(
-      Animated.sequence([
-        Animated.parallel([
-          Animated.timing(sizeAnimatedValue, {
-            toValue: endingCircleSize,
-            duration: animationTime,
-            easing: Easing.quad,
-            useNativeDriver: false,
-          }),
-          Animated.timing(topAnimatedValue, {
-            toValue: endingTopValue,
-            duration: animationTime,
-            easing: Easing.quad,
-            useNativeDriver: false,
-          }),
-          Animated.timing(opacityAnimatedValue, {
-            toValue: endingOpacity,
-            duration: animationTime,
-            easing: Easing.quad,
-            useNativeDriver: false,
-          }),
-          Animated.delay(delayTime),
-        ]),
-      ]),
-    ).start()
-  }, [
-    endingTopValue,
-    opacityAnimatedValue,
-    sizeAnimatedValue,
-    topAnimatedValue,
-  ])
-
-  useEffect(playAnimation, [playAnimation])
-
-  useEffect(() => {
-    AccessibilityInfo.isReduceMotionEnabled()?.then((result) => {
-      setIsReduceMotionEnabled(result)
-    })
-  }, [])
-
-  if (isReduceMotionEnabled) {
-    return null
-  }
-
-  return (
-    <Animated.View
-      style={{
-        position: "absolute",
-        top: topAnimatedValue,
-        alignSelf: "center",
-        width: sizeAnimatedValue,
-        height: sizeAnimatedValue,
-        borderColor: Colors.accent.success100,
-        borderWidth: Outlines.hairline,
-        borderRadius: Outlines.borderRadiusMax,
-        opacity: opacityAnimatedValue,
-      }}
-    />
-  )
-}
 
 const style = StyleSheet.create({
   statusContainer: {
     ...Affordances.floatingContainer,
-    paddingVertical: Spacing.small,
+    padding: Spacing.small,
     elevation: 0,
     borderWidth: Outlines.thin,
     overflow: "hidden",
   },
   statusTopContainer: {
     flexDirection: "row",
-    alignItems: "center",
+    alignItems: "flex-start",
     justifyContent: "space-between",
     marginBottom: Spacing.xxxSmall,
+  },
+  statusTextContainer: {
+    flex: 5,
+  },
+  iconContainer: {
+    flex: 1,
+    justifyContent: "flex-start",
+    alignItems: "flex-end",
   },
   statusIcon: {
     zIndex: Layout.zLevel1,


### PR DESCRIPTION
Why:
Currently if the status text on the exposure notification status card on
the dashboard is too long the element layout is out of alignment.

This commit:
Refactors the exposure detection status card and adds flex sizing to
layout the text and the icon.

|Before|After|
|----|----|
|![Simulator Screen Shot - iPhone 11 - 2020-11-09 at 09 32 37](https://user-images.githubusercontent.com/16049495/98555821-60c2e900-2270-11eb-9aa0-594338292433.png)|![Simulator Screen Shot - iPhone 11 - 2020-11-09 at 09 37 50](https://user-images.githubusercontent.com/16049495/98555827-63254300-2270-11eb-9ccd-b99e9dabff48.png)|

