### PR TITLE
Update activation flow ordering and styling

### DIFF
--- a/src/Activation/ActivationSummary.tsx
+++ b/src/Activation/ActivationSummary.tsx
@@ -103,6 +103,7 @@ const ActivationSummary: FunctionComponent = () => {
     <ScrollView
       style={style.container}
       contentContainerStyle={style.contentContainer}
+      alwaysBounceVertical={false}
     >
       <View style={style.innerContainer}>
         <View style={style.topContainer}>

--- a/src/Activation/ProductAnalyticsConsentForm.spec.tsx
+++ b/src/Activation/ProductAnalyticsConsentForm.spec.tsx
@@ -36,7 +36,7 @@ describe("ProductAnalyticsConsentForm", () => {
       await waitFor(() => {
         expect(updateUserConsent).toHaveBeenCalledWith(true)
         expect(navigationSpy).toHaveBeenCalledWith(
-          ActivationStackScreens.ActivationSummary,
+          ActivationStackScreens.ActivateExposureNotifications,
         )
       })
     })
@@ -68,7 +68,7 @@ describe("ProductAnalyticsConsentForm", () => {
       await waitFor(() => {
         expect(updateUserConsent).not.toHaveBeenCalled()
         expect(navigationSpy).toHaveBeenCalledWith(
-          ActivationStackScreens.ActivationSummary,
+          ActivationStackScreens.ActivateExposureNotifications,
         )
       })
     })

--- a/src/Activation/ProductAnalyticsConsentForm.tsx
+++ b/src/Activation/ProductAnalyticsConsentForm.tsx
@@ -26,13 +26,13 @@ const ProductAnalyticsConsentForm: FunctionComponent = () => {
   } = useConfigurationContext()
   const { updateUserConsent } = useProductAnalyticsContext()
 
-  const handleOnPressButton = async () => {
+  const handleOnPressYes = async () => {
     updateUserConsent(true)
-    navigation.navigate(ActivationStackScreens.ActivationSummary)
+    navigation.navigate(ActivationStackScreens.ActivateExposureNotifications)
   }
 
   const handleOnPressMaybeLater = () => {
-    navigation.navigate(ActivationStackScreens.ActivationSummary)
+    navigation.navigate(ActivationStackScreens.ActivateExposureNotifications)
   }
 
   const handleOnPressPrivacyPolicy = () => {
@@ -78,7 +78,7 @@ const ProductAnalyticsConsentForm: FunctionComponent = () => {
       <View style={style.buttonsContainer}>
         <TouchableOpacity
           style={style.button}
-          onPress={handleOnPressButton}
+          onPress={handleOnPressYes}
           accessibilityLabel={buttonText}
         >
           <Text style={style.buttonText}>{buttonText}</Text>

--- a/src/Activation/activationStackController.spec.ts
+++ b/src/Activation/activationStackController.spec.ts
@@ -18,8 +18,8 @@ describe("nextScreenFromExposureNotifications", () => {
       jest.resetModules()
     })
 
-    describe("when the bluetooth is off", () => {
-      it("returns the bluetooth screen", () => {
+    describe("when Bluetooth is off", () => {
+      it("returns the Bluetooth screen", () => {
         expect(
           nextScreenFromExposureNotifications({
             isLocationRequiredAndOff: true,
@@ -54,8 +54,8 @@ describe("nextScreenFromExposureNotifications", () => {
       jest.resetModules()
     })
 
-    describe("when the bluetooth is off", () => {
-      it("returns the bluetooth screen", () => {
+    describe("when Bluetooth is off", () => {
+      it("returns Bluetooth screen", () => {
         expect(
           nextScreenFromExposureNotifications({
             isLocationRequiredAndOff: true,
@@ -65,7 +65,7 @@ describe("nextScreenFromExposureNotifications", () => {
       })
     })
 
-    describe("when the bluetooth is on", () => {
+    describe("when Bluetooth is on", () => {
       describe("when the location is required and off", () => {
         it("returns the activate location screen", () => {
           expect(
@@ -78,13 +78,13 @@ describe("nextScreenFromExposureNotifications", () => {
       })
 
       describe("when location is not required or on", () => {
-        it("returns the anonymized data consent screen", () => {
+        it("returns the activation summary", () => {
           expect(
             nextScreenFromExposureNotifications({
               isLocationRequiredAndOff: false,
               isBluetoothOn: true,
             }),
-          ).toEqual(ActivationStackScreens.AnonymizedDataConsent)
+          ).toEqual(ActivationStackScreens.ActivationSummary)
         })
       })
     })
@@ -138,12 +138,12 @@ describe("nextScreenFromBluetooth", () => {
     })
 
     describe("when location is not required or on", () => {
-      it("returns the anonymized data consent screen", () => {
+      it("returns the activation summary screen", () => {
         expect(
           nextScreenFromBluetooth({
             isLocationRequiredAndOff: false,
           }),
-        ).toEqual(ActivationStackScreens.AnonymizedDataConsent)
+        ).toEqual(ActivationStackScreens.ActivationSummary)
       })
     })
   })

--- a/src/Activation/activationStackController.ts
+++ b/src/Activation/activationStackController.ts
@@ -18,7 +18,7 @@ export const nextScreenFromBluetooth = ({
   } else {
     return isLocationRequiredAndOff
       ? ActivationStackScreens.ActivateLocation
-      : ActivationStackScreens.AnonymizedDataConsent
+      : ActivationStackScreens.ActivationSummary
   }
 }
 

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -67,7 +67,7 @@ const ActivationStack: FunctionComponent = () => {
     }
     baseActivationSteps.unshift(acceptTermsOfService)
   }
-
+  ActivationSummary
   if (!isBluetoothOn) {
     const activateBluetooth: ActivationStep = {
       screenName: ActivationStackScreens.ActivateBluetooth,
@@ -92,12 +92,12 @@ const ActivationStack: FunctionComponent = () => {
     default: activationStepsIOS,
   })
 
-  if (enableProductAnalytics) {
+  if (enableProductAnalytics || true) {
     const anonymizedDataConsent: ActivationStep = {
       screenName: ActivationStackScreens.AnonymizedDataConsent,
       component: ProductAnalyticsConsentForm,
     }
-    activationSteps.push(anonymizedDataConsent)
+    activationSteps.unshift(anonymizedDataConsent)
   }
 
   const activationSummary: ActivationStep = {

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -1,15 +1,8 @@
 import React, { FunctionComponent } from "react"
-import { Platform, TouchableOpacity, StyleSheet, View } from "react-native"
-import {
-  createStackNavigator,
-  HeaderStyleInterpolators,
-  StackNavigationOptions,
-} from "@react-navigation/stack"
-import { SvgXml } from "react-native-svg"
-import { useNavigation } from "@react-navigation/native"
-import { useTranslation } from "react-i18next"
+import { Platform } from "react-native"
+import { createStackNavigator } from "@react-navigation/stack"
 
-import { Stacks, ActivationStackScreen, ActivationStackScreens } from "./index"
+import { ActivationStackScreen, ActivationStackScreens } from "./index"
 import { usePermissionsContext } from "../Device/PermissionsContext"
 import ActivateExposureNotifications from "../Activation/ActivateExposureNotifications"
 import ActivateLocation from "../Activation/ActivateLocation"
@@ -19,9 +12,9 @@ import ActivateBluetooth from "../Activation/ActivateBluetooth"
 import AcceptTermsOfService from "../Activation/AcceptTermsOfService"
 import ProductAnalyticsConsentForm from "../Activation/ProductAnalyticsConsentForm"
 import { useConfigurationContext } from "../ConfigurationContext"
+import { applyHeaderLeftBackButton } from "../navigation/HeaderLeftBackButton"
 
-import { Icons } from "../assets"
-import { Layout, Spacing, Colors, Typography } from "../styles"
+import { Headers } from "../styles"
 
 type ActivationStackParams = {
   [key in ActivationStackScreen]: undefined
@@ -30,8 +23,6 @@ type ActivationStackParams = {
 const Stack = createStackNavigator<ActivationStackParams>()
 
 const ActivationStack: FunctionComponent = () => {
-  const { t } = useTranslation()
-  const navigation = useNavigation()
   const { locationPermissions, isBluetoothOn } = usePermissionsContext()
   const {
     displayAcceptTermsOfService,
@@ -92,7 +83,7 @@ const ActivationStack: FunctionComponent = () => {
     default: activationStepsIOS,
   })
 
-  if (enableProductAnalytics || true) {
+  if (enableProductAnalytics) {
     const anonymizedDataConsent: ActivationStep = {
       screenName: ActivationStackScreens.AnonymizedDataConsent,
       component: ProductAnalyticsConsentForm,
@@ -106,46 +97,14 @@ const ActivationStack: FunctionComponent = () => {
   }
   activationSteps.push(activationSummary)
 
-  const CloseButton = () => {
-    const handleOnPressClose = () => {
-      navigation.navigate(Stacks.HowItWorks)
-    }
-
-    return (
-      <TouchableOpacity onPress={handleOnPressClose}>
-        <SvgXml
-          xml={Icons.Close}
-          fill={Colors.neutral.shade140}
-          style={style.closeIcon}
-          accessible
-          accessibilityLabel={t("common.close")}
-        />
-      </TouchableOpacity>
-    )
-  }
-
-  const HeaderRight: FunctionComponent = () => {
-    return (
-      <View style={style.headerRight}>
-        <CloseButton />
-      </View>
-    )
-  }
-
-  const screenOptions: StackNavigationOptions = {
-    headerShown: true,
-    headerLeft: () => null,
-    headerTitleAlign: "left",
-    headerTitle: t("onboarding.activation_header_title"),
-    headerTitleStyle: style.headerTitle,
-    gestureEnabled: false,
-    headerStyleInterpolator: HeaderStyleInterpolators.forNoAnimation,
-  }
-
   return (
     <Stack.Navigator
       initialRouteName={ActivationStackScreens.AcceptTermsOfService}
-      screenOptions={screenOptions}
+      screenOptions={{
+        ...Headers.headerMinimalOptions,
+        headerLeft: applyHeaderLeftBackButton(),
+        headerTitle: () => null,
+      }}
     >
       {activationSteps.map((step) => {
         return (
@@ -153,29 +112,11 @@ const ActivationStack: FunctionComponent = () => {
             name={step.screenName}
             component={step.component}
             key={`activation-screen-${step.screenName}`}
-            options={{
-              headerRight: () => HeaderRight({}),
-            }}
           />
         )
       })}
     </Stack.Navigator>
   )
 }
-
-const style = StyleSheet.create({
-  headerTitle: {
-    ...Typography.header.x30,
-    color: Colors.neutral.shade100,
-    maxWidth: Layout.halfWidth,
-  },
-  headerRight: {
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  closeIcon: {
-    paddingHorizontal: Spacing.large,
-  },
-})
 
 export default ActivationStack

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -58,7 +58,7 @@ const ActivationStack: FunctionComponent = () => {
     }
     baseActivationSteps.unshift(acceptTermsOfService)
   }
-  ActivationSummary
+
   if (!isBluetoothOn) {
     const activateBluetooth: ActivationStep = {
       screenName: ActivationStackScreens.ActivateBluetooth,


### PR DESCRIPTION
Why: we would like for the Share Analytics Consent screen to be at the start of the Activation flow. This will enable us to gather analytics on the rest of the Activation flow if the user opts in to sharing analytics.

This commit:
- Moves the Share Analytics Consent screen to the start of the Activation flow
- Updates the header for the Activation screens to only have a "Back" button instead of the "App Setup" title and a close button

![gif](https://user-images.githubusercontent.com/39350030/98970465-f7e0a880-24dd-11eb-86a4-1be5aabe8891.gif)