### PR TITLE
Reset product analytics on delete all data

### DIFF
--- a/src/ProductAnalytics/Context.tsx
+++ b/src/ProductAnalytics/Context.tsx
@@ -18,6 +18,7 @@ export type ProductAnalyticsContextState = {
     value?: number,
   ) => Promise<void>
   trackScreenView: (screen: string) => Promise<void>
+  resetUserConsent: () => Promise<void>
 }
 
 const initialContext = {
@@ -25,6 +26,7 @@ const initialContext = {
   updateUserConsent: () => Promise.resolve(),
   trackEvent: () => Promise.resolve(),
   trackScreenView: () => Promise.resolve(),
+  resetUserConsent: () => Promise.resolve(),
 }
 
 export type EventCategory = "product_analytics" | "epi_analytics"
@@ -90,6 +92,11 @@ const ProductAnalyticsProvider: FunctionComponent<{
     setUserConsentedToAnalytics(userConsented)
   }
 
+  const resetUserConsent = async (): Promise<void> => {
+    StorageUtils.removeAnalyticsConsent()
+    setUserConsentedToAnalytics(false)
+  }
+
   return (
     <ProductAnalyticsContext.Provider
       value={{
@@ -97,6 +104,7 @@ const ProductAnalyticsProvider: FunctionComponent<{
         updateUserConsent,
         trackEvent,
         trackScreenView,
+        resetUserConsent,
       }}
     >
       {children}

--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -10,15 +10,18 @@ import { useTranslation } from "react-i18next"
 import { showMessage } from "react-native-flash-message"
 
 import { useOnboardingContext } from "../OnboardingContext"
+import { useProductAnalyticsContext } from "../ProductAnalytics/Context"
 import { useSymptomHistoryContext } from "../SymptomHistory/SymptomHistoryContext"
 import { Text } from "../components"
 import { useStatusBarEffect } from "../navigation"
+import * as Storage from "../utils/storage"
 
 import { Spacing, Buttons, Typography, Colors, Affordances } from "../styles"
 
 const DeleteConfirmation: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { resetOnboarding } = useOnboardingContext()
+  const { resetUserConsent } = useProductAnalyticsContext()
   const { deleteAllEntries } = useSymptomHistoryContext()
   const {
     successFlashMessageOptions,
@@ -30,6 +33,8 @@ const DeleteConfirmation: FunctionComponent = () => {
     const deleteLogEntriesResult = await deleteAllEntries()
     if (deleteLogEntriesResult.kind === "success") {
       resetOnboarding()
+      resetUserConsent()
+      Storage.removeAll()
       showMessage({
         message: t("settings.data_deleted"),
         ...successFlashMessageOptions,

--- a/src/factories/productAnalyticsContext.ts
+++ b/src/factories/productAnalyticsContext.ts
@@ -6,4 +6,5 @@ export default Factory.define<ProductAnalyticsContextState>(() => ({
   updateUserConsent: () => Promise.resolve(),
   trackEvent: () => Promise.resolve(),
   trackScreenView: () => Promise.resolve(),
+  resetUserConsent: () => Promise.resolve(),
 }))

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,6 +1,12 @@
 import AsyncStorage from "@react-native-community/async-storage"
 
-async function getStoreData(key: string): Promise<string | null> {
+type StorageKey = "LANG_OVERRIDE" | "ONBOARDING_COMPLETE" | "ANALYTICS_CONSENT"
+
+const LANG_OVERRIDE: StorageKey = "LANG_OVERRIDE"
+const ONBOARDING_COMPLETE: StorageKey = "ONBOARDING_COMPLETE"
+const ANALYTICS_CONSENT: StorageKey = "ANALYTICS_CONSENT"
+
+async function getStoreData(key: StorageKey): Promise<string | null> {
   try {
     return await AsyncStorage.getItem(key)
   } catch (error) {
@@ -9,7 +15,7 @@ async function getStoreData(key: string): Promise<string | null> {
   }
 }
 
-async function setStoreData(key: string, item: string): Promise<void> {
+async function setStoreData(key: StorageKey, item: string): Promise<void> {
   try {
     return await AsyncStorage.setItem(key, item)
   } catch (error) {
@@ -17,7 +23,7 @@ async function setStoreData(key: string, item: string): Promise<void> {
   }
 }
 
-async function removeStoreData(key: string): Promise<void> {
+async function removeStoreData(key: StorageKey): Promise<void> {
   try {
     return await AsyncStorage.removeItem(key)
   } catch (error) {
@@ -25,7 +31,13 @@ async function removeStoreData(key: string): Promise<void> {
   }
 }
 
-const LANG_OVERRIDE = "LANG_OVERRIDE"
+export const removeAll = async (): Promise<void> => {
+  removeUserLocaleOverride()
+  removeIsOnboardingComplete()
+  removeAnalyticsConsent()
+}
+
+// Language Override
 export async function getUserLocaleOverride(): Promise<string | null> {
   return await getStoreData(LANG_OVERRIDE)
 }
@@ -34,7 +46,11 @@ export async function setUserLocaleOverride(locale: string): Promise<void> {
   return await setStoreData(LANG_OVERRIDE, locale)
 }
 
-const ONBOARDING_COMPLETE = "ONBOARDING_COMPLETE"
+export async function removeUserLocaleOverride(): Promise<void> {
+  return await removeStoreData("LANG_OVERRIDE")
+}
+
+// Onboarding completion
 export async function getIsOnboardingComplete(): Promise<boolean> {
   const onboardingComplete = await getStoreData(ONBOARDING_COMPLETE)
   return onboardingComplete === ONBOARDING_COMPLETE
@@ -48,7 +64,7 @@ export async function removeIsOnboardingComplete(): Promise<void> {
   return removeStoreData(ONBOARDING_COMPLETE)
 }
 
-const ANALYTICS_CONSENT = "ANALYTICS_CONSENT"
+// Consented to Product Analytics
 const USER_CONSENTED = "USER_CONSENTED"
 const USER_NOT_CONSENTED = "USER_NOT_CONSENTED"
 
@@ -59,6 +75,10 @@ export async function getAnalyticsConsent(): Promise<boolean> {
 
 export async function setAnalyticsConsent(consent: boolean): Promise<void> {
   return setStoreData(ANALYTICS_CONSENT, booleanToConsent(consent))
+}
+
+export async function removeAnalyticsConsent(): Promise<void> {
+  return removeStoreData(ANALYTICS_CONSENT)
 }
 
 const consentToBoolean = (consent: string | null): boolean => {


### PR DESCRIPTION
Why:
When a user elects to 'Delete all data' we would like to be deleting the
data related to remembering that the user has opted into sharing product
analytics.

This commit:
Adds the logic the to product analytics context to reset and invokes
this logic in the delete all data feature.