### PR TITLE
Disable "Check for Exposure" button while check is in progress

### DIFF
--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -120,6 +120,7 @@ const History: FunctionComponent<HistoryProps> = ({
       <TouchableOpacity
         onPress={handleOnPressCheckForExposures}
         style={style.button}
+        disabled={checkingForExposures}
         testID="check-for-exposures-button"
       >
         <Text style={style.buttonText}>


### PR DESCRIPTION
#### Why:
The native layer will infrequently return an error code if the "Check for Exposures" button is tapped in _very_ rapid succession. This results in an error toast being presented to the user, which we'd like to avoid/
![Nov-10-2020 14-18-17](https://user-images.githubusercontent.com/2637355/98722903-a4e0e700-235f-11eb-8035-615d97792b0e.gif)

#### This commit:
This commit disables the "Check for Exposures" button while an exposure check is in progress. 
