### PR TITLE
Make publish consent screen shorter

### DIFF
--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -42,11 +42,6 @@ describe("PublishConsentForm", () => {
     ).toBeDefined()
     expect(
       getByText(
-        /If you choose to do so, you’re helping others in your community make informed decisions about their health and playing your part to contain the spread of the virus./,
-      ),
-    ).toBeDefined()
-    expect(
-      getByText(
         /The only information shared will be the random set of numbers your phone exchanged over Bluetooth with other phones that were nearby during the past 14 days, along with a weighted risk score based on when your symptoms developed./,
       ),
     ).toBeDefined()

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -187,13 +187,6 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
             {t("export.publish_consent_title_bluetooth")}
           </Text>
           <Text style={style.bodyText}>{t("export.consent_body_0")}</Text>
-          <Text style={style.subheaderText}>
-            {t("export.consent_subheader_1")}
-          </Text>
-          <Text style={style.bodyText}>{t("export.consent_body_1")}</Text>
-          <Text style={style.subheaderText}>
-            {t("export.consent_subheader_2")}
-          </Text>
           <Text style={style.bodyText}>{t("export.consent_body_2")}</Text>
         </View>
         <TouchableOpacity
@@ -243,12 +236,6 @@ const createStyle = (insets: EdgeInsets) => {
     header: {
       ...Typography.header.x60,
       paddingBottom: Spacing.medium,
-    },
-    subheaderText: {
-      ...Typography.body.x30,
-      ...Typography.style.medium,
-      color: Colors.neutral.black,
-      marginBottom: Spacing.xxSmall,
     },
     bodyText: {
       ...Typography.body.x30,


### PR DESCRIPTION
Why: there is currently too much content on the screen which results in a poor UX, especially on smaller devices.

<img width="367" alt="Screen Shot 2020-11-10 at 6 13 13 PM" src="https://user-images.githubusercontent.com/39350030/98744866-76273880-2380-11eb-96f7-d2be53de40bc.png">