### PR TITLE
Update delete my data screen

### DIFF
--- a/src/Settings/DeleteConfirmation.spec.tsx
+++ b/src/Settings/DeleteConfirmation.spec.tsx
@@ -2,10 +2,8 @@ import React from "react"
 import { Alert } from "react-native"
 import { fireEvent, render } from "@testing-library/react-native"
 
-import { SymptomHistoryContext } from "../SymptomHistory/SymptomHistoryContext"
 import { OnboardingProvider } from "../OnboardingContext"
 import DeleteConfirmation from "./DeleteConfirmation"
-import { factories } from "../factories"
 
 jest.mock("@react-navigation/native")
 
@@ -14,14 +12,8 @@ describe("DeleteConfirmation", () => {
     const alertSpy = jest.spyOn(Alert, "alert")
 
     const { getByLabelText } = render(
-      <OnboardingProvider userHasCompletedOnboarding={false}>
-        <SymptomHistoryContext.Provider
-          value={factories.symptomHistoryContext.build({
-            deleteAllEntries: jest.fn(),
-          })}
-        >
-          <DeleteConfirmation />
-        </SymptomHistoryContext.Provider>
+      <OnboardingProvider userHasCompletedOnboarding>
+        <DeleteConfirmation />
       </OnboardingProvider>,
     )
 

--- a/src/Settings/DeleteConfirmation.spec.tsx
+++ b/src/Settings/DeleteConfirmation.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { fireEvent, render, waitFor } from "@testing-library/react-native"
-import { showMessage } from "react-native-flash-message"
+import { Alert } from "react-native"
+import { fireEvent, render } from "@testing-library/react-native"
 
 import { SymptomHistoryContext } from "../SymptomHistory/SymptomHistoryContext"
 import { OnboardingProvider } from "../OnboardingContext"
@@ -11,15 +11,14 @@ jest.mock("react-native-flash-message")
 jest.mock("@react-navigation/native")
 
 describe("DeleteConfirmation", () => {
-  it("allows users to delete their data", async () => {
-    const deleteAllEntriesSpy = jest.fn()
-    deleteAllEntriesSpy.mockResolvedValueOnce({ kind: "success" })
+  it("allows a user to delete their data", () => {
+    const alertSpy = jest.spyOn(Alert, "alert")
 
     const { getByLabelText } = render(
       <OnboardingProvider userHasCompletedOnboarding={false}>
         <SymptomHistoryContext.Provider
           value={factories.symptomHistoryContext.build({
-            deleteAllEntries: deleteAllEntriesSpy,
+            deleteAllEntries: jest.fn(),
           })}
         >
           <DeleteConfirmation />
@@ -28,66 +27,6 @@ describe("DeleteConfirmation", () => {
     )
 
     fireEvent.press(getByLabelText("Delete my data"))
-    await waitFor(() => {
-      expect(deleteAllEntriesSpy).toHaveBeenCalled()
-    })
-  })
-
-  describe("when data deletion is successful", () => {
-    it("presents a success message", async () => {
-      const showMessageSpy = showMessage as jest.Mock
-      const deleteAllEntriesSpy = jest.fn()
-      deleteAllEntriesSpy.mockResolvedValueOnce({ kind: "success" })
-
-      const { getByLabelText } = render(
-        <OnboardingProvider userHasCompletedOnboarding={false}>
-          <SymptomHistoryContext.Provider
-            value={factories.symptomHistoryContext.build({
-              deleteAllEntries: deleteAllEntriesSpy,
-            })}
-          >
-            <DeleteConfirmation />
-          </SymptomHistoryContext.Provider>
-        </OnboardingProvider>,
-      )
-
-      fireEvent.press(getByLabelText("Delete my data"))
-      await waitFor(() => {
-        expect(showMessageSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: "Data deleted",
-          }),
-        )
-      })
-    })
-  })
-
-  describe("when data deletion fails", () => {
-    it("presents an error message", async () => {
-      const showMessageSpy = showMessage as jest.Mock
-      const deleteAllEntriesSpy = jest.fn()
-      deleteAllEntriesSpy.mockResolvedValueOnce({ kind: "failure" })
-
-      const { getByLabelText } = render(
-        <OnboardingProvider userHasCompletedOnboarding={false}>
-          <SymptomHistoryContext.Provider
-            value={factories.symptomHistoryContext.build({
-              deleteAllEntries: deleteAllEntriesSpy,
-            })}
-          >
-            <DeleteConfirmation />
-          </SymptomHistoryContext.Provider>
-        </OnboardingProvider>,
-      )
-
-      fireEvent.press(getByLabelText("Delete my data"))
-      await waitFor(() => {
-        expect(showMessageSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: "Sorry, we could not delete your data",
-          }),
-        )
-      })
-    })
+    expect(alertSpy).toHaveBeenCalled()
   })
 })

--- a/src/Settings/DeleteConfirmation.spec.tsx
+++ b/src/Settings/DeleteConfirmation.spec.tsx
@@ -7,7 +7,6 @@ import { OnboardingProvider } from "../OnboardingContext"
 import DeleteConfirmation from "./DeleteConfirmation"
 import { factories } from "../factories"
 
-jest.mock("react-native-flash-message")
 jest.mock("@react-navigation/native")
 
 describe("DeleteConfirmation", () => {

--- a/src/Settings/DeleteConfirmation.spec.tsx
+++ b/src/Settings/DeleteConfirmation.spec.tsx
@@ -11,7 +11,7 @@ jest.mock("react-native-flash-message")
 jest.mock("@react-navigation/native")
 
 describe("DeleteConfirmation", () => {
-  it("allows a user to delete their data", () => {
+  it("shows a confirmation alert if the user presses delete my data", () => {
     const alertSpy = jest.spyOn(Alert, "alert")
 
     const { getByLabelText } = render(

--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -64,10 +64,6 @@ const DeleteConfirmation: FunctionComponent = () => {
     )
   }
 
-  const handleOnPressDeleteAllData = () => {
-    showAlert()
-  }
-
   const handleOnPressConfirmDeleteData = async () => {
     const result = await deleteAllData()
     if (result.kind === "success") {
@@ -81,6 +77,10 @@ const DeleteConfirmation: FunctionComponent = () => {
         ...errorFlashMessageOptions,
       })
     }
+  }
+
+  const handleOnPressDeleteAllData = () => {
+    showAlert()
   }
 
   return (

--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   View,
   ScrollView,
+  Alert,
 } from "react-native"
 import { useTranslation } from "react-i18next"
 import { showMessage } from "react-native-flash-message"
@@ -15,26 +16,61 @@ import { useSymptomHistoryContext } from "../SymptomHistory/SymptomHistoryContex
 import { Text } from "../components"
 import { useStatusBarEffect } from "../navigation"
 import * as Storage from "../utils/storage"
+import { useConfigurationContext } from "../ConfigurationContext"
+import { OperationResponse } from "../OperationResponse"
+import { useApplicationName } from "../Device/useApplicationInfo"
 
 import { Spacing, Buttons, Typography, Colors, Affordances } from "../styles"
 
 const DeleteConfirmation: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
+  const { t } = useTranslation()
   const { resetOnboarding } = useOnboardingContext()
   const { resetUserConsent } = useProductAnalyticsContext()
   const { deleteAllEntries } = useSymptomHistoryContext()
+  const { applicationName } = useApplicationName()
+  const {
+    displaySymptomHistory,
+    enableProductAnalytics,
+  } = useConfigurationContext()
   const {
     successFlashMessageOptions,
     errorFlashMessageOptions,
   } = Affordances.useFlashMessageOptions()
 
-  const { t } = useTranslation()
-  const handleOnPressDeleteAllData = async () => {
-    const deleteLogEntriesResult = await deleteAllEntries()
-    if (deleteLogEntriesResult.kind === "success") {
-      resetOnboarding()
-      resetUserConsent()
-      Storage.removeAll()
+  const deleteAllData = async (): Promise<OperationResponse> => {
+    resetOnboarding()
+    resetUserConsent()
+    Storage.removeAll()
+    const deleteAllEntriesResult = await deleteAllEntries()
+    return deleteAllEntriesResult
+  }
+
+  const showAlert = () => {
+    Alert.alert(
+      t("settings.delete_data_are_you_sure"),
+      t("settings.delete_data_this_action", { applicationName }),
+      [
+        {
+          text: t("common.cancel"),
+          style: "cancel",
+        },
+        {
+          text: t("common.confirm"),
+          onPress: () => handleOnPressConfirmDeleteData(),
+          style: "destructive",
+        },
+      ],
+    )
+  }
+
+  const handleOnPressDeleteAllData = () => {
+    showAlert()
+  }
+
+  const handleOnPressConfirmDeleteData = async () => {
+    const result = await deleteAllData()
+    if (result.kind === "success") {
       showMessage({
         message: t("settings.data_deleted"),
         ...successFlashMessageOptions,
@@ -46,18 +82,37 @@ const DeleteConfirmation: FunctionComponent = () => {
       })
     }
   }
+
   return (
     <>
       <StatusBar backgroundColor={Colors.secondary.shade10} />
       <View style={style.container}>
         <ScrollView
-          style={style.scrollContentContainer}
+          contentContainerStyle={style.contentContainer}
           alwaysBounceVertical={false}
         >
           <Text style={style.headerText}>{t("settings.delete_my_data")}</Text>
           <Text style={style.bodyText}>
-            {t("settings.delete_data_disclosure1")}
+            {t("settings.delete_data_disclosure1", { applicationName })}
           </Text>
+          <View style={style.bulletsContainer}>
+            <Text style={style.bulletText}>
+              • {t("settings.delete_data_language_token")}
+            </Text>
+            <Text style={style.bulletText}>
+              • {t("settings.delete_data_onboarding_token")}
+            </Text>
+            {enableProductAnalytics && (
+              <Text style={style.bulletText}>
+                • {t("settings.delete_data_product_analytics")}
+              </Text>
+            )}
+            {displaySymptomHistory && (
+              <Text style={style.bulletText}>
+                • {t("settings.delete_data_symptom_history")}
+              </Text>
+            )}
+          </View>
           <Text style={style.subheaderText}>
             {`${t("settings.delete_data_note")}:`}
           </Text>
@@ -83,9 +138,10 @@ const style = StyleSheet.create({
     height: "100%",
     backgroundColor: Colors.background.primaryLight,
   },
-  scrollContentContainer: {
+  contentContainer: {
     paddingTop: Spacing.small,
-    paddingHorizontal: Spacing.large,
+    paddingBottom: Spacing.medium,
+    paddingHorizontal: Spacing.medium,
   },
   headerText: {
     ...Typography.header.x50,
@@ -94,7 +150,14 @@ const style = StyleSheet.create({
   },
   bodyText: {
     ...Typography.body.x30,
-    marginBottom: Spacing.xxxLarge,
+    marginBottom: Spacing.small,
+  },
+  bulletsContainer: {
+    marginBottom: Spacing.small,
+  },
+  bulletText: {
+    ...Typography.body.x30,
+    marginBottom: Spacing.xSmall,
   },
   subheaderText: {
     ...Typography.header.x30,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -410,9 +410,15 @@
   },
   "settings": {
     "data_deleted": "Data deleted",
-    "delete_data_disclosure1": "When you tap the \"Delete My Data\" button below, the app will delete the Symptom History data that is stored on your phone.",
+    "delete_data_are_you_sure": "Are you sure?",
+    "delete_data_disclosure1": "When you press \"Delete My Data\", all data stored by {{applicationName}} will be deleted:",
     "delete_data_disclosure2": "This does not delete the data created or collected by your phone for Exposure Notifications.\n\nYou can delete this additional data in your device Settings.",
+    "delete_data_language_token": "A token stored on your device that saves your language preference",
     "delete_data_note": "Note",
+    "delete_data_onboarding_token": "A token stored on your device that saves whether you have completed the app onboarding",
+    "delete_data_product_analytics": "A token stored on your device that saves whether you have consented to sharing product analytics data",
+    "delete_data_symptom_history": "Any symptom logs stored on your device",
+    "delete_data_this_action": "This action will delete all data stored by {{applicationName}}.",
     "delete_my_data": "Delete my data",
     "errors": {
       "deleting_data": "Sorry, we could not delete your data"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -412,7 +412,7 @@
     "data_deleted": "Data deleted",
     "delete_data_are_you_sure": "Are you sure?",
     "delete_data_disclosure1": "When you press \"Delete My Data\", all data stored by {{applicationName}} will be deleted:",
-    "delete_data_disclosure2": "This does not delete the data created or collected by your phone for Exposure Notifications.\n\nYou can delete this additional data in your device Settings.",
+    "delete_data_disclosure2": "This does not delete the data created or collected by your device for Exposure Notifications.\n\nYou can delete this additional data in your device Settings.",
     "delete_data_language_token": "A token stored on your device that saves your language preference",
     "delete_data_note": "Note",
     "delete_data_onboarding_token": "A token stored on your device that saves whether you have completed the app onboarding",


### PR DESCRIPTION
Why: currently the delete my data screen does not accurately describe which data are deleted when the user presses the delete my data button.

This commit: 
- Adds bullet points to describe which data are deleted
- Updates some of the copy that explains what data is deleted
- Conditionally tells the user that the symptom logs and user consent data are deleted only if those features are active in their build
- Shows a confirmation alert if the user presses delete my data to confirm they want to delete their data
- Updates the spec for the delete my data screen to only test if the confirmation alert appears when the user presses the delete my data button

Co-Authored-By: John Schoeman <johnschoeman1617@gmail.com>

![gifdelete](https://user-images.githubusercontent.com/39350030/99452108-2224d280-28f1-11eb-92aa-82c1587765ba.gif)