### PR TITLE
Add header to Settings screen

### DIFF
--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -151,6 +151,7 @@ const SymptomHistory: FunctionComponent = () => {
   const { t } = useTranslation()
 
   const handleOnPressSymptomHistory = () => {
+    ;<Text style={style.headerText}>{t("screen_titles.home")}</Text>
     navigation.navigate(HomeStackScreens.EnterSymptoms)
   }
 

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -151,7 +151,6 @@ const SymptomHistory: FunctionComponent = () => {
   const { t } = useTranslation()
 
   const handleOnPressSymptomHistory = () => {
-    ;<Text style={style.headerText}>{t("screen_titles.home")}</Text>
     navigation.navigate(HomeStackScreens.EnterSymptoms)
   }
 

--- a/src/Settings/index.tsx
+++ b/src/Settings/index.tsx
@@ -191,9 +191,8 @@ const style = StyleSheet.create({
   headerText: {
     ...Typography.header.x60,
     ...Typography.style.bold,
-    marginTop: Spacing.medium,
+    marginVertical: Spacing.medium,
     marginHorizontal: Spacing.medium,
-    marginBottom: Spacing.medium,
   },
   section: {
     backgroundColor: Colors.background.primaryLight,

--- a/src/Settings/index.tsx
+++ b/src/Settings/index.tsx
@@ -116,6 +116,7 @@ const Settings: FunctionComponent = () => {
     <>
       <StatusBar backgroundColor={Colors.secondary.shade10} />
       <ScrollView style={style.container} alwaysBounceVertical={false}>
+        <Text style={style.headerText}>{t("screen_titles.settings")}</Text>
         <View style={style.section}>
           <ListItem
             label={selectLanguage.label}
@@ -186,6 +187,13 @@ const style = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: Colors.secondary.shade10,
+  },
+  headerText: {
+    ...Typography.header.x60,
+    ...Typography.style.bold,
+    marginTop: Spacing.medium,
+    marginHorizontal: Spacing.medium,
+    marginBottom: Spacing.medium,
   },
   section: {
     backgroundColor: Colors.background.primaryLight,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -297,7 +297,8 @@
     "location": "Location",
     "protect_privacy": "How we protect your privacy",
     "select_language": "Select Language",
-    "select_symptoms": "Select Symptoms"
+    "select_symptoms": "Select Symptoms",
+    "settings": "Settings"
   },
   "self_assessment": {
     "age_range": {


### PR DESCRIPTION
Why: we would like the Settings screen to have a header to match the rest of the tab screens.

<img width="358" alt="Screen Shot 2020-11-10 at 5 14 54 PM" src="https://user-images.githubusercontent.com/39350030/98739996-5724a880-2378-11eb-81af-fb75a18098d5.png">