### PR TITLE
Provide better error messages on request gaen api

### DIFF
--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -277,7 +277,8 @@ final class ExposureManager: NSObject {
     // in Settings.
     manager.setExposureNotificationEnabled(true) { error in
       if let error = error {
-        reject(error.localizedDescription, error.localizedDescription, error)
+        let errorString = error._code.enErrorString
+        reject(errorString, error.localizedDescription, error)
       } else {
         self.broadcastCurrentEnabledStatus()
         resolve(self.exposureNotificationStatus.rawValue)

--- a/ios/BT/Extensions/Exposure Notifications/ENError+Extensions.swift
+++ b/ios/BT/Extensions/Exposure Notifications/ENError+Extensions.swift
@@ -1,0 +1,9 @@
+//
+//  ENError+Extensions.swift
+//  BT
+//
+//  Created by Matthew Buckley on 11/30/20.
+//  Copyright © 2020 Path Check Inc. All rights reserved.
+//
+
+import Foundation

--- a/ios/BT/Extensions/Foundation/Int+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Int+Extensions.swift
@@ -4,4 +4,45 @@ extension Int {
     Date(timeIntervalSince1970: TimeInterval(self / 1000))
   }
 
+  var enErrorString: String {
+    switch self {
+    case 1:
+      return "IOSUnknown"
+    case 2:
+      return "BadParameter"
+    case 3:
+      return "NotEntitled"
+    case 4:
+      return "NotAuthorized"
+    case 5:
+      return "Unsupported"
+    case 6:
+      return "Invalidated"
+    case 7:
+      return "BluetoothOff"
+    case 8:
+      return "InsufficientStorage"
+    case 9:
+      return "NotEnabled"
+    case 10:
+      return "APIMisuse"
+    case 11:
+      return "Internal"
+    case 12:
+      return "InsufficientMemory"
+    case 13:
+      return "RateLimited"
+    case 14:
+      return "Restricted"
+    case 15:
+      return "BadFormat"
+    case 16:
+      return "DataInaccessible"
+    case 17:
+      return "TravelStatusNotAvailable"
+    default:
+      return "Unknown"
+    }
+  }
+
 }

--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -5,18 +5,15 @@ import {
   View,
   StyleSheet,
   TouchableOpacity,
-  Platform,
-  Alert,
 } from "react-native"
 import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
 
 import { usePermissionsContext } from "../Device/PermissionsContext"
-import { openAppSettings } from "../Device"
-import { useApplicationName } from "../Device/useApplicationInfo"
 import { useProductAnalyticsContext } from "../ProductAnalytics/Context"
 import { Text } from "../components"
 import { useActivationNavigation } from "./useActivationNavigation"
+import { useRequestExposureNotifications } from "../useRequestExposureNotifications"
 
 import { Icons } from "../assets"
 import { Spacing, Typography, Buttons, Colors, Iconography } from "../styles"
@@ -63,78 +60,17 @@ const ActivateExposureNotifications: FunctionComponent = () => {
 const EnableENButtons: FunctionComponent = () => {
   const { t } = useTranslation()
   const { trackEvent } = useProductAnalyticsContext()
-  const { exposureNotifications } = usePermissionsContext()
   const { goToNextScreenFrom } = useActivationNavigation()
-  const { applicationName } = useApplicationName()
-
-  const showNotAuthorizedAlert = () => {
-    const errorMessage = Platform.select({
-      ios: t("home.proximity_tracing.unauthorized_error_message_ios", {
-        applicationName,
-      }),
-      android: t("home.proximity_tracing.unauthorized_error_message_android", {
-        applicationName,
-      }),
-    })
-
-    Alert.alert(
-      t("home.proximity_tracing.unauthorized_error_title"),
-      errorMessage,
-      [
-        {
-          text: t("common.back"),
-          style: "cancel",
-        },
-        {
-          text: t("common.settings"),
-          onPress: () => openAppSettings(),
-        },
-      ],
-    )
-  }
-
-  const showEnableBluetoothAlert = () => {
-    Alert.alert(
-      t("onboarding.activate_exposure_notifications.bluetooth_header", {
-        applicationName,
-      }),
-      t("onboarding.activate_exposure_notifications.bluetooth_body"),
-      [
-        {
-          text: t("common.back"),
-          style: "cancel",
-        },
-        {
-          text: t("common.settings"),
-          onPress: () => {
-            openAppSettings()
-          },
-        },
-      ],
-    )
-  }
-
-  const handleOnPressEnable = async () => {
-    try {
-      const response = await exposureNotifications.request()
-      if (response.kind === "success") {
-        if (response.status === "BluetoothOff") {
-          showEnableBluetoothAlert()
-        } else {
-          showNotAuthorizedAlert()
-        }
-      } else {
-        showNotAuthorizedAlert()
-      }
-      trackEvent("product_analytics", "onboarding_en_permissions_accept")
-    } catch (e) {
-      showNotAuthorizedAlert()
-    }
-  }
+  const requestExposureNotifications = useRequestExposureNotifications()
 
   const handleOnPressDontEnable = () => {
     trackEvent("product_analytics", "onboarding_en_permissions_denied")
     goToNextScreenFrom("ActivateExposureNotifications")
+  }
+
+  const handleOnPressEnable = () => {
+    trackEvent("product_analytics", "onboarding_en_permissions_accept")
+    requestExposureNotifications()
   }
 
   return (

--- a/src/Activation/NotificationPermissions.spec.tsx
+++ b/src/Activation/NotificationPermissions.spec.tsx
@@ -104,11 +104,6 @@ const createPermissionProviderValue = (
     },
     exposureNotifications: {
       status: "Active",
-      request: () =>
-        Promise.resolve({
-          kind: "failure" as const,
-          error: "Unknown" as const,
-        }),
     },
   }
 }

--- a/src/Device/PermissionsContext.tsx
+++ b/src/Device/PermissionsContext.tsx
@@ -59,7 +59,6 @@ export interface PermissionsContextState {
   }
   exposureNotifications: {
     status: ENPermissionStatus
-    request: () => Promise<GaenNativeModule.RequestAuthorizationResponse>
   }
 }
 
@@ -72,8 +71,6 @@ const initialState = {
   },
   exposureNotifications: {
     status: "Unknown" as const,
-    request: () =>
-      Promise.resolve({ kind: "failure" as const, error: "Unknown" as const }),
   },
 }
 
@@ -81,7 +78,7 @@ const PermissionsContext = createContext<PermissionsContextState>(initialState)
 
 const PermissionsProvider: FunctionComponent = ({ children }) => {
   const locationPermissions = useLocationPermissions()
-  const { enPermission, requestENPermission } = useENPermissions()
+  const { enPermission } = useENPermissions()
   const {
     notificationPermission,
     checkNotificationPermission,
@@ -99,7 +96,6 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
         },
         exposureNotifications: {
           status: enPermission,
-          request: requestENPermission,
         },
       }}
     >
