### PR TITLE
Fix styling of guidance graphics

### DIFF
--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -8,7 +8,14 @@ import { ModalStackScreens } from "../../navigation"
 import { Text } from "../../components"
 import { useConnectionStatus } from "../../Device/useConnectionStatus"
 
-import { Buttons, Colors, Iconography, Spacing, Typography } from "../../styles"
+import {
+  Buttons,
+  Colors,
+  Iconography,
+  Outlines,
+  Spacing,
+  Typography,
+} from "../../styles"
 import { Icons } from "../../assets"
 import { useConfigurationContext } from "../../ConfigurationContext"
 
@@ -49,7 +56,7 @@ const ExposureActions: FunctionComponent = () => {
         {displayCallbackForm && (
           <RequestCallBackActions healthAuthorityName={healthAuthorityName} />
         )}
-        <Text style={style.bottomHeaderText}>
+        <Text style={style.bottomSubheaderText}>
           {t("exposure_history.exposure_detail.general_guidance", {
             healthAuthorityName,
           })}
@@ -184,17 +191,17 @@ const style = StyleSheet.create({
   recommendations: {
     flexDirection: "row",
     flexWrap: "wrap",
-    display: "flex",
     justifyContent: "space-between",
     marginBottom: Spacing.xxxLarge,
   },
   recommendation: {
     display: "flex",
-    alignItems: "center",
+    marginBottom: Spacing.xxSmall,
+    maxWidth: 120,
   },
   recommendationBubbleCircle: {
     ...Iconography.smallIcon,
-    borderRadius: 50,
+    borderRadius: Outlines.borderRadiusMax,
     backgroundColor: Colors.secondary.shade10,
     padding: Spacing.xLarge,
     marginBottom: Spacing.xSmall,

--- a/src/ExposureHistory/detail/ExposureActions.tsx
+++ b/src/ExposureHistory/detail/ExposureActions.tsx
@@ -191,13 +191,13 @@ const style = StyleSheet.create({
   recommendations: {
     flexDirection: "row",
     flexWrap: "wrap",
-    justifyContent: "space-between",
     marginBottom: Spacing.xxxLarge,
   },
   recommendation: {
     display: "flex",
     marginBottom: Spacing.xxSmall,
-    maxWidth: 120,
+    marginRight: Spacing.small,
+    maxWidth: 100,
   },
   recommendationBubbleCircle: {
     ...Iconography.smallIcon,


### PR DESCRIPTION
Why: the graphics under the general guidance section of the ExposureDetail screen were not aligned properly.

## Before
<img width="635" alt="Screen Shot 2020-11-16 at 5 24 51 PM" src="https://user-images.githubusercontent.com/39350030/99315449-ad8a5f00-2830-11eb-8f8e-73c56486f863.png">

## After
<img width="343" alt="Screen Shot 2020-11-16 at 5 23 01 PM" src="https://user-images.githubusercontent.com/39350030/99315483-b67b3080-2830-11eb-8321-7358d5a20fda.png">
<img width="372" alt="Screen Shot 2020-11-16 at 5 23 11 PM" src="https://user-images.githubusercontent.com/39350030/99315484-b713c700-2830-11eb-9016-db9b583f2d6a.png">