### PR TITLE
Update navigation on Active Exposure Notifications and Activate Location

### DIFF
--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -23,12 +23,9 @@ import { Spacing, Typography, Buttons, Colors, Iconography } from "../styles"
 
 const ActivateExposureNotifications: FunctionComponent = () => {
   const { t } = useTranslation()
-  const {
-    exposureNotifications: { status },
-  } = usePermissionsContext()
+  const { exposureNotifications } = usePermissionsContext()
 
-  // const isENActive = status === "Active"
-  const isENActive = true
+  const isENActive = exposureNotifications.status === "Active"
 
   return (
     <SafeAreaView style={style.safeArea}>
@@ -239,12 +236,10 @@ const style = StyleSheet.create({
   alreadyActiveIconContainer: {
     flex: 1,
     justifyContent: "center",
-    alignItems: "center",
   },
   alreadyActiveTextContainer: {
-    flex: 4,
+    flex: 8,
     justifyContent: "center",
-    alignItems: "center",
   },
   alreadyActiveText: {
     ...Typography.body.x30,

--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -8,6 +8,7 @@ import {
   Platform,
   Alert,
 } from "react-native"
+import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
 
 import { usePermissionsContext } from "../Device/PermissionsContext"
@@ -17,7 +18,8 @@ import { useProductAnalyticsContext } from "../ProductAnalytics/Context"
 import { Text } from "../components"
 import { useActivationNavigation } from "./useActivationNavigation"
 
-import { Spacing, Typography, Buttons, Colors } from "../styles"
+import { Icons } from "../assets"
+import { Spacing, Typography, Buttons, Colors, Iconography } from "../styles"
 
 const ActivateExposureNotifications: FunctionComponent = () => {
   const { t } = useTranslation()
@@ -25,7 +27,8 @@ const ActivateExposureNotifications: FunctionComponent = () => {
     exposureNotifications: { status },
   } = usePermissionsContext()
 
-  const isENActive = status === "Active"
+  // const isENActive = status === "Active"
+  const isENActive = true
 
   return (
     <SafeAreaView style={style.safeArea}>
@@ -164,9 +167,21 @@ const ENAlreadyEnabledButtons: FunctionComponent = () => {
 
   return (
     <View style={style.alreadyActiveContainer}>
-      <Text style={style.body}>
-        {t("onboarding.proximity_tracing_already_active")}
-      </Text>
+      <View style={style.alreadyActiveInfoContainer}>
+        <View style={style.alreadyActiveIconContainer}>
+          <SvgXml
+            xml={Icons.CheckInCircle}
+            fill={Colors.accent.success100}
+            width={Iconography.xSmall}
+            height={Iconography.xSmall}
+          />
+        </View>
+        <View style={style.alreadyActiveTextContainer}>
+          <Text style={style.alreadyActiveText}>
+            {t("onboarding.proximity_tracing_already_active")}
+          </Text>
+        </View>
+      </View>
       <TouchableOpacity onPress={handleOnPressContinue} style={style.button}>
         <Text style={style.buttonText}>{t("common.continue")}</Text>
       </TouchableOpacity>
@@ -216,7 +231,23 @@ const style = StyleSheet.create({
   alreadyActiveContainer: {
     borderTopWidth: 1,
     borderTopColor: Colors.neutral.shade50,
-    paddingTop: Spacing.medium,
+  },
+  alreadyActiveInfoContainer: {
+    flexDirection: "row",
+    paddingVertical: Spacing.large,
+  },
+  alreadyActiveIconContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  alreadyActiveTextContainer: {
+    flex: 4,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  alreadyActiveText: {
+    ...Typography.body.x30,
   },
 })
 

--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -9,7 +9,6 @@ import {
   Alert,
 } from "react-native"
 import { useTranslation } from "react-i18next"
-import { useFocusEffect } from "@react-navigation/native"
 
 import { usePermissionsContext } from "../Device/PermissionsContext"
 import { openAppSettings } from "../Device"
@@ -22,16 +21,51 @@ import { Spacing, Typography, Buttons, Colors } from "../styles"
 
 const ActivateExposureNotifications: FunctionComponent = () => {
   const { t } = useTranslation()
-  const { exposureNotifications } = usePermissionsContext()
-  const { applicationName } = useApplicationName()
-  const { trackEvent } = useProductAnalyticsContext()
-  const { goToNextScreenFrom } = useActivationNavigation()
+  const {
+    exposureNotifications: { status },
+  } = usePermissionsContext()
 
-  useFocusEffect(() => {
-    if (exposureNotifications.status === "Active") {
-      goToNextScreenFrom("ActivateExposureNotifications")
-    }
-  })
+  const isENActive = status === "Active"
+
+  return (
+    <SafeAreaView style={style.safeArea}>
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
+      >
+        <View style={style.content}>
+          <Text style={style.header}>
+            {t("onboarding.proximity_tracing_header")}
+          </Text>
+          <Text style={style.subheader}>
+            {t("onboarding.proximity_tracing_subheader1")}
+          </Text>
+          <Text style={style.body}>
+            {t("onboarding.proximity_tracing_body1")}
+          </Text>
+          <Text style={style.subheader}>
+            {t("onboarding.proximity_tracing_subheader2")}
+          </Text>
+          <Text style={style.body}>
+            {t("onboarding.proximity_tracing_body2")}
+          </Text>
+          <Text style={style.subheader}>
+            {t("onboarding.proximity_tracing_subheader3")}
+          </Text>
+        </View>
+        {!isENActive ? <EnableENButtons /> : <ENAlreadyEnabledButtons />}
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+const EnableENButtons: FunctionComponent = () => {
+  const { t } = useTranslation()
+  const { trackEvent } = useProductAnalyticsContext()
+  const { exposureNotifications } = usePermissionsContext()
+  const { goToNextScreenFrom } = useActivationNavigation()
+  const { applicationName } = useApplicationName()
 
   const showNotAuthorizedAlert = () => {
     const errorMessage = Platform.select({
@@ -104,47 +138,42 @@ const ActivateExposureNotifications: FunctionComponent = () => {
   }
 
   return (
-    <SafeAreaView style={style.safeArea}>
-      <ScrollView
-        style={style.container}
-        contentContainerStyle={style.contentContainer}
-        alwaysBounceVertical={false}
+    <View>
+      <TouchableOpacity onPress={handleOnPressEnable} style={style.button}>
+        <Text style={style.buttonText}>
+          {t("onboarding.proximity_tracing_button")}
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={handleOnPressDontEnable}
+        style={style.secondaryButton}
       >
-        <View style={style.content}>
-          <Text style={style.header}>
-            {t("onboarding.proximity_tracing_header")}
-          </Text>
-          <Text style={style.subheader}>
-            {t("onboarding.proximity_tracing_subheader1")}
-          </Text>
-          <Text style={style.body}>
-            {t("onboarding.proximity_tracing_body1")}
-          </Text>
-          <Text style={style.subheader}>
-            {t("onboarding.proximity_tracing_subheader2")}
-          </Text>
-          <Text style={style.body}>
-            {t("onboarding.proximity_tracing_body2")}
-          </Text>
-          <Text style={style.subheader}>
-            {t("onboarding.proximity_tracing_subheader3")}
-          </Text>
-        </View>
-        <TouchableOpacity onPress={handleOnPressEnable} style={style.button}>
-          <Text style={style.buttonText}>
-            {t("onboarding.proximity_tracing_button")}
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={handleOnPressDontEnable}
-          style={style.secondaryButton}
-        >
-          <Text style={style.secondaryButtonText}>{t("common.no_thanks")}</Text>
-        </TouchableOpacity>
-      </ScrollView>
-    </SafeAreaView>
+        <Text style={style.secondaryButtonText}>{t("common.no_thanks")}</Text>
+      </TouchableOpacity>
+    </View>
   )
 }
+
+const ENAlreadyEnabledButtons: FunctionComponent = () => {
+  const { t } = useTranslation()
+  const { goToNextScreenFrom } = useActivationNavigation()
+
+  const handleOnPressContinue = () => {
+    goToNextScreenFrom("ActivateExposureNotifications")
+  }
+
+  return (
+    <View style={style.alreadyActiveContainer}>
+      <Text style={style.body}>
+        {t("onboarding.proximity_tracing_already_active")}
+      </Text>
+      <TouchableOpacity onPress={handleOnPressContinue} style={style.button}>
+        <Text style={style.buttonText}>{t("common.continue")}</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
 const style = StyleSheet.create({
   safeArea: {
     backgroundColor: Colors.background.primaryLight,
@@ -183,6 +212,11 @@ const style = StyleSheet.create({
   },
   secondaryButtonText: {
     ...Typography.button.secondary,
+  },
+  alreadyActiveContainer: {
+    borderTopWidth: 1,
+    borderTopColor: Colors.neutral.shade50,
+    paddingTop: Spacing.medium,
   },
 })
 

--- a/src/Activation/ActivateLocation.tsx
+++ b/src/Activation/ActivateLocation.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect } from "react"
+import React, { FunctionComponent } from "react"
 import {
   Alert,
   ScrollView,
@@ -15,7 +15,14 @@ import { useApplicationName } from "../Device/useApplicationInfo"
 import { usePermissionsContext } from "../Device/PermissionsContext"
 import { openAppSettings } from "../Device"
 
-import { Colors, Spacing, Typography, Buttons, Outlines } from "../styles"
+import {
+  Colors,
+  Spacing,
+  Typography,
+  Buttons,
+  Outlines,
+  Iconography,
+} from "../styles"
 import { Icons } from "../assets"
 import { useActivationNavigation } from "./useActivationNavigation"
 
@@ -23,14 +30,42 @@ const ActivateLocation: FunctionComponent = () => {
   const { t } = useTranslation()
   const { applicationName } = useApplicationName()
   const { locationPermissions } = usePermissionsContext()
-  const { goToNextScreenFrom } = useActivationNavigation()
 
-  useEffect(() => {
-    const isLocationOn = locationPermissions === "RequiredOn"
-    if (isLocationOn) {
-      goToNextScreenFrom("ActivateLocation")
-    }
-  })
+  const isLocationOn = locationPermissions === "RequiredOn"
+
+  return (
+    <SafeAreaView style={style.safeArea}>
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
+      >
+        <View style={style.content}>
+          <Text style={style.header}>{t("onboarding.location_header")}</Text>
+          <View style={style.subheaderContainer}>
+            <SvgXml xml={Icons.AlertCircle} fill={Colors.accent.danger150} />
+            <Text style={style.subheaderText}>
+              {t("onboarding.location_subheader", { applicationName })}
+            </Text>
+          </View>
+          <Text style={style.bodyText}>
+            {t("onboarding.location_body", { applicationName })}
+          </Text>
+        </View>
+        {!isLocationOn ? (
+          <EnableLocationButtons />
+        ) : (
+          <LocationAlreadyEnabledButtons />
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+const EnableLocationButtons: FunctionComponent = () => {
+  const { t } = useTranslation()
+  const { applicationName } = useApplicationName()
+  const { goToNextScreenFrom } = useActivationNavigation()
 
   const handleOnPressMaybeLater = () => {
     goToNextScreenFrom("ActivateLocation")
@@ -58,40 +93,52 @@ const ActivateLocation: FunctionComponent = () => {
   }
 
   return (
-    <SafeAreaView style={style.safeArea}>
-      <ScrollView
-        style={style.container}
-        contentContainerStyle={style.contentContainer}
-        alwaysBounceVertical={false}
+    <View>
+      <TouchableOpacity
+        onPress={handleOnPressAllowLocationAccess}
+        style={style.button}
       >
-        <View style={style.content}>
-          <Text style={style.header}>{t("onboarding.location_header")}</Text>
-          <View style={style.subheaderContainer}>
-            <SvgXml xml={Icons.AlertCircle} fill={Colors.accent.danger150} />
-            <Text style={style.subheaderText}>
-              {t("onboarding.location_subheader", { applicationName })}
-            </Text>
-          </View>
-          <Text style={style.bodyText}>
-            {t("onboarding.location_body", { applicationName })}
+        <Text style={style.buttonText}>{t("common.settings")}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={handleOnPressMaybeLater}
+        style={style.secondaryButton}
+      >
+        <Text style={style.secondaryButtonText}>{t("common.maybe_later")}</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+const LocationAlreadyEnabledButtons: FunctionComponent = () => {
+  const { t } = useTranslation()
+  const { goToNextScreenFrom } = useActivationNavigation()
+
+  const handleOnPressContinue = () => {
+    goToNextScreenFrom("ActivateExposureNotifications")
+  }
+
+  return (
+    <View style={style.alreadyActiveContainer}>
+      <View style={style.alreadyActiveInfoContainer}>
+        <View style={style.alreadyActiveIconContainer}>
+          <SvgXml
+            xml={Icons.CheckInCircle}
+            fill={Colors.accent.success100}
+            width={Iconography.xSmall}
+            height={Iconography.xSmall}
+          />
+        </View>
+        <View style={style.alreadyActiveTextContainer}>
+          <Text style={style.alreadyActiveText}>
+            {t("onboarding.location_services_already_active")}
           </Text>
         </View>
-        <TouchableOpacity
-          onPress={handleOnPressAllowLocationAccess}
-          style={style.button}
-        >
-          <Text style={style.buttonText}>{t("common.settings")}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={handleOnPressMaybeLater}
-          style={style.secondaryButton}
-        >
-          <Text style={style.secondaryButtonText}>
-            {t("common.maybe_later")}
-          </Text>
-        </TouchableOpacity>
-      </ScrollView>
-    </SafeAreaView>
+      </View>
+      <TouchableOpacity onPress={handleOnPressContinue} style={style.button}>
+        <Text style={style.buttonText}>{t("common.continue")}</Text>
+      </TouchableOpacity>
+    </View>
   )
 }
 
@@ -145,6 +192,25 @@ const style = StyleSheet.create({
   },
   secondaryButtonText: {
     ...Typography.button.secondary,
+  },
+  alreadyActiveContainer: {
+    borderTopWidth: 1,
+    borderTopColor: Colors.neutral.shade50,
+  },
+  alreadyActiveInfoContainer: {
+    flexDirection: "row",
+    paddingVertical: Spacing.large,
+  },
+  alreadyActiveIconContainer: {
+    flex: 1,
+    justifyContent: "center",
+  },
+  alreadyActiveTextContainer: {
+    flex: 8,
+    justifyContent: "center",
+  },
+  alreadyActiveText: {
+    ...Typography.body.x30,
   },
 })
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -271,7 +271,8 @@
       "subheader_4": "Each phone periodically pings the server for the list of flagged IDs and looks for matches",
       "subheader_5": "You will be notified if {{applicationName}} finds a positive match with a flagged ID"
     },
-    "proximity_tracing_already_active": "Exposure notifications are active.",
+    "location_services_already_active": "Location services are active",
+    "proximity_tracing_already_active": "Exposure notifications are active",
     "proximity_tracing_body1": "If smartphones with the app installed are turned on, have bluetooth enabled, and are near each other for a period of time, an encounter is registered on your device.",
     "proximity_tracing_body2": "In the event of an encounter, your data, and information remain anonymous. The app doesn’t store any personal data. Only random IDs are exchanged. These are deleted after 14 days.",
     "proximity_tracing_button": "Activate Exposure Notifications",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -271,7 +271,7 @@
       "subheader_4": "Each phone periodically pings the server for the list of flagged IDs and looks for matches",
       "subheader_5": "You will be notified if {{applicationName}} finds a positive match with a flagged ID"
     },
-    "proximity_tracing_already_active": "Exposure notifications are currently active",
+    "proximity_tracing_already_active": "Exposure notifications are active.",
     "proximity_tracing_body1": "If smartphones with the app installed are turned on, have bluetooth enabled, and are near each other for a period of time, an encounter is registered on your device.",
     "proximity_tracing_body2": "In the event of an encounter, your data, and information remain anonymous. The app doesn’t store any personal data. Only random IDs are exchanged. These are deleted after 14 days.",
     "proximity_tracing_button": "Activate Exposure Notifications",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -271,6 +271,7 @@
       "subheader_4": "Each phone periodically pings the server for the list of flagged IDs and looks for matches",
       "subheader_5": "You will be notified if {{applicationName}} finds a positive match with a flagged ID"
     },
+    "proximity_tracing_already_active": "Exposure notifications are currently active",
     "proximity_tracing_body1": "If smartphones with the app installed are turned on, have bluetooth enabled, and are near each other for a period of time, an encounter is registered on your device.",
     "proximity_tracing_body2": "In the event of an encounter, your data, and information remain anonymous. The app doesn’t store any personal data. Only random IDs are exchanged. These are deleted after 14 days.",
     "proximity_tracing_button": "Activate Exposure Notifications",


### PR DESCRIPTION
Why: currently, when a user reaches either the Activate Exposure Notifications or Activate Location screen and has already activated the respective service, they will be automatically navigated to the next screen in the activation flow. We would like to instead inform the user that the respective service is turned on and present a button they can use to continue to the next activation step.

This commit:
- Removes the code that navigates the user to the next activation screen automatically
- Conditionally renders either the button to enable the service or a notice that the service is on and a continue button

<img width="308" alt="Screen Shot 2020-11-24 at 3 10 30 PM" src="https://user-images.githubusercontent.com/39350030/100146563-19d81480-2e68-11eb-8bee-cbfc3131cfe6.png">