### PR TITLE
Fix padding on call emergency services button

### DIFF
--- a/src/Home/CallEmergencyServices.tsx
+++ b/src/Home/CallEmergencyServices.tsx
@@ -1,0 +1,63 @@
+import React, { FunctionComponent } from "react"
+import { StyleSheet, TouchableOpacity, Linking } from "react-native"
+import { SvgXml } from "react-native-svg"
+import { useTranslation } from "react-i18next"
+
+import { Text } from "../components"
+
+import {
+  Iconography,
+  Spacing,
+  Buttons,
+  Typography,
+  Colors,
+  Outlines,
+} from "../styles"
+import { Icons } from "../assets"
+
+interface CallEmergencyServicesProps {
+  phoneNumber: string
+}
+
+const CallEmergencyServices: FunctionComponent<CallEmergencyServicesProps> = ({
+  phoneNumber,
+}) => {
+  const { t } = useTranslation()
+  const handleOnPressCallEmergencyServices = () => {
+    Linking.openURL(`tel:${phoneNumber}`)
+  }
+
+  const buttonText = t("home.call_emergency_services")
+
+  return (
+    <TouchableOpacity
+      onPress={handleOnPressCallEmergencyServices}
+      accessibilityLabel={buttonText}
+      accessibilityRole="button"
+      style={style.emergencyButtonContainer}
+    >
+      <SvgXml
+        xml={Icons.Phone}
+        fill={Colors.neutral.white}
+        width={Iconography.xSmall}
+        height={Iconography.xSmall}
+      />
+      <Text style={style.emergencyButtonText}>{buttonText}</Text>
+    </TouchableOpacity>
+  )
+}
+
+const style = StyleSheet.create({
+  emergencyButtonContainer: {
+    ...Buttons.thin.base,
+    borderRadius: Outlines.borderRadiusLarge,
+    backgroundColor: Colors.accent.danger100,
+    padding: Spacing.large,
+  },
+  emergencyButtonText: {
+    ...Typography.button.primary,
+    marginLeft: Spacing.small,
+  },
+})
+
+export default CallEmergencyServices

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -1,15 +1,13 @@
 import React, { FunctionComponent } from "react"
 import {
+  View,
   ScrollView,
-  Linking,
   TouchableOpacity,
   StyleSheet,
-  View,
   Image,
 } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
-import { SvgXml } from "react-native-svg"
 
 import {
   HomeStackScreens,
@@ -19,21 +17,14 @@ import {
 import { useConfigurationContext } from "../ConfigurationContext"
 import { StatusBar, Text } from "../components"
 
+import CovidDataCard from "../CovidData/Card"
 import ExposureDetectionStatusCard from "./ExposureDetectionStatus/Card"
 import SectionButton from "./SectionButton"
 import ShareLink from "./ShareLink"
-import CovidDataCard from "../CovidData/Card"
+import CallEmergencyServices from "./CallEmergencyServices"
 
-import { Icons, Images } from "../assets"
-import {
-  Spacing,
-  Colors,
-  Typography,
-  Outlines,
-  Iconography,
-  Buttons,
-  Affordances,
-} from "../styles"
+import { Images } from "../assets"
+import { Outlines, Spacing, Colors, Typography, Affordances } from "../styles"
 
 const IMAGE_HEIGHT = 170
 
@@ -63,7 +54,9 @@ const Home: FunctionComponent = () => {
         <ReportTestResult />
         {displaySelfAssessment && <SelfAssessment />}
         {displaySymptomHistory && <SymptomHistory />}
-        <CallEmergencyServices phoneNumber={emergencyPhoneNumber} />
+        <View style={style.callEmergencyServicesContainer}>
+          <CallEmergencyServices phoneNumber={emergencyPhoneNumber} />
+        </View>
       </ScrollView>
     </>
   )
@@ -181,45 +174,6 @@ const SymptomHistory: FunctionComponent = () => {
   )
 }
 
-interface CallEmergencyServicesProps {
-  phoneNumber: string
-}
-
-const CallEmergencyServices: FunctionComponent<CallEmergencyServicesProps> = ({
-  phoneNumber,
-}) => {
-  const { t } = useTranslation()
-  const handleOnPressCallEmergencyServices = () => {
-    Linking.openURL(`tel:${phoneNumber}`)
-  }
-
-  return (
-    <View style={style.emergencyButtonOuterContainer}>
-      <TouchableOpacity
-        onPress={handleOnPressCallEmergencyServices}
-        accessibilityLabel={t(
-          "self_assessment.call_emergency_services.call_emergencies",
-          {
-            phoneNumber,
-          },
-        )}
-        accessibilityRole="button"
-        style={style.emergencyButtonContainer}
-      >
-        <SvgXml
-          xml={Icons.Phone}
-          fill={Colors.neutral.white}
-          width={Iconography.xSmall}
-          height={Iconography.xSmall}
-        />
-        <Text style={style.emergencyButtonText}>
-          {t("home.call_emergency_services", { phoneNumber })}
-        </Text>
-      </TouchableOpacity>
-    </View>
-  )
-}
-
 const style = StyleSheet.create({
   container: {
     backgroundColor: Colors.background.primaryLight,
@@ -254,19 +208,10 @@ const style = StyleSheet.create({
     color: Colors.neutral.shade100,
     marginBottom: Spacing.xLarge,
   },
-  emergencyButtonOuterContainer: {
+  callEmergencyServicesContainer: {
     borderTopWidth: Outlines.hairline,
     borderColor: Colors.neutral.shade25,
     paddingTop: Spacing.large,
-  },
-  emergencyButtonContainer: {
-    ...Buttons.thin.base,
-    borderRadius: Outlines.borderRadiusLarge,
-    backgroundColor: Colors.accent.danger100,
-  },
-  emergencyButtonText: {
-    ...Typography.button.primary,
-    marginLeft: Spacing.small,
   },
 })
 


### PR DESCRIPTION
Why:
Current the padding on the call emergency services button is not
preserved if the button text is too long.

|Before|After|
|----|----|
|![Simulator Screen Shot - iPhone 11 - 2020-11-09 at 13 49 40](https://user-images.githubusercontent.com/16049495/98583827-025b3200-2293-11eb-9815-412034b32e5e.png)|![Simulator Screen Shot - iPhone 11 - 2020-11-09 at 13 48 26](https://user-images.githubusercontent.com/16049495/98583838-071fe600-2293-11eb-9bcf-9fb57c3a4eac.png)|

