### PR TITLE
Revert "Remove redundant step in build script"

### DIFF
--- a/bin/configure_builds.sh
+++ b/bin/configure_builds.sh
@@ -153,15 +153,27 @@ def update_ios_bundle_identifier(bundle_id)
   )
 end
 
+def update_android_application_id(application_id)
+  puts "Updating android applicationId to #{application_id}"
+  replace_string_in_file(
+    file_path: './android/app/build.gradle',
+    regex: /applicationId (.+)/,
+    value: "applicationId \"#{application_id}\""
+  )
+end
+
 IOS_BUNDLE_IDENTIFIER_KEY = "IOS_BUNDLE_ID"
+ANDROID_APPLICATION_ID_KEY = "ANDROID_APPLICATION_ID"
 def update_bundle_identifiers
   environment = Dotenv.parse(File.open(ENV_FILE))
   ios_bundle_identifier = environment.fetch(IOS_BUNDLE_IDENTIFIER_KEY, false)
+  android_application_id = environment.fetch(ANDROID_APPLICATION_ID_KEY, false)
 
-  if ios_bundle_identifier
+  if ios_bundle_identifier && android_application_id
     update_ios_bundle_identifier(ios_bundle_identifier)
+    update_android_application_id(android_application_id)
   else
-    failure_message "ios bundle identifier is required"
+    failure_message "Both ios bundle identifier and android id are required"
     exit 1
   end
 end


### PR DESCRIPTION
This reverts commit e6020301f167950d341fae4c319e8f390bbf5658.

Why:
Bitrise does not read from the local env during the CD process. While this
step is not necessary for local builds, it is for builds on Bitrise.