### PR TITLE
Add labels to tab bar

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -7,6 +7,7 @@ interface TextProps {
   style?: TextStyle
   testID?: string
   onPress?: () => void
+  allowFontScaling?: boolean
   children: ReactNode | string
 }
 
@@ -15,6 +16,7 @@ const Text: FunctionComponent<TextProps> = ({
   testID,
   children,
   onPress,
+  allowFontScaling = true,
 }: TextProps) => {
   const writingDirection = useLanguageDirection()
 
@@ -23,6 +25,7 @@ const Text: FunctionComponent<TextProps> = ({
       onPress={onPress}
       style={[{ writingDirection }, style]}
       testID={testID}
+      allowFontScaling={allowFontScaling}
     >
       {children}
     </RNText>

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -8,15 +8,19 @@ interface TextProps {
   testID?: string
   onPress?: () => void
   allowFontScaling?: boolean
+  numberOfLines?: number
+  ellipsizeMode?: "head" | "middle" | "tail" | "clip"
   children: ReactNode | string
 }
 
 const Text: FunctionComponent<TextProps> = ({
   style,
   testID,
-  children,
   onPress,
   allowFontScaling = true,
+  numberOfLines,
+  ellipsizeMode = "tail",
+  children,
 }: TextProps) => {
   const writingDirection = useLanguageDirection()
 
@@ -26,6 +30,8 @@ const Text: FunctionComponent<TextProps> = ({
       style={[{ writingDirection }, style]}
       testID={testID}
       allowFontScaling={allowFontScaling}
+      numberOfLines={numberOfLines}
+      ellipsizeMode={ellipsizeMode}
     >
       {children}
     </RNText>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -214,11 +214,11 @@
   },
   "navigation": {
     "exposure": "Exposure",
-    "exposure_history": "Exposures",
+    "exposure_history": "Exposure History",
     "home": "Dashboard",
     "more_info": "More Info",
     "settings": "Settings",
-    "symptom_history": "My Symptoms"
+    "symptom_history": "Symptom History"
   },
   "onboarding": {
     "activation_header_title": "App Setup",
@@ -288,7 +288,7 @@
   },
   "screen_titles": {
     "bluetooth": "Bluetooth",
-    "exposure_history": "Exposures",
+    "exposure_history": "Exposure History",
     "exposure_notifications": "Exposure Notifications",
     "exposure_scanning": "Exposure Detection",
     "home": "Dashboard",
@@ -431,7 +431,7 @@
       "you_did_not_feel_well": "You did not feel well, symptoms included: {{symptomList}}",
       "you_felt_well": "You felt well"
     },
-    "symptom_history": "My Symptoms",
+    "symptom_history": "Symptom History",
     "to_protect_your_privacy": "To protect your privacy, entries are stored on your device and deleted automatically after {{days}} days."
   },
   "symptom": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -214,11 +214,11 @@
   },
   "navigation": {
     "exposure": "Exposure",
-    "exposure_history": "Exposure History",
+    "exposure_history": "Exposures",
     "home": "Dashboard",
     "more_info": "More Info",
     "settings": "Settings",
-    "symptom_history": "Symptom History"
+    "symptom_history": "My Symptoms"
   },
   "onboarding": {
     "activation_header_title": "App Setup",
@@ -288,7 +288,7 @@
   },
   "screen_titles": {
     "bluetooth": "Bluetooth",
-    "exposure_history": "Exposure History",
+    "exposure_history": "Exposures",
     "exposure_notifications": "Exposure Notifications",
     "exposure_scanning": "Exposure Detection",
     "home": "Dashboard",
@@ -431,7 +431,7 @@
       "you_did_not_feel_well": "You did not feel well, symptoms included: {{symptomList}}",
       "you_felt_well": "You felt well"
     },
-    "symptom_history": "Symptom History",
+    "symptom_history": "My Symptoms",
     "to_protect_your_privacy": "To protect your privacy, entries are stored on your device and deleted automatically after {{days}} days."
   },
   "symptom": {

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -54,12 +54,14 @@ const MainTabNavigator: FunctionComponent = () => {
   }
 
   const TabIcon: FunctionComponent<TabIconProps> = ({ focused, icon }) => {
+    const iconSize = 22
+
     return (
       <SvgXml
         xml={icon}
         fill={focused ? Colors.primary.shade100 : Colors.neutral.shade50}
-        width={22}
-        height={22}
+        width={iconSize}
+        height={iconSize}
       />
     )
   }

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react"
-import { Pressable, View } from "react-native"
+import { Pressable, View, StyleSheet } from "react-native"
 import {
   BottomTabBarProps,
   createBottomTabNavigator,
@@ -76,13 +76,8 @@ const TabBar: FunctionComponent<TabBarProps> = ({
   return (
     <View
       style={{
-        flexDirection: "row",
-        justifyContent: "center",
+        ...style.tabBarContainer,
         paddingBottom: insets.bottom + Spacing.xxSmall,
-        paddingTop: Spacing.xxSmall,
-        backgroundColor: Colors.background.primaryLight,
-        borderTopWidth: Outlines.hairline,
-        borderColor: Colors.neutral.shade10,
       }}
     >
       {tabs.map((tab, index: number) => {
@@ -141,7 +136,7 @@ const TabBar: FunctionComponent<TabBarProps> = ({
           <Pressable
             onPress={handleOnPress}
             style={{
-              alignItems: "center",
+              ...style.tabButton,
               width: Layout.screenWidth / tabs.length,
             }}
             accessibilityRole="button"
@@ -153,14 +148,7 @@ const TabBar: FunctionComponent<TabBarProps> = ({
               allowFontScaling={false}
               numberOfLines={2}
               ellipsizeMode="middle"
-              style={{
-                ...Typography.style.normal,
-                fontSize: Typography.size.x15,
-                color: textColor,
-                textAlign: "center",
-                lineHeight: Typography.lineHeight.x5,
-                maxWidth: Spacing.xxxMassive,
-              }}
+              style={{ ...style.tabLabelText, color: textColor }}
             >
               {label}
             </Text>
@@ -180,7 +168,7 @@ const TabIcon: FunctionComponent<TabIconProps> = ({ focused, icon }) => {
   const iconSize = 22
 
   return (
-    <View style={{ marginBottom: Spacing.xxSmall }}>
+    <View style={style.tabIconContainer}>
       <SvgXml
         xml={icon}
         fill={focused ? Colors.primary.shade100 : Colors.neutral.shade50}
@@ -190,5 +178,29 @@ const TabIcon: FunctionComponent<TabIconProps> = ({ focused, icon }) => {
     </View>
   )
 }
+
+const style = StyleSheet.create({
+  tabBarContainer: {
+    flexDirection: "row",
+    justifyContent: "center",
+    paddingTop: Spacing.xxSmall,
+    backgroundColor: Colors.background.primaryLight,
+    borderTopWidth: Outlines.hairline,
+    borderColor: Colors.neutral.shade10,
+  },
+  tabButton: {
+    alignItems: "center",
+  },
+  tabIconContainer: {
+    marginBottom: Spacing.xxSmall,
+  },
+  tabLabelText: {
+    ...Typography.style.normal,
+    fontSize: Typography.size.x15,
+    textAlign: "center",
+    lineHeight: Typography.lineHeight.x5,
+    maxWidth: Spacing.xxxMassive,
+  },
+})
 
 export default MainTabNavigator

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -66,7 +66,8 @@ const MainTabNavigator: FunctionComponent = () => {
     )
   }
 
-  const tabs = ["home", "exposureHistory", "settings"]
+  type Tab = "home" | "exposureHistory" | "settings" | "symptomHistory"
+  const tabs: Tab[] = ["home", "exposureHistory", "settings"]
   if (displaySymptomHistory) {
     tabs.push("symptomHistory")
   }

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -85,46 +85,29 @@ const TabBar: FunctionComponent<TabBarProps> = ({
         borderColor: Colors.neutral.shade10,
       }}
     >
-      {state.routes.map((route, index: number) => {
-        const handleOnPress = () => {
-          !isFocused && navigation.navigate(route.name)
+      {tabs.map((tab, index: number) => {
+        const isFocused = (tab: Tab) => {
+          const focusedRouteName = state.routeNames[state.index]
+          return tab.name === focusedRouteName
         }
 
-        const isFocused = state.index === index
+        const focused = isFocused(tab)
 
-        const textColor = isFocused
+        const handleOnPress = () => {
+          !focused && navigation.navigate(tab.name)
+        }
+
+        const textColor = focused
           ? Colors.primary.shade100
           : Colors.neutral.shade100
-
-        const routeStringToTab = (route: string): TabRoute => {
-          switch (route) {
-            case "Home": {
-              return "Home"
-            }
-            case "ExposureHistory": {
-              return "ExposureHistory"
-            }
-            case "SymptomHistory": {
-              return "SymptomHistory"
-            }
-            case "Settings": {
-              return "Settings"
-            }
-            default: {
-              return "Home"
-            }
-          }
-        }
-
-        const currentTab = routeStringToTab(route.name)
 
         type TabButtonConfig = {
           label: string
           icon: string
         }
 
-        const determineConfig = (): TabButtonConfig => {
-          switch (currentTab) {
+        const determineConfig = (tab: Tab): TabButtonConfig => {
+          switch (tab.name) {
             case "Home": {
               return {
                 label: t("navigation.home"),
@@ -152,7 +135,7 @@ const TabBar: FunctionComponent<TabBarProps> = ({
           }
         }
 
-        const { label, icon } = determineConfig()
+        const { label, icon } = determineConfig(tab)
 
         return (
           <Pressable
@@ -162,10 +145,10 @@ const TabBar: FunctionComponent<TabBarProps> = ({
               width: Layout.screenWidth / tabs.length,
             }}
             accessibilityRole="button"
-            accessibilityState={isFocused ? { selected: true } : {}}
+            accessibilityState={focused ? { selected: true } : {}}
             key={index}
           >
-            <TabIcon focused={isFocused} icon={icon} />
+            <TabIcon focused={focused} icon={icon} />
             <Text
               allowFontScaling={false}
               numberOfLines={2}

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -9,10 +9,11 @@ import HomeStack from "./HomeStack"
 import SymptomHistoryStack from "./SymptomHistoryStack"
 import SettingsStack from "./SettingsStack"
 import { useConfigurationContext } from "../ConfigurationContext"
-
 import { Stacks } from "./index"
 import { TabBarIcons } from "../assets/svgs/TabBarNav"
-import { Colors } from "../styles"
+import { Text } from "../components"
+
+import { Colors, Typography } from "../styles"
 
 const Tab = createBottomTabNavigator()
 
@@ -79,8 +80,41 @@ const MainTabNavigator: FunctionComponent = () => {
     return tabIcon
   }
 
+  interface TabBarLabelProps {
+    focused: boolean
+    color: string
+    label: string
+  }
+
+  const applyTabBarLabel = (label: string) => {
+    const tabLabel = function (props: { focused: boolean; color: string }) {
+      return <TabBarLabel {...props} label={label} />
+    }
+    return tabLabel
+  }
+
+  const TabBarLabel: FunctionComponent<TabBarLabelProps> = ({
+    focused,
+    label,
+  }) => {
+    const color = focused ? Colors.primary.shade100 : Colors.neutral.shade100
+
+    return (
+      <Text
+        allowFontScaling={false}
+        style={{
+          ...Typography.style.normal,
+          fontSize: Typography.size.x15,
+          color: color,
+          textAlign: "center",
+        }}
+      >
+        {label}
+      </Text>
+    )
+  }
+
   const tabBarOptions = {
-    showLabel: false,
     style: {
       backgroundColor: Colors.background.primaryLight,
       borderTopWidth: 1,
@@ -95,7 +129,7 @@ const MainTabNavigator: FunctionComponent = () => {
         name={Stacks.Home}
         component={HomeStack}
         options={{
-          tabBarLabel: t("navigation.home"),
+          tabBarLabel: applyTabBarLabel(t("navigation.home")),
           tabBarIcon: HomeIcon,
         }}
       />
@@ -103,7 +137,7 @@ const MainTabNavigator: FunctionComponent = () => {
         name={Stacks.ExposureHistoryFlow}
         component={ExposureHistoryStack}
         options={{
-          tabBarLabel: t("navigation.exposure_history"),
+          tabBarLabel: applyTabBarLabel(t("navigation.exposure_history")),
           tabBarIcon: ExposureHistoryIcon,
         }}
       />
@@ -112,7 +146,7 @@ const MainTabNavigator: FunctionComponent = () => {
           name={Stacks.SymptomHistory}
           component={SymptomHistoryStack}
           options={{
-            tabBarLabel: t("navigation.symptom_history"),
+            tabBarLabel: applyTabBarLabel(t("navigation.symptom_history")),
             tabBarIcon: HeartbeatIcon,
           }}
         />
@@ -121,7 +155,7 @@ const MainTabNavigator: FunctionComponent = () => {
         name={Stacks.Settings}
         component={SettingsStack}
         options={{
-          tabBarLabel: t("navigation.settings"),
+          tabBarLabel: applyTabBarLabel(t("navigation.settings")),
           tabBarIcon: SettingsIcon,
         }}
       />

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -1,5 +1,8 @@
 import React, { FunctionComponent } from "react"
-import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
+import {
+  BottomTabBarProps,
+  createBottomTabNavigator,
+} from "@react-navigation/bottom-tabs"
 import { useTranslation } from "react-i18next"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { SvgXml } from "react-native-svg"
@@ -13,7 +16,9 @@ import { Stacks } from "./index"
 import { TabBarIcons } from "../assets/svgs/TabBarNav"
 import { Text } from "../components"
 
-import { Colors, Typography } from "../styles"
+import { Colors, Iconography, Outlines, Spacing, Typography } from "../styles"
+import { TouchableOpacity } from "react-native-gesture-handler"
+import { View } from "react-native"
 
 const Tab = createBottomTabNavigator()
 
@@ -26,57 +31,39 @@ const MainTabNavigator: FunctionComponent = () => {
     icon: string
   }
 
-  const TabIcon: FunctionComponent<TabIconProps> = ({
-    focused,
-    size,
-    icon,
-  }) => {
+  const TabIcon: FunctionComponent<TabIconProps> = ({ focused, icon }) => {
     return (
       <SvgXml
         xml={icon}
         fill={focused ? Colors.primary.shade100 : Colors.neutral.shade50}
-        width={size}
-        height={size}
+        width={22}
+        height={22}
       />
     )
   }
 
   interface TabBarIconProps {
     focused: boolean
-    size: number
   }
 
-  const HomeIcon: FunctionComponent<TabBarIconProps> = ({ focused, size }) => {
-    return <TabIcon icon={TabBarIcons.House} focused={focused} size={size} />
+  const HomeIcon: FunctionComponent<TabBarIconProps> = ({ focused }) => {
+    return <TabIcon icon={TabBarIcons.House} focused={focused} />
   }
 
   const ExposureHistoryIcon: FunctionComponent<TabBarIconProps> = ({
     focused,
-    size,
   }) => {
-    const tabIcon = (
-      <TabIcon icon={TabBarIcons.Exposure} focused={focused} size={size} />
-    )
+    const tabIcon = <TabIcon icon={TabBarIcons.Exposure} focused={focused} />
     return tabIcon
   }
 
-  const HeartbeatIcon: FunctionComponent<TabBarIconProps> = ({
-    focused,
-    size,
-  }) => {
-    const tabIcon = (
-      <TabIcon icon={TabBarIcons.Heartbeat} focused={focused} size={size} />
-    )
+  const HeartbeatIcon: FunctionComponent<TabBarIconProps> = ({ focused }) => {
+    const tabIcon = <TabIcon icon={TabBarIcons.Heartbeat} focused={focused} />
     return tabIcon
   }
 
-  const SettingsIcon: FunctionComponent<TabBarIconProps> = ({
-    focused,
-    size,
-  }) => {
-    const tabIcon = (
-      <TabIcon icon={TabBarIcons.Gear} focused={focused} size={size} />
-    )
+  const SettingsIcon: FunctionComponent<TabBarIconProps> = ({ focused }) => {
+    const tabIcon = <TabIcon icon={TabBarIcons.Gear} focused={focused} />
     return tabIcon
   }
 
@@ -84,13 +71,6 @@ const MainTabNavigator: FunctionComponent = () => {
     focused: boolean
     color: string
     label: string
-  }
-
-  const applyTabBarLabel = (label: string) => {
-    const tabLabel = function (props: { focused: boolean; color: string }) {
-      return <TabBarLabel {...props} label={label} />
-    }
-    return tabLabel
   }
 
   const TabBarLabel: FunctionComponent<TabBarLabelProps> = ({
@@ -126,13 +106,92 @@ const MainTabNavigator: FunctionComponent = () => {
     },
   }
 
+  const TabBar: FunctionComponent<BottomTabBarProps> = ({
+    state,
+    descriptors,
+    navigation,
+  }) => {
+    return (
+      <View
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          paddingHorizontal: Spacing.large,
+          paddingBottom: insets.bottom,
+          paddingTop: Spacing.xxSmall,
+          backgroundColor: Colors.background.primaryLight,
+          borderTopWidth: Outlines.hairline,
+          borderColor: Colors.neutral.shade10,
+        }}
+      >
+        {state.routes.map((route, index: number) => {
+          const { options } = descriptors[route.key]
+
+          const label = options.tabBarLabel
+          const icon = options.tabBarIcon
+          const focused = state.index === index
+
+          const handleOnPress = () => {
+            const event = navigation.emit({
+              type: "tabPress",
+              target: route.key,
+              canPreventDefault: true,
+            })
+            if (!focused && !event.defaultPrevented) {
+              navigation.navigate(route.name)
+            }
+          }
+
+          const textColor = focused
+            ? Colors.primary.shade100
+            : Colors.neutral.shade100
+
+          if (icon === undefined) {
+            return
+          }
+
+          return (
+            <TouchableOpacity
+              onPress={handleOnPress}
+              style={{ alignItems: "center" }}
+              accessibilityRole="button"
+              key={index}
+            >
+              <View style={{ marginBottom: Spacing.xxSmall }}>
+                {icon({ focused, color: "", size: 0 })}
+              </View>
+              <Text
+                allowFontScaling={false}
+                numberOfLines={2}
+                ellipsizeMode="middle"
+                style={{
+                  ...Typography.style.normal,
+                  fontSize: Typography.size.x15,
+                  color: textColor,
+                  textAlign: "center",
+                  lineHeight: Typography.lineHeight.x5,
+                  maxWidth: Spacing.xxxMassive,
+                }}
+              >
+                {label}
+              </Text>
+            </TouchableOpacity>
+          )
+        })}
+      </View>
+    )
+  }
+
   return (
-    <Tab.Navigator tabBarOptions={tabBarOptions}>
+    <Tab.Navigator
+      tabBar={(props) => <TabBar {...props} />}
+      tabBarOptions={tabBarOptions}
+    >
       <Tab.Screen
         name={Stacks.Home}
         component={HomeStack}
         options={{
-          tabBarLabel: applyTabBarLabel(t("navigation.home")),
+          tabBarLabel: t("navigation.home"),
           tabBarIcon: HomeIcon,
         }}
       />
@@ -140,7 +199,7 @@ const MainTabNavigator: FunctionComponent = () => {
         name={Stacks.ExposureHistoryFlow}
         component={ExposureHistoryStack}
         options={{
-          tabBarLabel: applyTabBarLabel(t("navigation.exposure_history")),
+          tabBarLabel: t("navigation.exposure_history"),
           tabBarIcon: ExposureHistoryIcon,
         }}
       />
@@ -150,7 +209,7 @@ const MainTabNavigator: FunctionComponent = () => {
             name={Stacks.SymptomHistory}
             component={SymptomHistoryStack}
             options={{
-              tabBarLabel: applyTabBarLabel(t("navigation.symptom_history")),
+              tabBarLabel: t("navigation.symptom_history"),
               tabBarIcon: HeartbeatIcon,
             }}
           />
@@ -159,7 +218,7 @@ const MainTabNavigator: FunctionComponent = () => {
         name={Stacks.Settings}
         component={SettingsStack}
         options={{
-          tabBarLabel: applyTabBarLabel(t("navigation.settings")),
+          tabBarLabel: t("navigation.settings"),
           tabBarIcon: SettingsIcon,
         }}
       />

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from "react"
+import { Pressable, View } from "react-native"
 import {
   BottomTabBarProps,
   createBottomTabNavigator,
@@ -16,31 +17,12 @@ import { Stacks } from "./index"
 import { TabBarIcons } from "../assets/svgs/TabBarNav"
 import { Text } from "../components"
 
-import { Colors, Iconography, Outlines, Spacing, Typography } from "../styles"
-import { TouchableOpacity } from "react-native-gesture-handler"
-import { View } from "react-native"
-
-const Tab = createBottomTabNavigator()
+import { Colors, Layout, Outlines, Spacing, Typography } from "../styles"
 
 const MainTabNavigator: FunctionComponent = () => {
   const { t } = useTranslation()
   const insets = useSafeAreaInsets()
   const { displaySymptomHistory } = useConfigurationContext()
-
-  interface TabIconProps extends TabBarIconProps {
-    icon: string
-  }
-
-  const TabIcon: FunctionComponent<TabIconProps> = ({ focused, icon }) => {
-    return (
-      <SvgXml
-        xml={icon}
-        fill={focused ? Colors.primary.shade100 : Colors.neutral.shade50}
-        width={22}
-        height={22}
-      />
-    )
-  }
 
   interface TabBarIconProps {
     focused: boolean
@@ -67,43 +49,24 @@ const MainTabNavigator: FunctionComponent = () => {
     return tabIcon
   }
 
-  interface TabBarLabelProps {
-    focused: boolean
-    color: string
-    label: string
+  interface TabIconProps extends TabBarIconProps {
+    icon: string
   }
 
-  const TabBarLabel: FunctionComponent<TabBarLabelProps> = ({
-    focused,
-    label,
-  }) => {
-    const color = focused ? Colors.primary.shade100 : Colors.neutral.shade100
-
+  const TabIcon: FunctionComponent<TabIconProps> = ({ focused, icon }) => {
     return (
-      <Text
-        allowFontScaling={false}
-        numberOfLines={2}
-        ellipsizeMode="middle"
-        style={{
-          ...Typography.style.normal,
-          fontSize: Typography.size.x15,
-          color: color,
-          textAlign: "center",
-          lineHeight: Typography.lineHeight.x5,
-        }}
-      >
-        {label}
-      </Text>
+      <SvgXml
+        xml={icon}
+        fill={focused ? Colors.primary.shade100 : Colors.neutral.shade50}
+        width={22}
+        height={22}
+      />
     )
   }
 
-  const tabBarOptions = {
-    style: {
-      backgroundColor: Colors.background.primaryLight,
-      borderTopWidth: 1,
-      borderTopColor: Colors.neutral.shade10,
-      height: insets.bottom + 60,
-    },
+  const tabs = ["home", "exposureHistory", "settings"]
+  if (displaySymptomHistory) {
+    tabs.push("symptomHistory")
   }
 
   const TabBar: FunctionComponent<BottomTabBarProps> = ({
@@ -115,9 +78,8 @@ const MainTabNavigator: FunctionComponent = () => {
       <View
         style={{
           flexDirection: "row",
-          justifyContent: "space-between",
-          paddingHorizontal: Spacing.large,
-          paddingBottom: insets.bottom,
+          justifyContent: "center",
+          paddingBottom: insets.bottom + Spacing.xxSmall,
           paddingTop: Spacing.xxSmall,
           backgroundColor: Colors.background.primaryLight,
           borderTopWidth: Outlines.hairline,
@@ -127,22 +89,15 @@ const MainTabNavigator: FunctionComponent = () => {
         {state.routes.map((route, index: number) => {
           const { options } = descriptors[route.key]
 
-          const label = options.tabBarLabel
+          const label = options.title
           const icon = options.tabBarIcon
-          const focused = state.index === index
+          const isFocused = state.index === index
 
           const handleOnPress = () => {
-            const event = navigation.emit({
-              type: "tabPress",
-              target: route.key,
-              canPreventDefault: true,
-            })
-            if (!focused && !event.defaultPrevented) {
-              navigation.navigate(route.name)
-            }
+            !isFocused && navigation.navigate(route.name)
           }
 
-          const textColor = focused
+          const textColor = isFocused
             ? Colors.primary.shade100
             : Colors.neutral.shade100
 
@@ -151,14 +106,18 @@ const MainTabNavigator: FunctionComponent = () => {
           }
 
           return (
-            <TouchableOpacity
+            <Pressable
               onPress={handleOnPress}
-              style={{ alignItems: "center" }}
+              style={{
+                alignItems: "center",
+                width: Layout.screenWidth / tabs.length,
+              }}
               accessibilityRole="button"
+              accessibilityState={isFocused ? { selected: true } : {}}
               key={index}
             >
               <View style={{ marginBottom: Spacing.xxSmall }}>
-                {icon({ focused, color: "", size: 0 })}
+                {icon({ focused: isFocused, color: "", size: 0 })}
               </View>
               <Text
                 allowFontScaling={false}
@@ -175,23 +134,22 @@ const MainTabNavigator: FunctionComponent = () => {
               >
                 {label}
               </Text>
-            </TouchableOpacity>
+            </Pressable>
           )
         })}
       </View>
     )
   }
 
+  const Tab = createBottomTabNavigator()
+
   return (
-    <Tab.Navigator
-      tabBar={(props) => <TabBar {...props} />}
-      tabBarOptions={tabBarOptions}
-    >
+    <Tab.Navigator tabBar={TabBar}>
       <Tab.Screen
         name={Stacks.Home}
         component={HomeStack}
         options={{
-          tabBarLabel: t("navigation.home"),
+          title: t("navigation.home"),
           tabBarIcon: HomeIcon,
         }}
       />
@@ -199,26 +157,25 @@ const MainTabNavigator: FunctionComponent = () => {
         name={Stacks.ExposureHistoryFlow}
         component={ExposureHistoryStack}
         options={{
-          tabBarLabel: t("navigation.exposure_history"),
+          title: t("navigation.exposure_history"),
           tabBarIcon: ExposureHistoryIcon,
         }}
       />
-      {displaySymptomHistory ||
-        (true && (
-          <Tab.Screen
-            name={Stacks.SymptomHistory}
-            component={SymptomHistoryStack}
-            options={{
-              tabBarLabel: t("navigation.symptom_history"),
-              tabBarIcon: HeartbeatIcon,
-            }}
-          />
-        ))}
+      {displaySymptomHistory && (
+        <Tab.Screen
+          name={Stacks.SymptomHistory}
+          component={SymptomHistoryStack}
+          options={{
+            title: t("navigation.symptom_history"),
+            tabBarIcon: HeartbeatIcon,
+          }}
+        />
+      )}
       <Tab.Screen
         name={Stacks.Settings}
         component={SettingsStack}
         options={{
-          tabBarLabel: t("navigation.settings"),
+          title: t("navigation.settings"),
           tabBarIcon: SettingsIcon,
         }}
       />

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -66,8 +66,8 @@ const MainTabNavigator: FunctionComponent = () => {
     )
   }
 
-  type Tab = "home" | "exposureHistory" | "settings" | "symptomHistory"
-  const tabs: Tab[] = ["home", "exposureHistory", "settings"]
+  type Tab_ = "home" | "exposureHistory" | "settings" | "symptomHistory"
+  const tabs: Tab_[] = ["home", "exposureHistory", "settings"]
   if (displaySymptomHistory) {
     tabs.push("symptomHistory")
   }

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -102,6 +102,8 @@ const MainTabNavigator: FunctionComponent = () => {
     return (
       <Text
         allowFontScaling={false}
+        numberOfLines={1}
+        ellipsizeMode="middle"
         style={{
           ...Typography.style.normal,
           fontSize: Typography.size.x15,

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -13,176 +13,198 @@ import HomeStack from "./HomeStack"
 import SymptomHistoryStack from "./SymptomHistoryStack"
 import SettingsStack from "./SettingsStack"
 import { useConfigurationContext } from "../ConfigurationContext"
-import { Stacks } from "./index"
+import { TabRoute, TabRoutes } from "./index"
 import { TabBarIcons } from "../assets/svgs/TabBarNav"
 import { Text } from "../components"
 
 import { Colors, Layout, Outlines, Spacing, Typography } from "../styles"
 
+type Tab = {
+  name: TabRoute
+  component: FunctionComponent
+}
+
 const MainTabNavigator: FunctionComponent = () => {
-  const { t } = useTranslation()
-  const insets = useSafeAreaInsets()
   const { displaySymptomHistory } = useConfigurationContext()
 
-  interface TabBarIconProps {
-    focused: boolean
+  const homeTab = {
+    name: TabRoutes.Home,
+    component: HomeStack,
+  }
+  const exposureHistoryTab = {
+    name: TabRoutes.ExposureHistory,
+    component: ExposureHistoryStack,
+  }
+  const symptomHistoryTab = {
+    name: TabRoutes.SymptomHistory,
+    component: SymptomHistoryStack,
+  }
+  const settingsTab = {
+    name: TabRoutes.Settings,
+    component: SettingsStack,
   }
 
-  const HomeIcon: FunctionComponent<TabBarIconProps> = ({ focused }) => {
-    return <TabIcon icon={TabBarIcons.House} focused={focused} />
-  }
+  const tabs: Tab[] = displaySymptomHistory
+    ? [homeTab, exposureHistoryTab, symptomHistoryTab, settingsTab]
+    : [homeTab, exposureHistoryTab, settingsTab]
 
-  const ExposureHistoryIcon: FunctionComponent<TabBarIconProps> = ({
-    focused,
-  }) => {
-    const tabIcon = <TabIcon icon={TabBarIcons.Exposure} focused={focused} />
-    return tabIcon
-  }
+  const TabNavigator = createBottomTabNavigator()
 
-  const HeartbeatIcon: FunctionComponent<TabBarIconProps> = ({ focused }) => {
-    const tabIcon = <TabIcon icon={TabBarIcons.Heartbeat} focused={focused} />
-    return tabIcon
-  }
+  return (
+    <TabNavigator.Navigator
+      tabBar={(props) => <TabBar {...props} tabs={tabs} />}
+    >
+      {tabs.map(({ name, component }) => {
+        return (
+          <TabNavigator.Screen name={name} component={component} key={name} />
+        )
+      })}
+    </TabNavigator.Navigator>
+  )
+}
 
-  const SettingsIcon: FunctionComponent<TabBarIconProps> = ({ focused }) => {
-    const tabIcon = <TabIcon icon={TabBarIcons.Gear} focused={focused} />
-    return tabIcon
-  }
+type TabBarProps = BottomTabBarProps & { tabs: Tab[] }
 
-  interface TabIconProps extends TabBarIconProps {
-    icon: string
-  }
+const TabBar: FunctionComponent<TabBarProps> = ({
+  state,
+  navigation,
+  tabs,
+}) => {
+  const { t } = useTranslation()
+  const insets = useSafeAreaInsets()
 
-  const TabIcon: FunctionComponent<TabIconProps> = ({ focused, icon }) => {
-    const iconSize = 22
+  return (
+    <View
+      style={{
+        flexDirection: "row",
+        justifyContent: "center",
+        paddingBottom: insets.bottom + Spacing.xxSmall,
+        paddingTop: Spacing.xxSmall,
+        backgroundColor: Colors.background.primaryLight,
+        borderTopWidth: Outlines.hairline,
+        borderColor: Colors.neutral.shade10,
+      }}
+    >
+      {state.routes.map((route, index: number) => {
+        const handleOnPress = () => {
+          !isFocused && navigation.navigate(route.name)
+        }
 
-    return (
+        const isFocused = state.index === index
+
+        const textColor = isFocused
+          ? Colors.primary.shade100
+          : Colors.neutral.shade100
+
+        const routeStringToTab = (route: string): TabRoute => {
+          switch (route) {
+            case "Home": {
+              return "Home"
+            }
+            case "ExposureHistory": {
+              return "ExposureHistory"
+            }
+            case "SymptomHistory": {
+              return "SymptomHistory"
+            }
+            case "Settings": {
+              return "Settings"
+            }
+            default: {
+              return "Home"
+            }
+          }
+        }
+
+        const currentTab = routeStringToTab(route.name)
+
+        type TabButtonConfig = {
+          label: string
+          icon: string
+        }
+
+        const determineConfig = (): TabButtonConfig => {
+          switch (currentTab) {
+            case "Home": {
+              return {
+                label: t("navigation.home"),
+                icon: TabBarIcons.House,
+              }
+            }
+            case "ExposureHistory": {
+              return {
+                label: t("navigation.exposure_history"),
+                icon: TabBarIcons.Exposure,
+              }
+            }
+            case "SymptomHistory": {
+              return {
+                label: t("navigation.symptom_history"),
+                icon: TabBarIcons.Heartbeat,
+              }
+            }
+            case "Settings": {
+              return {
+                label: t("navigation.settings"),
+                icon: TabBarIcons.Gear,
+              }
+            }
+          }
+        }
+
+        const { label, icon } = determineConfig()
+
+        return (
+          <Pressable
+            onPress={handleOnPress}
+            style={{
+              alignItems: "center",
+              width: Layout.screenWidth / tabs.length,
+            }}
+            accessibilityRole="button"
+            accessibilityState={isFocused ? { selected: true } : {}}
+            key={index}
+          >
+            <TabIcon focused={isFocused} icon={icon} />
+            <Text
+              allowFontScaling={false}
+              numberOfLines={2}
+              ellipsizeMode="middle"
+              style={{
+                ...Typography.style.normal,
+                fontSize: Typography.size.x15,
+                color: textColor,
+                textAlign: "center",
+                lineHeight: Typography.lineHeight.x5,
+                maxWidth: Spacing.xxxMassive,
+              }}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        )
+      })}
+    </View>
+  )
+}
+
+interface TabIconProps {
+  focused: boolean
+  icon: string
+}
+
+const TabIcon: FunctionComponent<TabIconProps> = ({ focused, icon }) => {
+  const iconSize = 22
+
+  return (
+    <View style={{ marginBottom: Spacing.xxSmall }}>
       <SvgXml
         xml={icon}
         fill={focused ? Colors.primary.shade100 : Colors.neutral.shade50}
         width={iconSize}
         height={iconSize}
       />
-    )
-  }
-
-  type Tab_ = "home" | "exposureHistory" | "settings" | "symptomHistory"
-  const tabs: Tab_[] = ["home", "exposureHistory", "settings"]
-  if (displaySymptomHistory) {
-    tabs.push("symptomHistory")
-  }
-
-  const TabBar: FunctionComponent<BottomTabBarProps> = ({
-    state,
-    descriptors,
-    navigation,
-  }) => {
-    return (
-      <View
-        style={{
-          flexDirection: "row",
-          justifyContent: "center",
-          paddingBottom: insets.bottom + Spacing.xxSmall,
-          paddingTop: Spacing.xxSmall,
-          backgroundColor: Colors.background.primaryLight,
-          borderTopWidth: Outlines.hairline,
-          borderColor: Colors.neutral.shade10,
-        }}
-      >
-        {state.routes.map((route, index: number) => {
-          const { options } = descriptors[route.key]
-
-          const label = options.title
-          const icon = options.tabBarIcon
-          const isFocused = state.index === index
-
-          const handleOnPress = () => {
-            !isFocused && navigation.navigate(route.name)
-          }
-
-          const textColor = isFocused
-            ? Colors.primary.shade100
-            : Colors.neutral.shade100
-
-          if (icon === undefined) {
-            return
-          }
-
-          return (
-            <Pressable
-              onPress={handleOnPress}
-              style={{
-                alignItems: "center",
-                width: Layout.screenWidth / tabs.length,
-              }}
-              accessibilityRole="button"
-              accessibilityState={isFocused ? { selected: true } : {}}
-              key={index}
-            >
-              <View style={{ marginBottom: Spacing.xxSmall }}>
-                {icon({ focused: isFocused, color: "", size: 0 })}
-              </View>
-              <Text
-                allowFontScaling={false}
-                numberOfLines={2}
-                ellipsizeMode="middle"
-                style={{
-                  ...Typography.style.normal,
-                  fontSize: Typography.size.x15,
-                  color: textColor,
-                  textAlign: "center",
-                  lineHeight: Typography.lineHeight.x5,
-                  maxWidth: Spacing.xxxMassive,
-                }}
-              >
-                {label}
-              </Text>
-            </Pressable>
-          )
-        })}
-      </View>
-    )
-  }
-
-  const Tab = createBottomTabNavigator()
-
-  return (
-    <Tab.Navigator tabBar={TabBar}>
-      <Tab.Screen
-        name={Stacks.Home}
-        component={HomeStack}
-        options={{
-          title: t("navigation.home"),
-          tabBarIcon: HomeIcon,
-        }}
-      />
-      <Tab.Screen
-        name={Stacks.ExposureHistoryFlow}
-        component={ExposureHistoryStack}
-        options={{
-          title: t("navigation.exposure_history"),
-          tabBarIcon: ExposureHistoryIcon,
-        }}
-      />
-      {displaySymptomHistory && (
-        <Tab.Screen
-          name={Stacks.SymptomHistory}
-          component={SymptomHistoryStack}
-          options={{
-            title: t("navigation.symptom_history"),
-            tabBarIcon: HeartbeatIcon,
-          }}
-        />
-      )}
-      <Tab.Screen
-        name={Stacks.Settings}
-        component={SettingsStack}
-        options={{
-          title: t("navigation.settings"),
-          tabBarIcon: SettingsIcon,
-        }}
-      />
-    </Tab.Navigator>
+    </View>
   )
 }
 

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -102,13 +102,14 @@ const MainTabNavigator: FunctionComponent = () => {
     return (
       <Text
         allowFontScaling={false}
-        numberOfLines={1}
+        numberOfLines={2}
         ellipsizeMode="middle"
         style={{
           ...Typography.style.normal,
           fontSize: Typography.size.x15,
           color: color,
           textAlign: "center",
+          lineHeight: Typography.lineHeight.x5,
         }}
       >
         {label}
@@ -143,16 +144,17 @@ const MainTabNavigator: FunctionComponent = () => {
           tabBarIcon: ExposureHistoryIcon,
         }}
       />
-      {displaySymptomHistory && (
-        <Tab.Screen
-          name={Stacks.SymptomHistory}
-          component={SymptomHistoryStack}
-          options={{
-            tabBarLabel: applyTabBarLabel(t("navigation.symptom_history")),
-            tabBarIcon: HeartbeatIcon,
-          }}
-        />
-      )}
+      {displaySymptomHistory ||
+        (true && (
+          <Tab.Screen
+            name={Stacks.SymptomHistory}
+            component={SymptomHistoryStack}
+            options={{
+              tabBarLabel: applyTabBarLabel(t("navigation.symptom_history")),
+              tabBarIcon: HeartbeatIcon,
+            }}
+          />
+        ))}
       <Tab.Screen
         name={Stacks.Settings}
         component={SettingsStack}

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -251,6 +251,19 @@ export const Stacks: { [key in Stack]: Stack } = {
   SymptomHistory: "SymptomHistory",
 }
 
+export type TabRoute =
+  | "Home"
+  | "ExposureHistory"
+  | "SymptomHistory"
+  | "Settings"
+
+export const TabRoutes: { [key in TabRoute]: TabRoute } = {
+  Home: "Home",
+  ExposureHistory: "ExposureHistory",
+  SymptomHistory: "SymptomHistory",
+  Settings: "Settings",
+}
+
 export const useStatusBarEffect = (
   statusBarStyle: StatusBarStyle,
   backgroundColor: string,

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -36,7 +36,7 @@ type LineHeight =
   | "x70"
   | "x80"
 export const lineHeight: Record<LineHeight, number> = {
-  x5: 12,
+  x5: 14,
   x10: 18,
   x20: 20,
   x30: 20,

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -15,7 +15,7 @@ type Size =
   | "x80"
 export const size: Record<Size, number> = {
   x10: 10,
-  x15: 12,
+  x15: 11,
   x20: 13,
   x30: 14,
   x40: 16,
@@ -25,8 +25,18 @@ export const size: Record<Size, number> = {
   x80: 30,
 }
 
-type LineHeight = "x10" | "x20" | "x30" | "x40" | "x50" | "x60" | "x70" | "x80"
+type LineHeight =
+  | "x5"
+  | "x10"
+  | "x20"
+  | "x30"
+  | "x40"
+  | "x50"
+  | "x60"
+  | "x70"
+  | "x80"
 export const lineHeight: Record<LineHeight, number> = {
+  x5: 12,
   x10: 18,
   x20: 20,
   x30: 20,

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -3,9 +3,19 @@ import { TextStyle } from "react-native"
 import * as Colors from "./colors"
 import * as Spacing from "./spacing"
 
-type Size = "x10" | "x20" | "x30" | "x40" | "x50" | "x60" | "x70" | "x80"
+type Size =
+  | "x10"
+  | "x15"
+  | "x20"
+  | "x30"
+  | "x40"
+  | "x50"
+  | "x60"
+  | "x70"
+  | "x80"
 export const size: Record<Size, number> = {
   x10: 10,
+  x15: 12,
   x20: 13,
   x30: 14,
   x40: 16,


### PR DESCRIPTION
Why: as a matter of best practice, we would like for the tab bar icons to have labels.

This commit:
- Introduces a custom tab bar component
- Adds labels to the tab bar icons

![Screen Shot 2020-11-13 at 12 32 13 PM](https://user-images.githubusercontent.com/39350030/99103787-1e6e1480-25ae-11eb-9a6d-9e6f04abd70a.png)
![Screen Shot 2020-11-13 at 12 32 23 PM](https://user-images.githubusercontent.com/39350030/99103790-1f06ab00-25ae-11eb-996d-2083aadc9517.png)
![Screen Shot 2020-11-13 at 12 32 55 PM](https://user-images.githubusercontent.com/39350030/99103791-1f9f4180-25ae-11eb-8562-a36a36524273.png)
![Screen Shot 2020-11-13 at 12 33 04 PM](https://user-images.githubusercontent.com/39350030/99103795-1f9f4180-25ae-11eb-9207-191b9d3b4d9b.png)