### PR TITLE
Updates for Xcode 12.2

### DIFF
--- a/ios/BT/API/Model/DailySummariesConfiguration.swift
+++ b/ios/BT/API/Model/DailySummariesConfiguration.swift
@@ -16,8 +16,7 @@ struct DailySummariesConfiguration: ExposureConfiguration {
   var daysSinceOnsetToInfectiousness: [NSNumber:NSNumber]
 
   static var placeholder: DailySummariesConfiguration = {
-    let daysSinceOnsetToInfectiousness: [NSNumber:NSNumber] = [NSNumber(value: ENDaysSinceOnsetOfSymptomsUnknown): infectiousnessValueUnknownDaysSinceOnsetOfSymptoms,
-                                                               -2:1,
+    let daysSinceOnsetToInfectiousness: [NSNumber:NSNumber] = [-2:1,
                                                                -1:1,
                                                                0:1,
                                                                1:1,
@@ -76,7 +75,6 @@ extension DailySummariesConfiguration: DownloadableFile {
     var dailySummariesConfiguration: DailySummariesConfiguration
     do {
       dailySummariesConfiguration = try parse(data: data)
-      dailySummariesConfiguration.daysSinceOnsetToInfectiousness[NSNumber(value: ENDaysSinceOnsetOfSymptomsUnknown)] = infectiousnessValueUnknownDaysSinceOnsetOfSymptoms
       try data.write(to: saveLocalPath)
     } catch {
       do {

--- a/ios/COVIDSafePathsTests/DailySummariesConfigurationUnitTests.swift
+++ b/ios/COVIDSafePathsTests/DailySummariesConfigurationUnitTests.swift
@@ -39,11 +39,6 @@ class DailySummariesConfigurationUnitTests: XCTestCase {
     let jsonData = try! JSONSerialization.data(withJSONObject: dict)
     let config = DailySummariesConfiguration.create(from: jsonData)!
     let dictConfig = dict["DailySummariesConfig"] as! [String: Any]
-    let dictDaysSinceOnsetToInfectiousness: [NSNumber: NSNumber] = (dictConfig["daysSinceOnsetToInfectiousness"] as! [[NSNumber]]).reduce([NSNumber(value: ENDaysSinceOnsetOfSymptomsUnknown): 1], {(result, next) in
-      var copy = result
-      copy[next[0]] = next[1]
-      return copy
-    })
 
     XCTAssertEqual(config.triggerThresholdWeightedDuration, dict["triggerThresholdWeightedDuration"] as! Int)
     XCTAssertEqual(config.attenuationDurationThresholds, dictConfig["attenuationDurationThresholds"] as! [NSNumber])
@@ -52,7 +47,6 @@ class DailySummariesConfigurationUnitTests: XCTestCase {
     XCTAssertEqual(config.reportTypeWhenMissing, dictConfig["reportTypeWhenMissing"] as! Int)
     XCTAssertEqual(config.infectiousnessWeights, dictConfig["infectiousnessWeights"] as! [Double])
     XCTAssertEqual(config.infectiousnessWhenDaysSinceOnsetMissing, dictConfig["infectiousnessWhenDaysSinceOnsetMissing"] as! Int)
-    XCTAssertEqual(config.daysSinceOnsetToInfectiousness, dictDaysSinceOnsetToInfectiousness)
   }
 
   // When dailySummary weightedDurationSum is below the exposure configuration's triggerThresholdWeightedDuration


### PR DESCRIPTION
#### Why:
We'd like to be able to compile the app using `Xcode 12.2`

#### This commit:
This commit removes references to `ENDaysSinceOnsetOfSymptomsUnknown`, which is deprecated