### PR TITLE
Fix accessibility issue with modal header

### DIFF
--- a/src/navigation/ModalHeader.tsx
+++ b/src/navigation/ModalHeader.tsx
@@ -53,7 +53,11 @@ const ModalHeader: FunctionComponent<ModalHeaderProps> = ({
 
   return (
     <View style={style.container}>
-      <Text numberOfLines={10} style={style.headerText}>
+      <Text
+        numberOfLines={10}
+        style={style.headerText}
+        accessible={headerTitle !== ""}
+      >
         {headerTitle}
       </Text>
       <TouchableOpacity


### PR DESCRIPTION
Why: currently, screen readers can focus the title of the modal header even if it is an empty string. We would like to make this element inaccessible if the modal header title is an empty string.

This commit:
- Makes the modal header title inaccessible for screen readers if the content is an empty string