@@ -167,13 +163,8 @@ const useENPermissions = () => {
     }
   }, [])
 
-  const requestENPermission = async () => {
-    return GaenNativeModule.requestAuthorization()
-  }
-
   return {
     enPermission: enPermissionStatus,
-    requestENPermission,
   }
 }
 

--- a/src/Device/useDeviceAlert.ts
+++ b/src/Device/useDeviceAlert.ts
@@ -1,0 +1,32 @@
+import { Alert } from "react-native"
+import { useTranslation } from "react-i18next"
+import { openAppSettings } from "./nativeModule"
+
+type DeviceAlerts = {
+  showFixLocationAlert: () => void
+}
+
+export const useDeviceAlert = (): DeviceAlerts => {
+  const { t } = useTranslation()
+
+  const showFixLocationAlert = () => {
+    Alert.alert(
+      t("home.bluetooth.location_disabled_error_title"),
+      t("home.bluetooth.location_disabled_error_message"),
+      [
+        {
+          text: t("common.back"),
+          style: "cancel",
+        },
+        {
+          text: t("common.settings"),
+          onPress: () => openAppSettings(),
+        },
+      ],
+    )
+  }
+
+  return {
+    showFixLocationAlert,
+  }
+}

--- a/src/Device/useExposureDetectionStatus.tsx
+++ b/src/Device/useExposureDetectionStatus.tsx
@@ -1,18 +1,17 @@
 import { usePermissionsContext } from "../Device/PermissionsContext"
 
