### PR TITLE
Account for archive url 404 (Android)

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/DiagnosisKeyFileSubmitter.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/DiagnosisKeyFileSubmitter.java
@@ -88,6 +88,9 @@ public class DiagnosisKeyFileSubmitter {
         + "] key file batches into a single submission to provideDiagnosisKeys().");
     List<File> files = new ArrayList<>();
     for (KeyFileBatch b : batches) {
+      Log.d(TAG, "Adding batch with "
+          + b.files().size()
+          + " files");
       files.addAll(b.files());
       logBatch(b);
     }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/DiagnosisKeyDownloader.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/DiagnosisKeyDownloader.java
@@ -89,8 +89,7 @@ class DiagnosisKeyDownloader {
    *
    * <p>TODO: Apply the timeout individually to each file instead.
    *
-   * <p>Currently all files in a given batch fail or succeed as a group. This is also not ideal; it
-   * would be better to support retrying only the failed downloads.
+   * <p>It would be better to support retrying only failed downloads.
    */
   ListenableFuture<ImmutableList<KeyFileBatch>> download() {
     String dir = randDirname();

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/DiagnosisKeyDownloader.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/DiagnosisKeyDownloader.java
@@ -131,7 +131,7 @@ class DiagnosisKeyDownloader {
     for (KeyFileBatch b : batches) {
       batchFiles.addAll(handleBatch(b, dir));
     }
-    return Futures.allAsList(batchFiles);
+    return Futures.successfulAsList(batchFiles);
   }
 
   /**
@@ -175,6 +175,12 @@ class DiagnosisKeyDownloader {
     // Collect the downloaded files per KeyFileBatch
     Map<KeyFileBatch, List<File>> collector = new HashMap<>();
     for (BatchFile bf : batchFiles) {
+      if (bf == null) {
+        // File will be null if it failed to download
+        Log.d(TAG, "File failed to download");
+        continue;
+      }
+
       if (!collector.containsKey(bf.batch)) {
         collector.put(bf.batch, new ArrayList<>());
       }


### PR DESCRIPTION
**Bug:**
The index file on the key server may specify urls of key archives that have been deleted from the server. These urls will return 404s.

**Fix:**
Instead of aborting the operation in the case of a 404 for an individual archive file, we proceed and download the files that are present on the server

iOS already fixed here: https://github.com/Path-Check/gaen-mobile/pull/638