### PR TITLE
Do not subscribe to location events on iOS

### DIFF
--- a/src/Device/useLocationPermissions.ts
+++ b/src/Device/useLocationPermissions.ts
@@ -42,17 +42,21 @@ const useLocationPermissions = (): LocationPermissions => {
     determineLocationEnabledState()
   }, [determineIsLocationRequired, determineLocationEnabledState])
 
-  useEffect(() => {
-    const subscription = subscribeToLocationStatusEvents((enabled: boolean) => {
-      if (enabled) {
-        setLocationEnabledState("On")
-      } else {
-        setLocationEnabledState("Off")
-      }
-    })
+  useEffect((): (() => void) | void => {
+    if (Platform.OS === "android") {
+      const subscription = subscribeToLocationStatusEvents(
+        (enabled: boolean) => {
+          if (enabled) {
+            setLocationEnabledState("On")
+          } else {
+            setLocationEnabledState("Off")
+          }
+        },
+      )
 
-    return () => {
-      subscription.remove()
+      return () => {
+        subscription.remove()
+      }
     }
   }, [])
 

--- a/src/Device/useLocationPermissions.ts
+++ b/src/Device/useLocationPermissions.ts
@@ -28,11 +28,8 @@ const useLocationPermissions = (): LocationPermissions => {
   const determineLocationEnabledState = useCallback(async () => {
     if (isLocationRequired) {
       isLocationEnabled().then((result) => {
-        if (result) {
-          setLocationEnabledState("On")
-        } else {
-          setLocationEnabledState("Off")
-        }
+        const enabledState = result ? "On" : "Off"
+        setLocationEnabledState(enabledState)
       })
     }
   }, [isLocationRequired])
@@ -46,11 +43,8 @@ const useLocationPermissions = (): LocationPermissions => {
     if (Platform.OS === "android") {
       const subscription = subscribeToLocationStatusEvents(
         (enabled: boolean) => {
-          if (enabled) {
-            setLocationEnabledState("On")
-          } else {
-            setLocationEnabledState("Off")
-          }
+          const enabledState = enabled ? "On" : "Off"
+          setLocationEnabledState(enabledState)
         },
       )
 


### PR DESCRIPTION
Why: we are currently attempting to subscribe to location status events on iOS, but this concept only exists on Android. Therefore, we have to only subscribe to location status events if the platform in Android.

This commit:
- Updates the `useLocationPermissions` hook to only run a side effect that subscribes to location status events if the platform is Android
- Slightly refactors the setting of the location enabled state to use a ternary to make the code easier to read

Co-Authored-By: Matt Buckley <matt@nicethings.io>