### PR TITLE
Update ux on submit code screen

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -186,17 +186,13 @@ const CodeInputForm: FunctionComponent = () => {
       >
         <View style={style.headerContainer}>
           <Text style={style.header}>
-            {t("export.code_input_title_bluetooth")}
-          </Text>
-
-          <Text style={style.subheader}>
-            {t("export.code_input_body_bluetooth")}
+            {t("export.enter_verification_code")}
           </Text>
         </View>
         <TextInput
           testID="code-input"
           value={code}
-          placeholder={t("export.code_input_placeholder").toUpperCase()}
+          placeholder={t("export.code").toUpperCase()}
           placeholderTextColor={Colors.text.placeholder}
           maxLength={codeLengthMax}
           style={codeInputStyle}
@@ -265,14 +261,10 @@ const style = StyleSheet.create({
     justifyContent: "center",
   },
   headerContainer: {
-    marginBottom: Spacing.xxLarge,
+    marginBottom: Spacing.medium,
   },
   header: {
     ...Typography.header.x60,
-    marginBottom: Spacing.xxSmall,
-  },
-  subheader: {
-    ...Typography.body.x30,
   },
   errorSubtitle: {
     ...Typography.utility.error,

--- a/src/AffectedUserFlow/VerificationCodeInfo.tsx
+++ b/src/AffectedUserFlow/VerificationCodeInfo.tsx
@@ -29,10 +29,12 @@ const MoreInfo: FunctionComponent = () => {
 
   const verificationCodeInfoText =
     verificationCodeInfo ||
-    t("export.verification_code_info_body", { healthAuthorityName })
+    t("export.verification_code_info.info_body", { healthAuthorityName })
   const verificationCodeHowDoIGetText =
     verificationCodeHowDoIGet ||
-    t("export.how_do_i_get_body", { healthAuthorityName })
+    t("export.verification_code_info.how_do_i_get_body", {
+      healthAuthorityName,
+    })
 
   const handleOnPressLink = () => {
     const url = healthAuthorityVerificationCodeInfoUrl
@@ -49,22 +51,30 @@ const MoreInfo: FunctionComponent = () => {
       >
         <View style={style.section}>
           <Text style={style.headerText}>
-            {t("export.verification_code_info_header")}
+            {t("export.verification_code_info.info_header")}
           </Text>
           <Text style={style.contentText}>{verificationCodeInfoText}</Text>
         </View>
         <View style={style.section}>
           <Text style={style.headerText}>
-            {t("export.how_do_i_get_header")}
+            {t("export.verification_code_info.how_do_i_get_header")}
           </Text>
           <Text style={style.contentText}>{verificationCodeHowDoIGetText}</Text>
+          {Boolean(healthAuthorityVerificationCodeInfoUrl) && (
+            <TouchableOpacity style={style.button} onPress={handleOnPressLink}>
+              <Text style={style.buttonText}>{t("common.learn_more")}</Text>
+              <SvgXml xml={Icons.Arrow} fill={Colors.primary.shade100} />
+            </TouchableOpacity>
+          )}
         </View>
-        {Boolean(healthAuthorityVerificationCodeInfoUrl) && (
-          <TouchableOpacity style={style.button} onPress={handleOnPressLink}>
-            <Text style={style.buttonText}>{t("common.learn_more")}</Text>
-            <SvgXml xml={Icons.Arrow} fill={Colors.primary.shade100} />
-          </TouchableOpacity>
-        )}
+        <View style={style.section}>
+          <Text style={style.headerText}>
+            {t("export.verification_code_info.what_happens_header")}
+          </Text>
+          <Text style={style.contentText}>
+            {t("export.verification_code_info.what_happens_body")}
+          </Text>
+        </View>
       </ScrollView>
     </>
   )

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -71,14 +71,17 @@
     "title": "Unknown Error"
   },
   "export": {
-    "verification_code_info_header": "Verification Code Info",
-    "verification_code_info_body": "A verification code is a code provided to you by your health authority, {{healthAuthorityName}}, if you receive a positive test result. It is used to verify that your positive test result is authentic.\n\nEach verification code will expire after a short period to ensure that stale test results are not submitted.\n\nIf the verification code you have cannot be submitted, you will need to get a new one from your health authority.",
-    "how_do_i_get_header": "How do I get a verification code?",
-    "how_do_i_get_body": "Contact your health authority, {{healthAuthorityName}}.",
-    "code_input_body_bluetooth": "Enter your verification code",
+    "verification_code_info": {
+      "info_header": "What is a verification code?",
+      "info_body": "A verification code is a code provided to you by your health authority, {{healthAuthorityName}}, if you receive a positive test result.\n\nThe verification code is used to verify that your positive test result is authentic.\n\nEach verification code will expire after a short period to ensure that stale test results are not submitted.\n\nIf you encounter an error when submitting your verification code, you must get a new code from your health authority before submitting again.",
+      "how_do_i_get_header": "How do I get a verification code?",
+      "how_do_i_get_body": "Contact your health authority, {{healthAuthorityName}}.",
+      "what_happens_header": "What happens when I submit my code?",
+      "what_happens_body": "When you submit your verification code, the app will ask you to share the random anonymous exposure keys from other devices to which you have connected.\n\nIf you give permission, the app will send these keys to an exposure notification server. The notification server will notify the devices you have connected to of the positive test result.\n\nThe app never collects or stores personal information. Only the random anonymous keys stored on your device are shared."
+    },
+    "enter_verification_code": "Enter verification code",
     "code_input_button_cancel": "Cancel",
-    "code_input_placeholder": "Enter Code",
-    "code_input_title_bluetooth": "Verify your diagnosis",
+    "code": "Code",
     "complete_body_bluetooth": "You’re helping contain the spread of the virus and protect others in your community.",
     "complete_title": "Thanks for keeping your community safe!",
     "consent_body_0": "Sharing your positive diagnosis is optional and can only be done with your consent.",


### PR DESCRIPTION
Why:
Currently we refer to a `diagnosis` on the submit verification code
screen. We would like to consistently use terms and replace this with
`Enter verification code` to be consistent with the rest of the
application

This commit:
Updates some copy and adds more info to the VerificationCodeInfo screen.

Co-Authored-By: Devin Jameson <devin@thoughtbot.com>

|Before|After|
|---|-----|
|![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 17 00 25](https://user-images.githubusercontent.com/16049495/100285913-bde0bf00-2f3f-11eb-979d-f8c5fd37c88d.png)|![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 16 49 12](https://user-images.githubusercontent.com/16049495/100285795-81ad5e80-2f3f-11eb-96fb-0ffaee33f651.png)

|Before|After|
|-----|-----|
|![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 17 01 54](https://user-images.githubusercontent.com/16049495/100285982-f1bbe480-2f3f-11eb-8f8b-90218d8fdcf4.png)|![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 16 49 19](https://user-images.githubusercontent.com/16049495/100285801-840fb880-2f3f-11eb-961c-2a95bbdb397d.png)
