### PR TITLE
Fix flash message display issue

### DIFF
--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -41,6 +41,10 @@ const History: FunctionComponent<HistoryProps> = ({
   const { t } = useTranslation()
   const navigation = useNavigation()
   const { checkForNewExposures } = useExposureContext()
+  const {
+    successFlashMessageOptions,
+    errorFlashMessageOptions,
+  } = Affordances.useFlashMessageOptions()
 
   const [checkingForExposures, setCheckingForExposures] = useState<boolean>(
     false,
@@ -56,21 +60,21 @@ const History: FunctionComponent<HistoryProps> = ({
     if (checkResult.kind === "success") {
       showMessage({
         message: t("common.success"),
-        ...Affordances.successFlashMessageOptions,
+        ...successFlashMessageOptions,
       })
     } else {
       switch (checkResult.error) {
         case "ExceededCheckRateLimit": {
           showMessage({
             message: t("common.success"),
-            ...Affordances.successFlashMessageOptions,
+            ...successFlashMessageOptions,
           })
           break
         }
         default: {
           showMessage({
             message: t("common.something_went_wrong"),
-            ...Affordances.errorFlashMessageOptions,
+            ...errorFlashMessageOptions,
           })
         }
       }

--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -20,6 +20,10 @@ const DeleteConfirmation: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { resetOnboarding } = useOnboardingContext()
   const { deleteAllEntries } = useSymptomHistoryContext()
+  const {
+    successFlashMessageOptions,
+    errorFlashMessageOptions,
+  } = Affordances.useFlashMessageOptions()
 
   const { t } = useTranslation()
   const handleOnPressDeleteAllData = async () => {
@@ -28,12 +32,12 @@ const DeleteConfirmation: FunctionComponent = () => {
       resetOnboarding()
       showMessage({
         message: t("settings.data_deleted"),
-        ...Affordances.successFlashMessageOptions,
+        ...successFlashMessageOptions,
       })
     } else {
       showMessage({
         message: t("settings.errors.deleting_data"),
-        ...Affordances.errorFlashMessageOptions,
+        ...errorFlashMessageOptions,
       })
     }
   }

--- a/src/SymptomHistory/Form/SelectSymptoms.tsx
+++ b/src/SymptomHistory/Form/SelectSymptoms.tsx
@@ -46,6 +46,7 @@ const SelectSymptomsForm: FunctionComponent<SelectSymptomsFormProps> = ({
 }) => {
   useStatusBarEffect("dark-content", Colors.secondary.shade10)
   const { t } = useTranslation()
+  const { successFlashMessageOptions } = Affordances.useFlashMessageOptions()
 
   const { updateEntry } = useSymptomHistoryContext()
 
@@ -78,7 +79,7 @@ const SelectSymptomsForm: FunctionComponent<SelectSymptomsFormProps> = ({
     } else {
       showMessage({
         message: t("symptom_history.errors.updating_symptoms"),
-        ...Affordances.successFlashMessageOptions,
+        ...successFlashMessageOptions,
       })
     }
   }
@@ -86,7 +87,7 @@ const SelectSymptomsForm: FunctionComponent<SelectSymptomsFormProps> = ({
   const showSuccessMessage = () => {
     showMessage({
       message: t("common.success"),
-      ...Affordances.successFlashMessageOptions,
+      ...successFlashMessageOptions,
     })
   }
 

--- a/src/styles/affordances.ts
+++ b/src/styles/affordances.ts
@@ -1,10 +1,50 @@
 import { ViewStyle } from "react-native"
 import { MessageOptions } from "react-native-flash-message"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 import * as Colors from "./colors"
 import * as Typography from "./typography"
 import * as Outlines from "./outlines"
 import * as Spacing from "./spacing"
+
+type FlashMessageOptions = Omit<MessageOptions, "message">
+
+type FlashMessageVariants = {
+  successFlashMessageOptions: FlashMessageOptions
+  errorFlashMessageOptions: FlashMessageOptions
+}
+
+export const useFlashMessageOptions = (): FlashMessageVariants => {
+  const insets = useSafeAreaInsets()
+
+  const flashMessageOptions: FlashMessageOptions = {
+    titleStyle: { ...Typography.header.x40, color: Colors.neutral.black },
+    animationDuration: 100,
+    floating: true,
+    position: { top: insets.top + Spacing.small },
+  }
+
+  const successFlashMessageOptions: FlashMessageOptions = {
+    ...flashMessageOptions,
+    backgroundColor: Colors.accent.success50,
+  }
+
+  const errorFlashMessageOptions: FlashMessageOptions = {
+    ...flashMessageOptions,
+    backgroundColor: Colors.accent.danger75,
+  }
+
+  return { successFlashMessageOptions, errorFlashMessageOptions }
+}
+
+export const floatingContainer: ViewStyle = {
+  ...Outlines.lightShadow,
+  backgroundColor: Colors.background.primaryLight,
+  borderRadius: Outlines.borderRadiusLarge,
+  paddingVertical: Spacing.large,
+  paddingHorizontal: Spacing.large,
+  marginBottom: Spacing.large,
+}
 
 export const iconBadge: ViewStyle = {
   position: "absolute",
@@ -16,32 +56,4 @@ export const iconBadge: ViewStyle = {
   height: 12,
   justifyContent: "center",
   alignItems: "center",
-}
-
-type FlashMessageOptions = Omit<MessageOptions, "message">
-
-export const flashMessageOptions: FlashMessageOptions = {
-  titleStyle: { ...Typography.header.x40, color: Colors.neutral.black },
-  animationDuration: 100,
-  floating: true,
-  position: { top: Spacing.huge },
-}
-
-export const successFlashMessageOptions: FlashMessageOptions = {
-  ...flashMessageOptions,
-  backgroundColor: Colors.accent.success50,
-}
-
-export const errorFlashMessageOptions: FlashMessageOptions = {
-  ...flashMessageOptions,
-  backgroundColor: Colors.accent.danger75,
-}
-
-export const floatingContainer: ViewStyle = {
-  ...Outlines.lightShadow,
-  backgroundColor: Colors.background.primaryLight,
-  borderRadius: Outlines.borderRadiusLarge,
-  paddingVertical: Spacing.large,
-  paddingHorizontal: Spacing.large,
-  marginBottom: Spacing.large,
 }

--- a/src/styles/affordances.ts
+++ b/src/styles/affordances.ts
@@ -21,7 +21,7 @@ export const useFlashMessageOptions = (): FlashMessageVariants => {
     titleStyle: { ...Typography.header.x40, color: Colors.neutral.black },
     animationDuration: 100,
     floating: true,
-    position: { top: insets.top + Spacing.small },
+    position: { top: insets.top },
   }
 
   const successFlashMessageOptions: FlashMessageOptions = {

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -61,6 +61,8 @@ export const thin: Record<Thin, ViewStyle> = {
 type Outlined = "base" | "thin"
 const outlinedBase: ViewStyle = {
   ...primaryBase,
+  elevation: 0,
+  shadowOpacity: 0,
   backgroundColor: Colors.transparent.invisible,
   borderColor: Colors.primary.shade100,
   borderWidth: Outlines.hairline,


### PR DESCRIPTION
Why: the styling of the flash message does not take into account the
screen insets, so the flash message is showing up on with the correct
amount of top padding only on iOS devices with notches.

This commit:
- Updates the top padding for the flash message to use the screen insets

![gif](https://user-images.githubusercontent.com/39350030/98729525-0a85a100-2369-11eb-91c5-4861035176bf.gif)