-interface ExposureDetectionStatus {
-  exposureDetectionStatus: boolean
-}
+type ExposureDetectionStatus = "On" | "Off"
 
 export const useExposureDetectionStatus = (): ExposureDetectionStatus => {
   const { locationPermissions, exposureNotifications } = usePermissionsContext()
 
   const isLocationRequiredAndOff = locationPermissions === "RequiredOff"
 
-  const isExposureNotificationsOn = exposureNotifications.status === "Active"
+  const isExposureNotificationsActive =
+    exposureNotifications.status === "Active"
 
   const exposureDetectionStatus =
-    isExposureNotificationsOn && !isLocationRequiredAndOff
+    isExposureNotificationsActive && !isLocationRequiredAndOff ? "On" : "Off"
 
-  return { exposureDetectionStatus }
+  return exposureDetectionStatus
 }

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -8,11 +8,10 @@ import { showMessage } from "react-native-flash-message"
 import { ExposureDatum } from "../../exposure"
 import { LoadingIndicator, StatusBar, Text } from "../../components"
 import { useStatusBarEffect } from "../../navigation/index"
-import { useExposureContext } from "../../ExposureContext"
-
 import DateInfoHeader from "./DateInfoHeader"
 import ExposureList from "./ExposureList"
 import NoExposures from "./NoExposures"
+import { useExposureContext } from "../../ExposureContext"
 
 import { Icons } from "../../assets"
 import { ExposureHistoryStackScreens } from "../../navigation"
