### PR TITLE
Push Notification/Linking Update

### DIFF
--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -55,7 +55,7 @@ const linking: LinkingOptions = {
   prefixes: ["pathcheck://"],
   config: {
     screens: {
-      ExposureHistoryFlow: "exposureHistory",
+      ExposureHistory: "exposureHistory",
     },
   },
 }


### PR DESCRIPTION
#### Why:
We'd like exposure notifications to navigate users to the exposure history screen when tapped.

#### This commit:
This commit specifies the requisite screen for `Linking`
![Nov-26-2020 09-59-04](https://user-images.githubusercontent.com/2637355/100372025-473ed280-2fce-11eb-8462-50be4ee14b6a.gif)
