### PR TITLE
Fix layout for wide buttons

### DIFF
--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -32,7 +32,13 @@ interface HowItWorksScreenProps {
 }
 
 const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
-  howItWorksScreenContent,
+  howItWorksScreenContent: {
+    image,
+    imageLabel,
+    header,
+    primaryButtonLabel,
+    primaryButtonOnPress,
+  },
 }) => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()
@@ -43,14 +49,6 @@ const HowItWorksScreen: FunctionComponent<HowItWorksScreenProps> = ({
   const handleOnPressProtectPrivacy = () => {
     navigation.navigate(ModalStackScreens.ProtectPrivacy)
   }
-
-  const {
-    image,
-    imageLabel,
-    header,
-    primaryButtonLabel,
-    primaryButtonOnPress,
-  } = howItWorksScreenContent
 
   return (
     <>

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -11,9 +11,6 @@ const base: ViewStyle = {
   alignItems: "center",
   width: "100%",
 }
-const heightBase: ViewStyle = {
-  paddingVertical: Spacing.medium,
-}
 const heightThin: ViewStyle = {
   paddingVertical: Spacing.xSmall,
 }
@@ -23,8 +20,8 @@ const heightThin: ViewStyle = {
 type Primary = "base" | "disabled"
 const primaryBase: ViewStyle = {
   ...base,
-  ...heightBase,
   ...Outlines.lightShadow,
+  padding: Spacing.medium,
   borderRadius: Outlines.borderRadiusLarge,
   backgroundColor: Colors.primary.shade100,
   maxWidth: Layout.screenWidth * 0.95,


### PR DESCRIPTION
Why:
Currently, wide buttons will allow text that is too long to overflow to
the edge of the button. We would like for buttons to have a consistent
horizontal padding.

|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-30 at 09 48 51](https://user-images.githubusercontent.com/16049495/100645641-d101df00-32f1-11eb-876e-e1bdfe72179b.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-30 at 09 48 37](https://user-images.githubusercontent.com/16049495/100645632-cd6e5800-32f1-11eb-9b35-996ff3f12288.png)|

