### PR TITLE
Reduce vertical padding of exposure detection status card

### DIFF
--- a/src/Home/ExposureDetectionStatus/Card.tsx
+++ b/src/Home/ExposureDetectionStatus/Card.tsx
@@ -105,7 +105,7 @@ const ExposureDetectionStatusCard: FunctionComponent = () => {
 const style = StyleSheet.create({
   statusContainer: {
     ...Affordances.floatingContainer,
-    padding: Spacing.small,
+    paddingVertical: Spacing.medium,
     elevation: 0,
     borderWidth: Outlines.thin,
     overflow: "hidden",


### PR DESCRIPTION
Why: there is too much vertical padding on the exposure detection status card.
|Old|New|
|--|--|
|![old](https://user-images.githubusercontent.com/39350030/100628691-7d45c480-32f6-11eb-9bd7-4a3dfbb6af9a.png)|![new](https://user-images.githubusercontent.com/39350030/100628688-7cad2e00-32f6-11eb-96f7-5794cb2ab188.png)|
