### PR TITLE
Handle edge cases in EN permissions activation

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureNotificationsModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureNotificationsModule.java
@@ -51,7 +51,7 @@ public class ExposureNotificationsModule extends ReactContextBaseJavaModule {
     FutureCallback<Void> callback = new FutureCallback<Void>() {
       @Override
       public void onSuccess(Void result) {
-        promise.resolve(CallbackMessages.GENERIC_SUCCESS);
+        promise.resolve((Util.getEnStatusWritableArray(true)));
       }
 
       @Override

--- a/ios/BT/DebugAction.swift
+++ b/ios/BT/DebugAction.swift
@@ -4,6 +4,5 @@
   simulateExposure,
   fetchExposures,
   resetExposures,
-  toggleENAuthorization,
   showLastProcessedFilePath
 }

--- a/ios/BT/ExposureManager+Debug.swift
+++ b/ios/BT/ExposureManager+Debug.swift
@@ -44,11 +44,6 @@ extension ExposureManager: ExposureManagerDebuggable {
     case .resetExposures:
       btSecureStorage.exposures = List<Exposure>()
       resolve("Exposures: \(btSecureStorage.exposures.count)")
-    case .toggleENAuthorization:
-      let enabled = manager.exposureNotificationEnabled ? false : true
-      requestExposureNotificationAuthorization(enabled: enabled) { result in
-        resolve("EN Enabled: \(self.manager.exposureNotificationEnabled)")
-      }
     case .showLastProcessedFilePath:
       let path = btSecureStorage.userState.urlOfMostRecentlyDetectedKeyFile
       resolve(path)

--- a/ios/BT/bridge/DebugMenuModule.m
+++ b/ios/BT/bridge/DebugMenuModule.m
@@ -44,13 +44,6 @@ RCT_REMAP_METHOD(fetchExposures,
   [[ExposureManager shared] handleDebugAction:DebugActionSimulateExposure resolve:resolve reject:reject];
 }
 
-RCT_REMAP_METHOD(toggleExposureNotifications,
-                 toggleExposureNotificationsWithResolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject)
-{
-  [[ExposureManager shared] handleDebugAction:DebugActionToggleENAuthorization resolve:resolve reject:reject];
-}
-
 RCT_REMAP_METHOD(resetExposures,
                  resetExposuresWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/BT/bridge/ENPermissionsModule.m
+++ b/ios/BT/bridge/ENPermissionsModule.m
@@ -13,14 +13,7 @@ RCT_EXPORT_MODULE();
 RCT_REMAP_METHOD(requestExposureNotificationAuthorization,
                  requestExposureNotificationAuthorizationWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-  [[ExposureManager shared] requestExposureNotificationAuthorizationWithEnabled:YES
-                                                                       callback:^(ExposureManagerError * _Nullable error) {
-    if (error) {
-      reject(error.errorCode, error.localizedMessage, error.underlyingError);
-    } else {
-      resolve(@[GENERIC_SUCCESS]);
-    }
-  }];
+  [[ExposureManager shared] requestExposureNotificationAuthorizationWithResolve:resolve reject:reject];
 }
 
 RCT_REMAP_METHOD(getCurrentENPermissionsStatus,

--- a/ios/COVIDSafePathsTests/DebugMenuUnitTests.swift
+++ b/ios/COVIDSafePathsTests/DebugMenuUnitTests.swift
@@ -80,20 +80,6 @@ class DebugMenuUnitTests: XCTestCase {
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 0)
   }
 
-  func testDebugToggleENAuthorization() {
-    let debugAction = DebugAction.toggleENAuthorization
-    let exposureManager = defaultExposureManager(enAPIVersion: .v1)
-    let successExpetactionResolve = self.expectation(description: "resolve is called")
-    let successExpectationReject = self.expectation(description: "reject is not called")
-    successExpectationReject.isInverted = true
-    exposureManager.handleDebugAction(debugAction, resolve: { (success) in
-      successExpetactionResolve.fulfill()
-    }) { (_, _, _) in
-      successExpectationReject.fulfill()
-    }
-    wait(for: [successExpetactionResolve, successExpectationReject], timeout: 0)
-  }
-
   func testDebugShowLastProcessedFilePath() {
     let debugAction = DebugAction.showLastProcessedFilePath
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)

--- a/ios/COVIDSafePathsTests/XCTestCase+Extensions.swift
+++ b/ios/COVIDSafePathsTests/XCTestCase+Extensions.swift
@@ -103,10 +103,6 @@ extension XCTestCase {
       return Progress()
     }
     
-    enManagerMock.setExposureNotificationEnabledHandler = { enabled, completionHandler in
-      completionHandler(nil)
-    }
-    
     enManagerMock.getExposureInfoHandler = { summary, useExplanation, completionHandler in
       guard !forceGetExposureInfoError else {
         completionHandler(nil, GenericError.unknown)
@@ -137,10 +133,6 @@ extension XCTestCase {
     
     mockDaySummariesENExposureDetectionSummary.daySummariesHandler = {
       return [enExposureDaySummaryMock]
-    }
-    
-    enManagerMock.setExposureNotificationEnabledHandler = { enabled, completionHandler in
-      completionHandler(nil)
     }
     
     enManagerMock.enDetectExposuresHandler = { configuration, diagnosisKeys, completionHandler in

--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -1,15 +1,22 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent, useCallback } from "react"
 import {
   ScrollView,
   SafeAreaView,
   View,
   StyleSheet,
   TouchableOpacity,
+  Platform,
+  Alert,
 } from "react-native"
 import { useTranslation } from "react-i18next"
-import { useNavigation } from "@react-navigation/native"
+import { useFocusEffect, useNavigation } from "@react-navigation/native"
 
-import { usePermissionsContext } from "../Device/PermissionsContext"
+import {
+  ENPermissionStatus,
+  usePermissionsContext,
+} from "../Device/PermissionsContext"
+import { openAppSettings } from "../Device"
+import { useApplicationName } from "../Device/useApplicationInfo"
 import { useProductAnalyticsContext } from "../ProductAnalytics/Context"
 import { nextScreenFromExposureNotifications } from "./activationStackController"
 import { Text } from "../components"
@@ -24,23 +31,68 @@ const ActivateExposureNotifications: FunctionComponent = () => {
     isBluetoothOn,
     exposureNotifications,
   } = usePermissionsContext()
-
+  const { applicationName } = useApplicationName()
   const { trackEvent } = useProductAnalyticsContext()
+
   const isLocationRequiredAndOff = locationPermissions === "RequiredOff"
 
-  const navigateToNextScreen = () => {
+  const navigateToNextScreen = useCallback(() => {
     navigation.navigate(
       nextScreenFromExposureNotifications({
         isLocationRequiredAndOff,
         isBluetoothOn,
       }),
     )
+  }, [isBluetoothOn, isLocationRequiredAndOff, navigation])
+
+  useFocusEffect(
+    useCallback(() => {
+      if (exposureNotifications.status === ENPermissionStatus.ENABLED) {
+        navigateToNextScreen()
+      }
+    }, [exposureNotifications.status, navigateToNextScreen]),
+  )
+
+  const showNotAuthorizedAlert = () => {
+    const errorMessage = Platform.select({
+      ios: t("home.proximity_tracing.unauthorized_error_message_ios", {
+        applicationName,
+      }),
+      android: t("home.proximity_tracing.unauthorized_error_message_android", {
+        applicationName,
+      }),
+    })
+
+    Alert.alert(
+      t("home.proximity_tracing.unauthorized_error_title"),
+      errorMessage,
+      [
+        {
+          text: t("common.back"),
+          style: "cancel",
+        },
+        {
+          text: t("common.settings"),
+          onPress: () => openAppSettings(),
+        },
+      ],
+    )
   }
 
-  const handleOnPressActivateExposureNotifications = async () => {
-    await exposureNotifications.request()
-    trackEvent("product_analytics", "onboarding_en_permissions_accept")
-    navigateToNextScreen()
+  const handleOnPressEnable = async () => {
+    try {
+      const response = await exposureNotifications.request()
+      if (response.kind === "success") {
+        if (response.status !== ENPermissionStatus.ENABLED) {
+          showNotAuthorizedAlert()
+        }
+      } else {
+        showNotAuthorizedAlert()
+      }
+      trackEvent("product_analytics", "onboarding_en_permissions_accept")
+    } catch (e) {
+      showNotAuthorizedAlert()
+    }
   }
 
   const handleOnPressDontEnable = () => {
@@ -75,10 +127,7 @@ const ActivateExposureNotifications: FunctionComponent = () => {
             {t("onboarding.proximity_tracing_subheader3")}
           </Text>
         </View>
-        <TouchableOpacity
-          onPress={handleOnPressActivateExposureNotifications}
-          style={style.button}
-        >
+        <TouchableOpacity onPress={handleOnPressEnable} style={style.button}>
           <Text style={style.buttonText}>
             {t("onboarding.proximity_tracing_button")}
           </Text>

--- a/src/Activation/NotificationPermissions.spec.tsx
+++ b/src/Activation/NotificationPermissions.spec.tsx
@@ -95,7 +95,11 @@ const createPermissionProviderValue = (
     exposureNotifications: {
       status: ENPermissionStatus.ENABLED,
       check: () => {},
-      request: () => Promise.resolve(),
+      request: () =>
+        Promise.resolve({
+          kind: "failure" as const,
+          error: "Unknown" as const,
+        }),
     },
   }
 }

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.spec.tsx
@@ -72,7 +72,11 @@ const createPermissionProviderValue = (
     exposureNotifications: {
       status: enPermissionStatus,
       check: () => {},
-      request: () => Promise.resolve(),
+      request: () =>
+        Promise.resolve({
+          kind: "failure" as const,
+          error: "Unknown" as const,
+        }),
     },
   }
 }

--- a/src/Home/ExposureDetectionStatus/Screen.spec.tsx
+++ b/src/Home/ExposureDetectionStatus/Screen.spec.tsx
@@ -17,7 +17,7 @@ import {
 } from "../../Device/PermissionsContext"
 import { LocationPermissions } from "../../Device/useLocationPermissions"
 import { factories } from "../../factories"
-
+import { RequestAuthorizationResponse } from "../../gaen/nativeModule"
 import ExposureDetectionStatusScreen from "./Screen"
 
 jest.mock("@react-navigation/native")
@@ -177,7 +177,7 @@ describe("ExposureDetectionStatusScreen", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
 
       const expectedMessage =
-        "To enable Exposure Notifications, go to the Exposure Notification section in Settings and Share Exposure Information and set the Active Region to applicationName"
+        "Open Settings, then navigate to the Exposure Notifications settings for this app. Ensure Share Exposure Information is turned on, then press 'Set As Active Region'."
 
       fireEvent.press(getByTestId("exposure-notifications-status-container"))
       expect(requestSpy).toHaveBeenCalled()
@@ -328,7 +328,8 @@ const createPermissionProviderValue = (
   isBluetoothOn = true,
   locationPermissions: LocationPermissions = "RequiredOn",
   enPermissionStatus: ENPermissionStatus,
-  requestPermission: () => Promise<void> = () => Promise.resolve(),
+  requestPermission: () => Promise<RequestAuthorizationResponse> = () =>
+    Promise.resolve({ kind: "failure" as const, error: "Unknown" as const }),
 ) => {
   return {
     isBluetoothOn,

--- a/src/Home/ExposureDetectionStatus/Screen.tsx
+++ b/src/Home/ExposureDetectionStatus/Screen.tsx
@@ -104,14 +104,16 @@ const ExposureDetectionStatus: FunctionComponent = () => {
 
     const handleOnPressFix = async () => {
       try {
-        await exposureNotifications.request()
-
-        if (status !== ENPermissionStatus.ENABLED) {
-          showNotAuthorizedAlert()
+        const response = await exposureNotifications.request()
+        if (response.kind === "success") {
+          if (response.status !== ENPermissionStatus.ENABLED) {
+            showNotAuthorizedAlert()
+          }
         } else {
-          trackEvent("product_analytics", "exposure_notifications_enabled")
+          showNotAuthorizedAlert()
         }
-      } catch {
+        trackEvent("product_analytics", "exposure_notifications_enabled")
+      } catch (e) {
         showNotAuthorizedAlert()
       }
     }

--- a/src/Home/index.spec.tsx
+++ b/src/Home/index.spec.tsx
@@ -14,6 +14,7 @@ import {
   PermissionStatus,
 } from "../Device/PermissionsContext"
 import { LocationPermissions } from "../Device/useLocationPermissions"
+import { RequestAuthorizationResponse } from "src/gaen/nativeModule"
 
 jest.mock("@react-navigation/native")
 
@@ -195,7 +196,8 @@ const createPermissionProviderValue = (
   isBluetoothOn: boolean,
   locationPermissions: LocationPermissions,
 ) => {
-  const requestPermission: () => Promise<void> = () => Promise.resolve()
+  const requestPermission: () => Promise<RequestAuthorizationResponse> = () =>
+    Promise.resolve({ kind: "failure" as const, error: "Unknown" as const })
   return {
     isBluetoothOn,
     locationPermissions,

--- a/src/Settings/ENDebugMenu.tsx
+++ b/src/Settings/ENDebugMenu.tsx
@@ -154,12 +154,6 @@ const ENDebugMenu: FunctionComponent<ENDebugMenuProps> = ({ navigation }) => {
               }}
             />
             <DebugMenuListItem
-              label="Toggle Exposure Notifications"
-              onPress={handleOnPressSimulationButton(
-                NativeModule.toggleExposureNotifications,
-              )}
-            />
-            <DebugMenuListItem
               label="Reset Exposures"
               itemStyle={style.lastListItem}
               onPress={handleOnPressSimulationButton(

--- a/src/factories/gaenStrategy.tsx
+++ b/src/factories/gaenStrategy.tsx
@@ -20,6 +20,10 @@ export default Factory.define<GaenStrategy>(() => ({
       return { remove: () => {} }
     },
     check: () => {},
-    request: () => Promise.resolve(),
+    request: () =>
+      Promise.resolve({
+        kind: "failure" as const,
+        error: "Unknown" as const,
+      }),
   },
 }))

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -197,8 +197,8 @@
     "proximity_tracing_info_subheader_1": "How does Exposure Notifications work?",
     "proximity_tracing_info_subheader_2": "Is my data secure?",
     "proximity_tracing": {
-      "unauthorized_error_message_android": "To enable Exposure Notifications, go to the COVID-19 Exposure Notifications of your Settings App and enable 'Use Exposure Notifications'",
-      "unauthorized_error_message_ios": "To enable Exposure Notifications, go to the Exposure Notification section in Settings and Share Exposure Information and set the Active Region to {{applicationName}}",
+      "unauthorized_error_message_android": "To enable Exposure Notifications, go to the COVID-19 Exposure Notifications screen of your Settings app and enable 'Use Exposure Notifications'",
+      "unauthorized_error_message_ios": "Open Settings, then navigate to the Exposure Notifications settings for this app. Ensure Share Exposure Information is turned on, then press 'Set As Active Region'.",
       "unauthorized_error_title": "Enable Exposure Notifications"
     },
     "report_result": "Report Result",


### PR DESCRIPTION
Why: currently, there are various cases in which we do not present the correct information to the user on how to enable Exposure Notifications. These cases arise on the ActivateExposureNotifications and ExposureDetectionStatus screens.

This commit:
- Updates the exposureNotifications.request function in the PermissionsContext to not only request authorization from the GAEN API, but also return the authorization status determined from the request to the GAEN API
- Adds a side effect to the ActivateExposureNotifications screen to navigate to the next screen in the Activation flow if the exposure notification status is enabled
- Adds an Alert to the ActiveExposureNotifications screen that tells the user how to enable exposure notifications if they request authorization from the GAEN API, but need to change something in the app settings in order for exposure notifications to be enabled
- Updates the copy for the Alert that explains to the user how to enable exposure notifications in the app settings

Co-Authored-By: John Schoeman <johnschoeman1617@gmail.com>
Co-Authored-By: Matt Buckley <matt@nicethings.io>

![gif1](https://user-images.githubusercontent.com/39350030/99423117-3c998480-28ce-11eb-808d-b9958dbe4f49.gif)
![gif2](https://user-images.githubusercontent.com/39350030/99423121-3dcab180-28ce-11eb-9a2e-557e24406fd7.gif)