### PR TITLE
Fix for trailing / bug 

### DIFF
--- a/ios/BT/API/APIClient.swift
+++ b/ios/BT/API/APIClient.swift
@@ -153,7 +153,7 @@ private extension BTAPIClient {
   func downloadRequest<T: APIRequest>(for request: T,
                                       requestType: RequestType) -> DataRequest {
     let baseUrl = baseUrlFor(requestType)
-    let r = sessionManager.request(baseUrl.appendingPathComponent(request.path))
+    let r = request.path.isEmpty ? sessionManager.request(baseUrl) : sessionManager.request(baseUrl.appendingPathComponent(request.path))
     debugPrint(r)
     return r
   }


### PR DESCRIPTION
#### Why:
For requests with empty paths, the iOS api client was erroneously appending a trailing `/`, which resulted in `404`s.

#### This commit:
This commit ensures that only non-empty paths will be appended to download request urls. 