### PR TITLE
Fix various accessibility issues across app

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -161,6 +161,8 @@ const CodeInputForm: FunctionComponent = () => {
 
   const isIOS = Platform.OS === "ios"
 
+  const shouldBeAccessible = errorMessage !== ""
+
   return (
     <KeyboardAvoidingView
       contentContainerStyle={style.outerContentContainer}
@@ -194,7 +196,12 @@ const CodeInputForm: FunctionComponent = () => {
           onSubmitEditing={Keyboard.dismiss}
           blurOnSubmit={false}
         />
-        <Text style={style.errorSubtitle}>{errorMessage}</Text>
+        <View
+          accessibilityElementsHidden={!shouldBeAccessible}
+          accessible={shouldBeAccessible}
+        >
+          <Text style={style.errorSubtitle}>{errorMessage}</Text>
+        </View>
         <TouchableOpacity
           style={isDisabled ? style.buttonDisabled : style.button}
           onPress={handleOnPressSubmit}

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -143,7 +143,7 @@ const style = StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     alignItems: "center",
-    marginTop: Spacing.xSmall,
+    marginTop: Spacing.xxSmall,
     marginHorizontal: Spacing.medium,
   },
   headerText: {

--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -6,7 +6,6 @@ import {
   View,
   ScrollView,
   ImageSourcePropType,
-  ViewStyle,
   TouchableOpacity,
 } from "react-native"
 import { useNavigation } from "@react-navigation/native"
@@ -17,11 +16,10 @@ import { SvgXml } from "react-native-svg"
 import { ModalStackScreens, useStatusBarEffect } from "../navigation"
 import { Text } from "../components"
 
-import { Outlines, Colors, Spacing, Typography, Buttons } from "../styles"
+import { Colors, Spacing, Typography, Buttons } from "../styles"
 import { Icons } from "../assets"
 
 type HowItWorksScreenContent = {
-  screenNumber: number
   image: ImageSourcePropType
   imageLabel: string
   header: string
@@ -31,12 +29,10 @@ type HowItWorksScreenContent = {
 
 interface HowItWorksScreenProps {
   howItWorksScreenContent: HowItWorksScreenContent
-  totalScreenCount: number
 }
 
 const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
   howItWorksScreenContent,
-  totalScreenCount,
 }) => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()
@@ -49,7 +45,6 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
   }
 
   const {
-    screenNumber,
     image,
     imageLabel,
     header,
@@ -72,10 +67,6 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
             style={style.image}
             resizeMode={"contain"}
           />
-          <PositionDots
-            highlightedDotIdx={screenNumber}
-            totalDotCount={totalScreenCount}
-          />
           <Text style={style.headerText}>{header}</Text>
         </View>
       </ScrollView>
@@ -89,7 +80,10 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
             <Text style={style.buttonText}>{primaryButtonLabel}</Text>
             <SvgXml xml={Icons.Arrow} fill={Colors.background.primaryLight} />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleOnPressProtectPrivacy}>
+          <TouchableOpacity
+            onPress={handleOnPressProtectPrivacy}
+            accessibilityRole="button"
+          >
             <Text style={style.bottomButtonText}>
               {t("onboarding.protect_privacy_button")}
             </Text>
@@ -153,56 +147,6 @@ const createStyle = (insets: EdgeInsets) => {
     },
   })
 }
-
-interface PositionDotsProps {
-  highlightedDotIdx: number
-  totalDotCount: number
-}
-
-const PositionDots: FunctionComponent<PositionDotsProps> = ({
-  highlightedDotIdx,
-  totalDotCount,
-}) => {
-  const determineDotStyle = (dotPosition: number): ViewStyle => {
-    if (dotPosition === highlightedDotIdx) {
-      return dotsStyle.dotHighlighted
-    } else {
-      return dotsStyle.dot
-    }
-  }
-
-  const screens = Array.from(Array(totalDotCount), (i) => i + 1)
-
-  return (
-    <View style={dotsStyle.dotsContainer}>
-      {screens.map((_, idx) => {
-        return <View style={determineDotStyle(idx + 1)} key={idx} />
-      })}
-    </View>
-  )
-}
-const dotsStyle = StyleSheet.create({
-  dotsContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    width: 150,
-    justifyContent: "space-between",
-    marginBottom: Spacing.medium,
-    paddingHorizontal: Spacing.large,
-  },
-  dotHighlighted: {
-    backgroundColor: Colors.primary.shade100,
-    width: 10,
-    height: 10,
-    borderRadius: Outlines.borderRadiusMax,
-  },
-  dot: {
-    backgroundColor: Colors.neutral.shade30,
-    width: 5,
-    height: 5,
-    borderRadius: Outlines.borderRadiusMax,
-  },
-})
 
 const MemoizedHowItWorksScreen = React.memo(HowItWorksScreen)
 