@@ -54,7 +53,7 @@ const History: FunctionComponent<HistoryProps> = ({
     navigation.navigate(ExposureHistoryStackScreens.MoreInfo)
   }
 
-  const handleOnPressCheckForExposures = async () => {
+  const checkForExposures = async () => {
     setCheckingForExposures(true)
     const checkResult = await checkForNewExposures()
     if (checkResult.kind === "success") {
@@ -63,23 +62,16 @@ const History: FunctionComponent<HistoryProps> = ({
         ...successFlashMessageOptions,
       })
     } else {
-      switch (checkResult.error) {
-        case "ExceededCheckRateLimit": {
-          showMessage({
-            message: t("common.success"),
-            ...successFlashMessageOptions,
-          })
-          break
-        }
-        default: {
-          showMessage({
-            message: t("common.something_went_wrong"),
-            ...errorFlashMessageOptions,
-          })
-        }
-      }
+      showMessage({
+        message: t("common.something_went_wrong"),
+        ...errorFlashMessageOptions,
+      })
     }
     setCheckingForExposures(false)
+  }
+
+  const handleOnPressCheckForExposures = async () => {
+    await checkForExposures()
   }
 
   const showExposureHistory = exposures.length > 0

--- a/src/Home/ExposureDetectionStatus/Card.tsx
+++ b/src/Home/ExposureDetectionStatus/Card.tsx
@@ -24,7 +24,7 @@ import {
 const ExposureDetectionStatusCard: FunctionComponent = () => {
   const navigation = useNavigation()
   const { t } = useTranslation()
-  const { exposureDetectionStatus } = useExposureDetectionStatus()
+  const exposureDetectionStatus = useExposureDetectionStatus()
 
   const handleOnPressExposureDetectionStatus = () => {
     navigation.navigate(HomeStackScreens.ExposureDetectionStatus)
@@ -55,7 +55,7 @@ const ExposureDetectionStatusCard: FunctionComponent = () => {
     statusIconFill,
     statusText,
     actionText,
-  } = exposureDetectionStatus ? enabledConfig : disabledConfig
+  } = exposureDetectionStatus === "On" ? enabledConfig : disabledConfig
 
   const statusContainerStyle = {
     ...style.statusContainer,
@@ -86,7 +86,9 @@ const ExposureDetectionStatusCard: FunctionComponent = () => {
             fill={statusIconFill}
             style={style.statusIcon}
           />
-          {exposureDetectionStatus && <AnimatedCircle iconSize={iconSize} />}
+          {exposureDetectionStatus === "On" && (
+            <AnimatedCircle iconSize={iconSize} />
+          )}
         </View>
       </View>
       <View style={style.statusBottomContainer}>

--- a/src/Home/ExposureDetectionStatus/Screen.spec.tsx
+++ b/src/Home/ExposureDetectionStatus/Screen.spec.tsx
@@ -10,11 +10,7 @@ import { useNavigation } from "@react-navigation/native"
 import "@testing-library/jest-native/extend-expect"
 
 import { HomeStackScreens } from "../../navigation"
-import {
-  PermissionsContext,
-  ENPermissionStatus,
-} from "../../Device/PermissionsContext"
-import { LocationPermissions } from "../../Device/useLocationPermissions"
+import { PermissionsContext } from "../../Device/PermissionsContext"
 import { factories } from "../../factories"
 import { RequestAuthorizationResponse } from "../../gaen/nativeModule"
 import ExposureDetectionStatusScreen from "./Screen"
@@ -32,6 +28,18 @@ jest.mock("../../Device/useApplicationInfo", () => {
   }
 })
 
+let mockedRequestAuthorizationResponse: RequestAuthorizationResponse = {
+  kind: "success",
+  status: "Active",
+}
+jest.mock("../../gaen/nativeModule", () => {
+  return {
+    requestAuthorization: async () => {
+      return mockedRequestAuthorizationResponse
+    },
+  }
+})
+
 describe("ExposureDetectionStatusScreen", () => {
   beforeEach(() => {
     jest.resetAllMocks()
@@ -39,17 +47,13 @@ describe("ExposureDetectionStatusScreen", () => {
 
   describe("When the app is not authorized", () => {
     it("shows a disabled message for Exposure Notifications and a general disabled message", () => {
-      const enPermissionStatus = "Unauthorized"
-      const locationPermissions = "NotRequired"
-      const permissionProviderValue = createPermissionProviderValue(
-        locationPermissions,
-        enPermissionStatus,
-      )
+      mockedRequestAuthorizationResponse = {
+        kind: "success",
+        status: "Unauthorized",
+      }
 
       const { getByTestId, getByText } = render(
-        <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatusScreen />
-        </PermissionsContext.Provider>,
+        <ExposureDetectionStatusScreen />,
       )
 
       const exposureNotificationsStatusContainer = getByTestId(
@@ -68,30 +72,22 @@ describe("ExposureDetectionStatusScreen", () => {
     })
 
     it("allows the user to get info on how to fix exposure notifications and shows a not authorized alert", async () => {
-      const enPermissionStatus = "Unauthorized"
-      const requestSpy = jest.fn()
-      const permissionProviderValue = createPermissionProviderValue(
-        "RequiredOn",
-        enPermissionStatus,
-        requestSpy,
-      )
+      mockedRequestAuthorizationResponse = {
+        kind: "success",
+        status: "Unauthorized",
+      }
 
-      const { getByTestId } = render(
-        <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatusScreen />
-        </PermissionsContext.Provider>,
-      )
+      const { getByTestId } = render(<ExposureDetectionStatusScreen />)
 
       const alertSpy = jest.spyOn(Alert, "alert")
 
       const expectedMessage =
-        "Open Settings, then navigate to the Exposure Notifications settings for this app. Ensure Share Exposure Information is turned on, then press 'Set As Active Region'."
+        "Open the Settings app, then navigate to the Exposure Notifications settings for this app. Ensure 'Share Exposure Information' is turned on, then press 'Set As Active Region'."
 
       fireEvent.press(getByTestId("exposure-notifications-status-container"))
-      expect(requestSpy).toHaveBeenCalled()
       await waitFor(() => {
         expect(alertSpy).toHaveBeenCalledWith(
-          "Enable Exposure Notifications",
+          "Share Exposure Information",
           expectedMessage,
           [
             expect.objectContaining({ text: "Back" }),
@@ -102,50 +98,31 @@ describe("ExposureDetectionStatusScreen", () => {
     })
   })
 
-  describe("When the app is not enabled", () => {
-    it("allows the user to request exposure notification permissions", () => {
-      const enPermissionStatus = "Disabled"
-      const requestSpy = jest.fn()
-      const permissionProviderValue = createPermissionProviderValue(
-        "RequiredOn",
-        enPermissionStatus,
-        requestSpy,
-      )
-
-      const { getByTestId } = render(
-        <PermissionsContext.Provider value={permissionProviderValue}>
-          <ExposureDetectionStatusScreen />
-        </PermissionsContext.Provider>,
-      )
-
-      fireEvent.press(getByTestId("exposure-notifications-status-container"))
-      expect(requestSpy).toHaveBeenCalled()
-    })
-  })
-
   describe("When exposure notification permissions are authorized and the app is enabled", () => {
-    it("allows the user to get more info about Exposure Notifications", () => {
+    it("allows the user to get more info about Exposure Notifications", async () => {
       const navigateSpy = jest.fn()
       ;(useNavigation as jest.Mock).mockReturnValue({
         navigate: navigateSpy,
       })
 
-      const enPermissionStatus = "Active"
-      const permissionProviderValue = createPermissionProviderValue(
-        "RequiredOn",
-        enPermissionStatus,
-      )
+      const permissionsState = factories.permissionsContext.build({
+        exposureNotifications: {
+          status: "Active",
+        },
+      })
 
       const { getByTestId } = render(
-        <PermissionsContext.Provider value={permissionProviderValue}>
+        <PermissionsContext.Provider value={permissionsState}>
           <ExposureDetectionStatusScreen />
         </PermissionsContext.Provider>,
       )
 
       fireEvent.press(getByTestId("exposure-notifications-status-container"))
-      expect(navigateSpy).toHaveBeenCalledWith(
-        HomeStackScreens.ExposureNotificationsInfo,
-      )
+      await waitFor(() => {
+        expect(navigateSpy).toHaveBeenCalledWith(
+          HomeStackScreens.ExposureNotificationsInfo,
+        )
+      })
     })
   })
 
@@ -225,24 +202,3 @@ describe("ExposureDetectionStatusScreen", () => {
     })
   })
 })
-
-const createPermissionProviderValue = (
-  locationPermissions: LocationPermissions = "RequiredOn",
-  enPermissionStatus: ENPermissionStatus,
-  requestPermission: () => Promise<RequestAuthorizationResponse> = () =>
-    Promise.resolve({ kind: "failure" as const, error: "Unknown" as const }),
-) => {
-  return {
-    locationPermissions,
-    notification: {
-      status: "Unknown" as const,
-      check: () => {},
-      request: () => {},
-    },
-    exposureNotifications: {
-      status: enPermissionStatus,
-      check: () => {},
-      request: requestPermission,
-    },
-  }
-}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -213,11 +213,6 @@
     "proximity_tracing_info_body_2": "In the event of an encounter, your data, and information remain anonymous. The app doesn’t store any personal data. Only random IDs are exchanged. These are deleted within 14 days.",
     "proximity_tracing_info_subheader_1": "How does Exposure Notifications work?",
     "proximity_tracing_info_subheader_2": "Is my data secure?",
-    "proximity_tracing": {
-      "unauthorized_error_message_android": "To enable Exposure Notifications, go to the COVID-19 Exposure Notifications screen of your Settings app and enable 'Use Exposure Notifications'",
-      "unauthorized_error_message_ios": "Open Settings, then navigate to the Exposure Notifications settings for this app. Ensure Share Exposure Information is turned on, then press 'Set As Active Region'.",
-      "unauthorized_error_title": "Enable Exposure Notifications"
-    },
     "request_call": "Request Call",
     "submit_code": "Submit code",
     "take_assessment": "Take Assessment",
@@ -246,10 +241,6 @@
     "symptom_history": "Symptoms"
   },
   "onboarding": {
-    "activate_exposure_notifications": {
-      "bluetooth_body": "To activate Exposure Notifications, you must first turn on Bluetooth in your device settings.",
-      "bluetooth_header": "Enable Bluetooth"
-    },
     "activation_header_title": "App Setup",
     "app_setup_complete_body": "{{applicationName}} is active. Thank you for helping break the chain of infection.",
     "app_setup_complete_header": "App Setup Complete!",
@@ -490,5 +481,15 @@
     "shortness_of_breath_or_difficulty_breathing": "Shortness of breath or difficulty breathing",
     "sore_throat": "Sore throat",
     "trouble_breathing": "Trouble breathing"
+  },
+  "exposure_notification_alerts": {
+    "use_exposure_notifications_android_title": "Enable Exposure Notifications",
+    "use_exposure_notifications_android_body": "To enable Exposure Notifications, go to the COVID-19 Exposure Notifications screen of your Settings app and enable 'Use Exposure Notifications'.",
+    "share_exposure_information_ios_title": "Share Exposure Information",
+    "share_exposure_information_ios_body": "Open the Settings app, then navigate to the Exposure Notifications settings for this app. Ensure 'Share Exposure Information' is turned on, then press 'Set As Active Region'.",
+    "set_active_region_ios_title": "Set Active Region",
+    "set_active_region_ios_body": "Open the Settings app, navigate to the Exposure Notifications settings for this app, then press 'Set As Active Region'.",
+    "bluetooth_title": "Enable Bluetooth",
+    "bluetooth_body": "To activate Exposure Notifications, you must first turn on Bluetooth in your Settings app."
   }
 }

--- a/src/useRequestExposureNotifications.tsx
+++ b/src/useRequestExposureNotifications.tsx
@@ -1,0 +1,105 @@
+import { useTranslation } from "react-i18next"
+import { Alert, Platform } from "react-native"
+
+import { ENPermissionStatus } from "./Device/PermissionsContext"
+import { RequestAuthorizationError } from "./gaen/nativeModule"
+import { useApplicationName } from "./Device/useApplicationInfo"
+import { openAppSettings } from "./Device/nativeModule"
+import * as NativeModule from "./gaen/nativeModule"
+
+export const useRequestExposureNotifications = (): (() => void) => {
+  const { t } = useTranslation()
+  const { applicationName } = useApplicationName()
+
+  const requestExposureNotifications = async () => {
+    const response = await NativeModule.requestAuthorization()
+    if (response.kind === "success") {
+      handleENRequestSuccess(response.status)
+    } else {
+      handleENRequestFailure(response.error)
+    }
+  }
+
+  const handleENRequestSuccess = (status: ENPermissionStatus) => {
+    switch (status) {
+      case "Active":
+        break
+      case "BluetoothOff":
+        showEnableBluetoothAlert()
+        break
+      default:
+        showBaseExposureNotificationsAlert()
+    }
+  }
+
+  const handleENRequestFailure = (error: RequestAuthorizationError) => {
+    switch (error) {
+      case "Restricted":
+        showSetToActiveRegionAlert()
+        break
+      case "NotAuthorized":
+        showBaseExposureNotificationsAlert()
+        break
+      case "Unknown":
+        showBaseExposureNotificationsAlert()
+        break
+      default:
+        showBaseExposureNotificationsAlert()
+    }
+  }
+
+  const showBaseExposureNotificationsAlert = () => {
+    if (Platform.OS === "ios") {
+      showShareExposureInformationAlert()
+    } else {
+      showUseExposureNotificationsAlert()
+    }
+  }
+
+  const showAlert = (title: string, body: string) => {
+    Alert.alert(title, body, [
+      {
+        text: t("common.back"),
+        style: "cancel",
+      },
+      {
+        text: t("common.settings"),
+        onPress: () => openAppSettings(),
+      },
+    ])
+  }
+
+  const showUseExposureNotificationsAlert = () => {
+    showAlert(
+      t(
+        "exposure_notification_alerts.use_exposure_notifications_android_title",
+      ),
+      t("exposure_notification_alerts.use_exposure_notifications_android_body"),
+    )
+  }
+
+  const showShareExposureInformationAlert = () => {
+    showAlert(
+      t("exposure_notification_alerts.share_exposure_information_ios_title"),
+      t("exposure_notification_alerts.share_exposure_information_ios_body"),
+    )
+  }
+
+  const showSetToActiveRegionAlert = () => {
+    showAlert(
+      t("exposure_notification_alerts.set_active_region_ios_title"),
+      t("exposure_notification_alerts.set_active_region_ios_body"),
+    )
+  }
+
+  const showEnableBluetoothAlert = () => {
+    showAlert(
+      t("exposure_notification_alerts.bluetooth_title", {
+        applicationName,
+      }),
+      t("exposure_notification_alerts.bluetooth_body"),
+    )
+  }
+
+  return requestExposureNotifications
+}


### PR DESCRIPTION
Why:
There are many ways that the request to enable gean permissions for the
app could fail. Most of these response failures mean that the user needs to
manually enable the permissions for the app. We would like to be able to
provide specific instructions to the user on how to enable the
permissions.

this commit:
Refactors the api for the requestAuthorization function in the gaen
native module such that it is more clear what the native layer's
response actually was and to make it easier to respond to the specific
error. We provide a mapping on the native layer for a complete list of
error responses such that we can respond to each case on an individual basis.

Co-Authored-By: John Schoeman <johnschoeman1617@gmail.com>
Co-Authored-By; Matt Buckley <matt@nicethings.io>