### PR TITLE
Track if a user opts into product analytics

### DIFF
--- a/src/ProductAnalytics/Context.tsx
+++ b/src/ProductAnalytics/Context.tsx
@@ -10,7 +10,7 @@ import { StorageUtils } from "../utils"
 
 export type ProductAnalyticsContextState = {
   userConsentedToAnalytics: boolean
-  updateUserConsent: (consent: boolean) => Promise<void>
+  updateUserConsent: (userConsented: boolean) => Promise<void>
   trackEvent: (
     category: EventCategory,
     action: string,
@@ -73,9 +73,21 @@ const ProductAnalyticsProvider: FunctionComponent<{
       productAnalyticsClient.trackView([screen])
     }
   }
-  const updateUserConsent = async (consent: boolean) => {
-    await StorageUtils.setAnalyticsConsent(consent)
-    setUserConsentedToAnalytics(consent)
+
+  const updateUserConsent = async (userConsented: boolean) => {
+    const trackConsented = async () => {
+      const isOnboardingComplete = await StorageUtils.getIsOnboardingComplete()
+      const eventName = isOnboardingComplete
+        ? "settings_consented_to_analytics"
+        : "onboarding_consented_to_analytics"
+      if (userConsented) {
+        productAnalyticsClient.trackEvent("product_analytics", eventName)
+      }
+    }
+
+    trackConsented()
+    StorageUtils.setAnalyticsConsent(userConsented)
+    setUserConsentedToAnalytics(userConsented)
   }
 
   return (

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -19,6 +19,7 @@ export const subscribeToExposureEvents = (
   const ExposureEvents = new NativeEventEmitter(
     NativeModules.ExposureEventEmitter,
   )
+
   return ExposureEvents.addListener(
     "onExposureRecordUpdated",
     (rawExposure: string) => {


### PR DESCRIPTION
Why:
If a user chooses to share anonymous product usage data with the
application we would like to log this event.

This commit:
Adds the logic to the `updateUserConsented` function to log this event.
Note that it was necessary to not reuse the existing trackEvent function
as when a user is initially agreeing to the sharing of analytic data
they are not opted in and we cannot reuse that function as it does not
track events if the user is not opted in.

Co-Authored-By: devin jameson <devin@thoughtbot.com>