### PR TITLE
Move share app link lower on dashboard screen

### DIFF
--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -48,10 +48,10 @@ const Home: FunctionComponent = () => {
       >
         <Text style={style.headerText}>{t("screen_titles.home")}</Text>
         <ExposureDetectionStatusCard />
-        <ShareLink />
         {displayCovidData && <CovidDataCard />}
         {displayCallbackForm && <TalkToContactTracer />}
         <ReportTestResult />
+        <ShareLink />
         {displaySelfAssessment && <SelfAssessment />}
         {displaySymptomHistory && <SymptomHistory />}
         <View style={style.callEmergencyServicesContainer}>


### PR DESCRIPTION
Why: we would like other content on the screen to show up above the fold.