### PR TITLE
Update screen names

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -219,11 +219,11 @@
   },
   "navigation": {
     "exposure": "Exposure",
-    "exposure_history": "Exposure History",
+    "exposure_history": "Exposures",
     "home": "Dashboard",
     "more_info": "More Info",
     "settings": "Settings",
-    "symptom_history": "Symptom History"
+    "symptom_history": "Symptoms"
   },
   "onboarding": {
     "activation_header_title": "App Setup",
@@ -305,7 +305,7 @@
   },
   "screen_titles": {
     "bluetooth": "Bluetooth",
-    "exposure_history": "Exposure History",
+    "exposure_history": "Exposures",
     "exposure_notifications": "Exposure Notifications",
     "exposure_scanning": "Exposure Detection",
     "home": "Dashboard",
@@ -443,7 +443,7 @@
       "you_did_not_feel_well": "You did not feel well, symptoms included: {{symptomList}}",
       "you_felt_well": "You felt well"
     },
-    "symptom_history": "Symptom History",
+    "symptom_history": "Symptoms",
     "to_protect_your_privacy": "To protect your privacy, entries are stored on your device and deleted automatically after {{days}} days."
   },
   "symptom": {


### PR DESCRIPTION
Why: we would like to rename "Exposure History" to "Exposures" and "Symptom History" to "Symptoms" to reduce text length in the tab bar.

This commit:
- Updates "Exposure History" to "Exposures"
- Updates "Symptom History" to "Symptoms"

Co-Authored-By: John Schoeman <johnschoeman1617@gmail.com>

<img width="362" alt="Screen Shot 2020-11-19 at 1 37 52 PM" src="https://user-images.githubusercontent.com/39350030/99709122-c54e2700-2a6c-11eb-9e14-92d91d7b681e.png">