### PR TITLE
Add documentation for data stored locally on device

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ The PathCheck Google Apple Exposure Notification (GAEN) solution is a full open 
 
 What’s truly special about PathCheck is our strong commitment to preserving the privacy of individual users. We're building an application that can help contain outbreaks of COVID-19 without forcing users to sacrifice their personal privacy.
 
-See the [Data Dictionary](doc/DATA_DICTIONARY) for a reference of all data that
+See the [Non-Local Data Dictionary](doc/NON_LOCAL_DATA_DICTIONARY.md) for a reference of all data that
 the app may submit to external services during use.
+See the [Local Data Dictionary](doc/LOCAL_DATA_DICTIONARY.md) for a reference of all data that
+the app stores locally during use.
 
 ## Custom Builds
 

--- a/docs/LOCAL_DATA_DICTIONARY.md
+++ b/docs/LOCAL_DATA_DICTIONARY.md
@@ -1,11 +1,10 @@
 ## Local Data Dictionary
 
-This file is an list of all of the data which is stored locally on the
-device.
+This file lists of all of the data which may be stored locally on the device.
 
 #### GAEN Exposure Notification Related Data
 
-`ios/BT/Storage/BTSecureStorage.swift`
+reference file: `ios/BT/Storage/BTSecureStorage.swift`
 
 All builds of the app store the following pieces of Exposure Notification related data:
 
@@ -13,9 +12,11 @@ All builds of the app store the following pieces of Exposure Notification relate
 2. The timestamp of the last exposure check run in the background or manually requested from the app
 3. The remote url path of the last key archive pulled down by the app from the key server
 
-#### Symptom Log Data
+#### Symptom History Logs
 
-All builds of the app store the symptom logs created in the app by the user. Users can delete these logs from their device by tapping the "Delete my data" button on the settings screen.
+All builds of the app which enable the Symptom History feature store the symptom
+logs created in the app by the user. Users can delete these logs from their
+device by tapping the "Delete my data" button on the settings screen.
 
 Reference:
 [Exposure Notification (iOS)](https://developer.apple.com/documentation/exposurenotification)

--- a/docs/LOCAL_DATA_DICTIONARY.md
+++ b/docs/LOCAL_DATA_DICTIONARY.md
@@ -1,0 +1,21 @@
+## Local Data Dictionary
+
+This file is an list of all of the data which is stored locally on the
+device.
+
+#### GAEN Exposure Notification Related Data
+
+`ios/BT/Storage/BTSecureStorage.swift`
+
+All builds of the app store the following pieces of Exposure Notification related data:
+
+1. The timestamp of any exposures detected by the [Exposure Notifications framework](https://developer.apple.com/documentation/exposurenotification/enmanager/3586331-detectexposures).
+2. The timestamp of the last exposure check run in the background or manually requested from the app
+3. The remote url path of the last key archive pulled down by the app from the key server
+
+#### Symptom Log Data
+
+All builds of the app store the symptom logs created in the app by the user. Users can delete these logs from their device by tapping the "Delete my data" button on the settings screen.
+
+Reference:
+[Exposure Notification (iOS)](https://developer.apple.com/documentation/exposurenotification)

--- a/docs/NON_LOCAL_DATA_DICTIONARY.md
+++ b/docs/NON_LOCAL_DATA_DICTIONARY.md
@@ -1,26 +1,25 @@
-## Data Dictionary
+## Non-Local Data Dictionary
 
 This file lists all of the data which could theoretically leave the
 device.
 
-
 ### General Notes
 
 - Many application features are configurable and optionally enabled on a per
-  build basis, so not every listed here is necessarily included in a public
-  release of the app via the App Store or the Play Store.
+  build basis, so not every item listed here is necessarily included in a public
+  release of the app via the App Store or the Play Store. If a build does not
+  require an optional feature, it is not included.
 
 - All network communication is encrypted with standard SSL security protections.
 
 - No network communication includes personally-identifying information such as a
-device id or IP address.
+  device id or IP address.
 
 - No extra data is shared that is not essential to the proper functioning of
-the application.
+  the application.
 
 - All data that leaves the device must be explicitly agreed to be sent by
-the user to be shared.
-
+  the user to be shared.
 
 #### GAEN Exposure Notification Related Data
 
@@ -37,13 +36,11 @@ requests that leave the device with a data payload:
 Users must explicitly agree to share these keys before they can be
 sent.
 
-
 Reference:
 
 [wiki/Exposure_Notification](https://en.wikipedia.org/wiki/Exposure_Notification)
 
 [Verification Flow Diagram](https://developers.google.com/android/exposure-notifications/verification-system#flow-diagram)
-
 
 #### Error Reporting (Optional)
 
@@ -53,7 +50,6 @@ Builds that have error reporting enabled send crash and error information to an
 error reporting service. Currently, we only support
 [Bugsnag](https://docs.bugsnag.com/). Bugsnag generates random Ids, referred to
 as 'Device Ids' by Bugsnag, but are not associated with device UUIDs.
-
 
 #### Contact Tracer Callback Form (Optional)
 


### PR DESCRIPTION
### Why:
We would like to transparently document all data that the app stores locally on the device.
While this project is open source and all of if this is determinable by
reviewing the source code, we would like to make this inspection process
accessible to those that do not have programming experience.

### This commit:
Introduces a "local" data dictionary and moves what was previously the "data dictionary" to a "Non-Local Data Dictionary" file.