--- a/src/Settings/index.tsx
+++ b/src/Settings/index.tsx
@@ -30,6 +30,7 @@ import ShareAnonymizedDataListItem from "./ShareAnonymizedDataListItem"
 
 type SettingsListItem = {
   label: string
+  accessibilityLabel: string
   onPress: () => void
   icon: string
 }
@@ -65,27 +66,32 @@ const Settings: FunctionComponent = () => {
   }
 
   const selectLanguage: SettingsListItem = {
-    label: t("common.select_language"),
+    label: languageName,
+    accessibilityLabel: t("common.select_language"),
     onPress: handleOnPressSelectLanguage,
     icon: Icons.LanguagesIcon,
   }
   const legal: SettingsListItem = {
     label: t("screen_titles.legal"),
+    accessibilityLabel: t("screen_titles.legal"),
     onPress: () => navigation.navigate(SettingsStackScreens.Legal),
     icon: Icons.Document,
   }
   const howTheAppWorks: SettingsListItem = {
     label: t("screen_titles.how_the_app_works"),
+    accessibilityLabel: t("screen_titles.how_the_app_works"),
     onPress: handleOnPressHowTheAppWorks,
     icon: Icons.RestartWithCheck,
   }
   const deleteMyData: SettingsListItem = {
     label: t("settings.delete_my_data"),
+    accessibilityLabel: t("settings.delete_my_data"),
     onPress: handleOnPressDeleteMyData,
     icon: Icons.Trash,
   }
   const debugMenu: SettingsListItem = {
     label: "EN Debug Menu",
+    accessibilityLabel: "EN Debug Menu",
     onPress: () => navigation.navigate(SettingsStackScreens.ENDebugMenu),
     icon: Icons.Document,
   }
