### PR TITLE
Fix styling issue with tab bar

### DIFF
--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -137,7 +137,7 @@ const TabBar: FunctionComponent<TabBarProps> = ({
             onPress={handleOnPress}
             style={{
               ...style.tabButton,
-              width: Layout.screenWidth / tabs.length,
+              width: (Layout.screenWidth / tabs.length) * 0.9,
             }}
             accessibilityRole="button"
             accessibilityState={focused ? { selected: true } : {}}
@@ -182,8 +182,9 @@ const TabIcon: FunctionComponent<TabIconProps> = ({ focused, icon }) => {
 const style = StyleSheet.create({
   tabBarContainer: {
     flexDirection: "row",
-    justifyContent: "center",
+    justifyContent: "space-between",
     paddingTop: Spacing.xxSmall,
+    paddingHorizontal: Spacing.xSmall,
     backgroundColor: Colors.background.primaryLight,
     borderTopWidth: Outlines.hairline,
     borderColor: Colors.neutral.shade10,


### PR DESCRIPTION
Why: the tab bar icons were appearing too close to one another, which made the labels beneath them difficult to read.

This commit:
-Adds more spacing between the tab bar icons.

<img width="365" alt="Screen Shot 2020-11-19 at 1 29 16 PM" src="https://user-images.githubusercontent.com/39350030/99708009-3d1b5200-2a6b-11eb-9f0e-c3e9dc4be51d.png">