### PR TITLE
Fix for Key Server Error Message Change

### DIFF
--- a/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
@@ -116,7 +116,7 @@ describe("postDiagnosisKeys", () => {
     it("returns a no-op EmptyExposureKeys response if the error corresponds", async () => {
       const newKeysInserted = 0
       const message =
-        "unable to validate diagnosis verification: calculating expected HMAC: cannot calculate hmac on empty exposure keys."
+        "unable to validate diagnosis verification: calculating expected HMAC: cannot calculate hmac on empty exposure keys"
       const jsonResponse = {
         error: message,
         insertedExposures: newKeysInserted,

--- a/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
@@ -116,7 +116,7 @@ describe("postDiagnosisKeys", () => {
     it("returns a no-op EmptyExposureKeys response if the error corresponds", async () => {
       const newKeysInserted = 0
       const message =
-        "unable to validate diagnosis verification: calculating expect HMAC: cannot calculate hmac on empty exposure keys"
+        "unable to validate diagnosis verification: calculating expected HMAC: cannot calculate hmac on empty exposure keys."
       const jsonResponse = {
         error: message,
         insertedExposures: newKeysInserted,

--- a/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
@@ -116,7 +116,7 @@ describe("postDiagnosisKeys", () => {
     it("returns a no-op EmptyExposureKeys response if the error corresponds", async () => {
       const newKeysInserted = 0
       const message =
-        "unable to validate diagnosis verification: calculating expect HMAC: cannont calculate hmac on empty exposure keys"
+        "unable to validate diagnosis verification: calculating expect HMAC: cannot calculate hmac on empty exposure keys"
       const jsonResponse = {
         error: message,
         insertedExposures: newKeysInserted,

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -75,7 +75,7 @@ class PostDiagnosisKeysRequest {
   private static RETRY_STATUS_CODES = [429, 503]
   private static INTERNAL_ERROR = "internal_error"
   private static EMPTY_EXPOSURE_KEYS =
-    "unable to validate diagnosis verification: calculating expect HMAC: cannot calculate hmac on empty exposure keys"
+    "unable to validate diagnosis verification: calculating expected HMAC: cannot calculate hmac on empty exposure keys."
   private static EXISTING_KEYS_SENT_RESPONSE =
     "no revision token, but sent existing keys"
   private static TIMEOUT = 5000

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -75,7 +75,7 @@ class PostDiagnosisKeysRequest {
   private static RETRY_STATUS_CODES = [429, 503]
   private static INTERNAL_ERROR = "internal_error"
   private static EMPTY_EXPOSURE_KEYS =
-    "unable to validate diagnosis verification: calculating expect HMAC: cannont calculate hmac on empty exposure keys"
+    "unable to validate diagnosis verification: calculating expect HMAC: cannot calculate hmac on empty exposure keys"
   private static EXISTING_KEYS_SENT_RESPONSE =
     "no revision token, but sent existing keys"
   private static TIMEOUT = 5000

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -75,7 +75,7 @@ class PostDiagnosisKeysRequest {
   private static RETRY_STATUS_CODES = [429, 503]
   private static INTERNAL_ERROR = "internal_error"
   private static EMPTY_EXPOSURE_KEYS =
-    "unable to validate diagnosis verification: calculating expected HMAC: cannot calculate hmac on empty exposure keys."
+    "unable to validate diagnosis verification: calculating expected HMAC: cannot calculate hmac on empty exposure keys"
   private static EXISTING_KEYS_SENT_RESPONSE =
     "no revision token, but sent existing keys"
   private static TIMEOUT = 5000


### PR DESCRIPTION
#### Why:
The key server (https://github.com/google/exposure-notifications-server) error response when an empty key set has been submitted has been fixed to remove a typo (`expect` -> `expected`, `cannont` -> `cannot`), so we'd like the string we use to match against that error message to be updated as well.

#### This commit:
This commit updates the `EMPTY_EXPOSURE_KEYS` string to match the error message sent by the key server