@@ -113,6 +119,7 @@ const Settings: FunctionComponent = () => {
         <View style={style.section}>
           <ListItem
             label={selectLanguage.label}
+            accessibilityLabel={selectLanguage.accessibilityLabel}
             onPress={selectLanguage.onPress}
             icon={selectLanguage.icon}
           />
@@ -137,6 +144,7 @@ const Settings: FunctionComponent = () => {
         <View style={style.section}>
           <ListItem
             label={deleteMyData.label}
+            accessibilityLabel={deleteMyData.label}
             onPress={deleteMyData.onPress}
             icon={deleteMyData.icon}
           />
@@ -145,6 +153,7 @@ const Settings: FunctionComponent = () => {
           <View style={style.section}>
             <ListItem
               label={debugMenu.label}
+              accessibilityLabel={debugMenu.label}
               onPress={debugMenu.onPress}
               icon={debugMenu.icon}
             />

--- a/src/Settings/index.tsx
+++ b/src/Settings/index.tsx
@@ -65,7 +65,7 @@ const Settings: FunctionComponent = () => {
   }
 
   const selectLanguage: SettingsListItem = {
-    label: languageName,
+    label: t("common.select_language"),
     onPress: handleOnPressSelectLanguage,
     icon: Icons.LanguagesIcon,
   }

--- a/src/SymptomHistory/index.tsx
+++ b/src/SymptomHistory/index.tsx
@@ -83,7 +83,7 @@ const style = StyleSheet.create({
     backgroundColor: Colors.background.primaryLight,
   },
   contentContainer: {
-    paddingVertical: Spacing.large,
+    paddingVertical: Spacing.medium,
     paddingHorizontal: Spacing.medium,
   },
   headerText: {

--- a/src/Welcome.tsx
+++ b/src/Welcome.tsx
@@ -71,6 +71,7 @@ const Welcome: FunctionComponent = () => {
           <TouchableOpacity
             onPress={handleOnPressSelectLanguage}
             accessibilityLabel={t("common.select_language")}
+            accessibilityRole="button"
           >
             <View style={style.languageButtonContainer}>
               <Text style={style.languageButtonText}>{languageName}</Text>

--- a/src/Welcome.tsx
+++ b/src/Welcome.tsx
@@ -68,7 +68,10 @@ const Welcome: FunctionComponent = () => {
         alwaysBounceVertical={false}
       >
         <View style={style.mainContentContainer}>
-          <TouchableOpacity onPress={handleOnPressSelectLanguage}>
+          <TouchableOpacity
+            onPress={handleOnPressSelectLanguage}
+            accessibilityLabel={t("common.select_language")}
+          >
             <View style={style.languageButtonContainer}>
               <Text style={style.languageButtonText}>{languageName}</Text>
             </View>

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -18,7 +18,7 @@ const ListItem: FunctionComponent<ListItemProps> = ({
   icon,
 }) => {
   return (
-    <TouchableOpacity onPress={onPress} accessible accessibilityLabel={label}>
+    <TouchableOpacity onPress={onPress} accessibilityLabel={label}>
       <View style={style.listItem}>
         <SvgXml
           fill={Colors.primary.shade100}
@@ -26,8 +26,6 @@ const ListItem: FunctionComponent<ListItemProps> = ({
           width={Iconography.small}
           height={Iconography.small}
           style={style.icon}
-          accessible
-          accessibilityLabel={label}
         />
         <Text style={style.listItemText}>{label}</Text>
       </View>

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -8,17 +8,20 @@ import { Iconography, Spacing, Typography, Colors } from "../styles"
 
 interface ListItemProps {
   label: string
+  accessibilityLabel: string
   onPress: () => void
   icon: string
 }
 
 const ListItem: FunctionComponent<ListItemProps> = ({
   label,
+  accessibilityLabel,
   onPress,
   icon,
 }) => {
+  console.log(accessibilityLabel)
   return (
-    <TouchableOpacity onPress={onPress} accessibilityLabel={label}>
+    <TouchableOpacity onPress={onPress} accessibilityLabel={accessibilityLabel}>
       <View style={style.listItem}>
         <SvgXml
           fill={Colors.primary.shade100}

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -19,7 +19,6 @@ const ListItem: FunctionComponent<ListItemProps> = ({
   onPress,
   icon,
 }) => {
-  console.log(accessibilityLabel)
   return (
     <TouchableOpacity onPress={onPress} accessibilityLabel={accessibilityLabel}>
       <View style={style.listItem}>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
     "success_header": "You're in the queue"
   },
   "common": {
+    "select_language": "Select language",
     "back": "Back",
     "close": "Close",
     "close_screen": "Close screen",
@@ -217,7 +218,7 @@
     "home": "Dashboard",
     "more_info": "More Info",
     "settings": "Settings",
-    "symptom_history": "Symptom Checker"
+    "symptom_log": "Symptom Log"
   },
   "onboarding": {
     "activation_header_title": "App Setup",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -212,13 +212,12 @@
     "unchecked_checkbox": "Unchecked checkbox"
   },
   "navigation": {
-    "connect": "Connect",
     "exposure": "Exposure",
     "exposure_history": "Exposure History",
     "home": "Dashboard",
     "more_info": "More Info",
     "settings": "Settings",
-    "symptom_log": "Symptom Log"
+    "symptom_history": "Symptom History"
   },
   "onboarding": {
     "activation_header_title": "App Setup",

--- a/src/modals/LanguageSelection.tsx
+++ b/src/modals/LanguageSelection.tsx
@@ -75,7 +75,6 @@ const LanguageSelection: FunctionComponent = () => {
           style={style.languageButton}
           onPress={handleOnSelectLanguage}
           ref={firstLanguageButton}
-          accessible
         >
           <LanguageButtonText />
         </TouchableOpacity>

--- a/src/modals/LanguageSelection.tsx
+++ b/src/modals/LanguageSelection.tsx
@@ -88,7 +88,7 @@ const LanguageSelection: FunctionComponent = () => {
         if (reactTag) {
           /* Accessibility focus is only set if this function is called three
            times in a row. See issue:
-           https://github.com/facebook/react-native/issues/30097*/
+           https://github.com/facebook/react-native/issues/30097 */
           AccessibilityInfo.setAccessibilityFocus(reactTag)
           AccessibilityInfo.setAccessibilityFocus(reactTag)
           AccessibilityInfo.setAccessibilityFocus(reactTag)

--- a/src/modals/LanguageSelection.tsx
+++ b/src/modals/LanguageSelection.tsx
@@ -1,5 +1,12 @@
-import React, { FunctionComponent } from "react"
-import { FlatList, View, StyleSheet, TouchableOpacity } from "react-native"
+import React, { FunctionComponent, useEffect, useRef } from "react"
+import {
+  FlatList,
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  findNodeHandle,
+  AccessibilityInfo,
+} from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 
@@ -22,7 +29,15 @@ const LanguageSelection: FunctionComponent = () => {
     value: string
   }
 
-  const renderItem = ({ item }: { item: ListItem }) => {
+  interface LanguageListItemProps {
+    item: ListItem
+    index: number
+  }
+
+  const LanguageListItem: FunctionComponent<LanguageListItemProps> = ({
+    item,
+    index,
+  }) => {
     const handleOnSelectLanguage = () => {
       setUserLocaleOverride(item.value)
       navigation.goBack()
@@ -37,14 +52,61 @@ const LanguageSelection: FunctionComponent = () => {
       ...languageButtonTextStyle,
     }
 
-    return (
-      <TouchableOpacity
-        style={style.languageButton}
-        onPress={handleOnSelectLanguage}
-      >
-        <Text style={languageButtonTextStyles}>{item.label}</Text>
-      </TouchableOpacity>
-    )
+    const LanguageButtonText = () => {
+      return <Text style={languageButtonTextStyles}>{item.label}</Text>
+    }
+
+    const firstLanguageButton = useRef(null)
+
+    const LanguageButton = () => {
+      return (
+        <TouchableOpacity
+          style={style.languageButton}
+          onPress={handleOnSelectLanguage}
+        >
+          <LanguageButtonText />
+        </TouchableOpacity>
+      )
+    }
+
+    const LanguageButtonWithRef = () => {
+      return (
+        <TouchableOpacity
+          style={style.languageButton}
+          onPress={handleOnSelectLanguage}
+          ref={firstLanguageButton}
+          accessible
+        >
+          <LanguageButtonText />
+        </TouchableOpacity>
+      )
+    }
+
+    useEffect(() => {
+      if (firstLanguageButton && firstLanguageButton.current) {
+        const reactTag = findNodeHandle(firstLanguageButton.current)
+        if (reactTag) {
+          /* Accessibility focus is only set if this function is called three
+           times in a row. See issue:
+           https://github.com/facebook/react-native/issues/30097*/
+          AccessibilityInfo.setAccessibilityFocus(reactTag)
+          AccessibilityInfo.setAccessibilityFocus(reactTag)
+          AccessibilityInfo.setAccessibilityFocus(reactTag)
+        }
+      }
+    }, [])
+
+    const isFirstLanguageButton = index === 0
+
+    if (isFirstLanguageButton) {
+      return <LanguageButtonWithRef />
+    } else {
+      return <LanguageButton />
+    }
+  }
+
+  const renderItem = ({ item, index }: { item: ListItem; index: number }) => {
+    return <LanguageListItem item={item} index={index} />
   }
 
   return (

--- a/src/navigation/HowItWorksStack.tsx
+++ b/src/navigation/HowItWorksStack.tsx
@@ -102,24 +102,11 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
     getNotified,
   ]
 
-  const toStackScreen = (datum: HowItWorksScreenDatum, idx: number) => {
-    const screenNumber = idx + 1
-    const howItWorksScreenDisplayDatum = {
-      screenNumber,
-      ...datum,
-    }
-
+  const toStackScreen = (datum: HowItWorksScreenDatum) => {
     return (
-      <Stack.Screen
-        key={howItWorksScreenDisplayDatum.header}
-        name={howItWorksScreenDisplayDatum.name}
-      >
+      <Stack.Screen key={datum.header} name={datum.name}>
         {(props) => (
-          <HowItWorksScreen
-            {...props}
-            howItWorksScreenContent={howItWorksScreenDisplayDatum}
-            totalScreenCount={howItWorksScreenData.length}
-          />
+          <HowItWorksScreen {...props} howItWorksScreenContent={datum} />
         )}
       </Stack.Screen>
     )
@@ -146,7 +133,7 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
         headerStyleInterpolator: HeaderStyleInterpolators.forNoAnimation,
       }}
     >
-      {howItWorksScreenData.map((data, idx) => toStackScreen(data, idx))}
+      {howItWorksScreenData.map(toStackScreen)}
     </Stack.Navigator>
   )
 }

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -23,21 +23,17 @@ const MainTabNavigator: FunctionComponent = () => {
 
   interface TabIconProps extends TabBarIconProps {
     icon: string
-    label: string
   }
 
   const TabIcon: FunctionComponent<TabIconProps> = ({
     focused,
     size,
     icon,
-    label,
   }) => {
     return (
       <SvgXml
         xml={icon}
         fill={focused ? Colors.primary.shade100 : Colors.neutral.shade50}
-        accessible
-        accessibilityLabel={label}
         width={size}
         height={size}
       />
@@ -50,14 +46,7 @@ const MainTabNavigator: FunctionComponent = () => {
   }
 
   const HomeIcon: FunctionComponent<TabBarIconProps> = ({ focused, size }) => {
-    return (
-      <TabIcon
-        icon={TabBarIcons.House}
-        label={t("navigation.home")}
-        focused={focused}
-        size={size}
-      />
-    )
+    return <TabIcon icon={TabBarIcons.House} focused={focused} size={size} />
   }
 
   const ExposureHistoryIcon: FunctionComponent<TabBarIconProps> = ({
@@ -65,12 +54,7 @@ const MainTabNavigator: FunctionComponent = () => {
     size,
   }) => {
     const tabIcon = (
-      <TabIcon
-        icon={TabBarIcons.Exposure}
-        label={t("navigation.exposure_history")}
-        focused={focused}
-        size={size}
-      />
+      <TabIcon icon={TabBarIcons.Exposure} focused={focused} size={size} />
     )
     return tabIcon
   }
@@ -80,12 +64,7 @@ const MainTabNavigator: FunctionComponent = () => {
     size,
   }) => {
     const tabIcon = (
-      <TabIcon
-        icon={TabBarIcons.Heartbeat}
-        label={t("navigation.symptom_history")}
-        focused={focused}
-        size={size}
-      />
+      <TabIcon icon={TabBarIcons.Heartbeat} focused={focused} size={size} />
     )
     return tabIcon
   }
@@ -95,12 +74,7 @@ const MainTabNavigator: FunctionComponent = () => {
     size,
   }) => {
     const tabIcon = (
-      <TabIcon
-        icon={TabBarIcons.Gear}
-        label={t("navigation.settings")}
-        focused={focused}
-        size={size}
-      />
+      <TabIcon icon={TabBarIcons.Gear} focused={focused} size={size} />
     )
     return tabIcon
   }
@@ -138,16 +112,16 @@ const MainTabNavigator: FunctionComponent = () => {
           name={Stacks.SymptomHistory}
           component={SymptomHistoryStack}
           options={{
-            tabBarLabel: t("navigation.symptom_history"),
+            tabBarLabel: t("navigation.symptom_log"),
             tabBarIcon: HeartbeatIcon,
           }}
         />
       )}
       <Tab.Screen
-        name={Stacks.Connect}
+        name={Stacks.Settings}
         component={SettingsStack}
         options={{
-          tabBarLabel: t("navigation.connect"),
+          tabBarLabel: t("navigation.settings"),
           tabBarIcon: SettingsIcon,
         }}
       />

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -112,7 +112,7 @@ const MainTabNavigator: FunctionComponent = () => {
           name={Stacks.SymptomHistory}
           component={SymptomHistoryStack}
           options={{
-            tabBarLabel: t("navigation.symptom_log"),
+            tabBarLabel: t("navigation.symptom_history"),
             tabBarIcon: HeartbeatIcon,
           }}
         />


### PR DESCRIPTION
Why: there are accessibility issues in the app that result in a poor experience for screen readers.

This commit:
- Updates the error message text on the `CodeInputForm` to only be accessible when there is an error message.
- Removes the screen number dots from the `HowItWorksScreen` because they suggest to users that the screens should be navigable with swipe gestures (they are not)
- Adds an `accessibilityRole` of `button` to the "How we protect your privacy" button
- Adds an `accessibilityLabel` of "Select language" to the language button on the `WelcomeScreen` and also adds an `accessibilityRole` of `button`
- Adds an `accessibilityLabel` of "Select language" to the language button on the `Settings` index
- For screen readers, focuses the first language option on the `LanguageSelection` screen when the screen mounts
- Removes duplicate accessibility labels on the bottom tab bar (we currently have accessibility labels on the tab bar icons and the svgs within the tab bar icons)
- Updates the settings tab bar icon to use the correct name and label (it is currently using the old name and label for the `Connect` screen)