### PR TITLE
Handle rate limit error on check for exposures

### DIFF
--- a/ios/BT/API/Result.swift
+++ b/ios/BT/API/Result.swift
@@ -10,7 +10,7 @@ public enum Result<T> {
 public enum ExposureResult {
 
   case success(Int)
-  case failure(ExposureError)
+  case failure(Error)
 
 }
 

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -441,9 +441,8 @@ final class ExposureManager: NSObject {
         btSecureStorage.storeExposures(newExposures)
         completionHandler(.success(processedFileCount))
       case let .failure(error):
-        let exposureError = ExposureError.default(error.localizedDescription)
         btSecureStorage.exposureDetectionErrorLocalizedDescription = error.localizedDescription
-        completionHandler(.failure(exposureError))
+        completionHandler(.failure(error))
       }
     }
   }

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -261,8 +261,9 @@ final class ExposureManager: NSObject {
       switch result {
       case .success:
         resolve(String.genericSuccess)
-      case .failure(let exposureError):
-        reject(exposureError.localizedDescription, exposureError.errorDescription, exposureError)
+      case .failure(let error):
+        let errorString = error._code.enErrorString
+        reject(errorString, error.localizedDescription, error)
       }
     }
   }

--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -7,10 +7,8 @@ import React, {
   useContext,
 } from "react"
 
-import { failureResponse, OperationResponse } from "./OperationResponse"
 import { ExposureKey } from "./exposureKey"
 import { ExposureInfo } from "./exposure"
-import { checkForNewExposures as detectExposures } from "./gaen/nativeModule"
 import { useProductAnalyticsContext } from "./ProductAnalytics/Context"
 import * as NativeModule from "./gaen/nativeModule"
 
@@ -24,7 +22,7 @@ export interface ExposureState {
   lastExposureDetectionDate: Posix | null
   storeRevisionToken: (revisionToken: string) => Promise<void>
   refreshExposureInfo: () => void
-  checkForNewExposures: () => Promise<OperationResponse>
+  detectExposures: () => Promise<NativeModule.DetectExposuresResponse>
 }
 
 const initialState = {
@@ -43,7 +41,7 @@ const initialState = {
     return Promise.resolve()
   },
   refreshExposureInfo: () => {},
-  checkForNewExposures: () => {
+  detectExposures: () => {
     return Promise.resolve({ kind: "success" as const })
   },
 }
@@ -98,17 +96,14 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
     }
   }, [trackEvent])
 
-  const checkForNewExposures = async (): Promise<OperationResponse> => {
-    try {
-      const response = await detectExposures()
-      if (response.kind === "failure") {
-        throw new Error(response.error)
-      }
+  const detectExposures = async (): Promise<
+    NativeModule.DetectExposuresResponse
+  > => {
+    const response = await NativeModule.detectExposures()
+    if (response.kind === "success") {
       await refreshExposureInfo()
-      return { kind: "success" }
-    } catch (e) {
-      return failureResponse(e.message)
     }
+    return response
   }
 
   return (
@@ -117,7 +112,7 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
         exposureInfo,
         lastExposureDetectionDate,
         refreshExposureInfo,
-        checkForNewExposures,
+        detectExposures,
         getCurrentExposures: NativeModule.getCurrentExposures,
         getExposureKeys: NativeModule.getExposureKeys,
         getRevisionToken: NativeModule.getRevisionToken,

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -64,13 +64,23 @@ const History: FunctionComponent<HistoryProps> = ({
         message: t("common.success"),
         ...successFlashMessageOptions,
       })
-    } else {
+    } else if (result.kind === "failure") {
       switch (result.error) {
         case "RateLimited":
           showMessage({
             message: t("common.success"),
             ...successFlashMessageOptions,
           })
+          break
+        case "NotAuthorized":
+          showAlert(
+            t(
+              "exposure_notification_alerts.share_exposure_information_ios_title",
+            ),
+            t(
+              "exposure_notification_alerts.share_exposure_information_ios_body",
+            ),
+          )
           break
         default:
           showAlert(

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -1,5 +1,11 @@
 import React, { FunctionComponent, useState } from "react"
-import { StyleSheet, TouchableOpacity, View, ScrollView } from "react-native"
+import {
+  Alert,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  ScrollView,
+} from "react-native"
 import { SvgXml } from "react-native-svg"
 import { useTranslation } from "react-i18next"
 import { useNavigation, useIsFocused } from "@react-navigation/native"
@@ -39,11 +45,8 @@ const History: FunctionComponent<HistoryProps> = ({
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()
   const navigation = useNavigation()
-  const { checkForNewExposures } = useExposureContext()
-  const {
-    successFlashMessageOptions,
-    errorFlashMessageOptions,
-  } = Affordances.useFlashMessageOptions()
+  const { detectExposures } = useExposureContext()
+  const { successFlashMessageOptions } = Affordances.useFlashMessageOptions()
 
   const [checkingForExposures, setCheckingForExposures] = useState<boolean>(
     false,
@@ -55,19 +58,36 @@ const History: FunctionComponent<HistoryProps> = ({
 
   const checkForExposures = async () => {
     setCheckingForExposures(true)
-    const checkResult = await checkForNewExposures()
-    if (checkResult.kind === "success") {
+    const result = await detectExposures()
+    if (result.kind === "success") {
       showMessage({
         message: t("common.success"),
         ...successFlashMessageOptions,
       })
     } else {
-      showMessage({
-        message: t("common.something_went_wrong"),
-        ...errorFlashMessageOptions,
-      })
+      switch (result.error) {
+        case "RateLimited":
+          showMessage({
+            message: t("common.success"),
+            ...successFlashMessageOptions,
+          })
+          break
+        default:
+          showAlert(
+            t("exposure_notification_alerts.unhandled_error_title"),
+            t("exposure_notification_alerts.unhandled_error_body"),
+          )
+      }
     }
     setCheckingForExposures(false)
+  }
+
+  const showAlert = (title: string, body: string) => {
+    Alert.alert(title, body, [
+      {
+        text: t("common.okay"),
+      },
+    ])
   }
 
   const handleOnPressCheckForExposures = async () => {

--- a/src/factories/exposureContext.tsx
+++ b/src/factories/exposureContext.tsx
@@ -9,5 +9,5 @@ export default Factory.define<ExposureState>(() => ({
   storeRevisionToken: (_revisionToken: string) => Promise.resolve(),
   getRevisionToken: () => Promise.resolve(""),
   refreshExposureInfo: () => {},
-  checkForNewExposures: () => Promise.resolve({ kind: "success" }),
+  detectExposures: () => Promise.resolve({ kind: "success" }),
 }))

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -159,7 +159,11 @@ export const fetchLastExposureDetectionDate = async (): Promise<Posix | null> =>
   }
 }
 
-type DetectExposuresError = "RateLimited" | "Unknown"
+type DetectExposuresError =
+  | "RateLimited"
+  | "Unknown"
+  | "NotEnabled"
+  | "NotAuthorized"
 
 export type DetectExposuresResponse =
   | DetectExposuresResponseSuccess
@@ -182,6 +186,10 @@ export const detectExposures = async (): Promise<DetectExposuresResponse> => {
     switch (e.code) {
       case "RateLimited":
         return { kind: "failure", error: "RateLimited" }
+      case "NotEnabled":
+        return { kind: "failure", error: "NotEnabled" }
+      case "NotAuthorized":
+        return { kind: "failure", error: "NotAuthorized" }
       default:
         Logger.error("Unhandled Error in detectExposures", { e })
         return { kind: "failure", error: "Unknown" }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,6 +32,7 @@
     "no_thanks": "No thanks",
     "off": "OFF",
     "on": "ON",
+    "okay": "Okay",
     "save": "Save",
     "select_language": "Select language",
     "settings": "Open Settings",
@@ -490,6 +491,8 @@
     "set_active_region_ios_title": "Set Active Region",
     "set_active_region_ios_body": "Open the Settings app, navigate to the Exposure Notifications settings for this app, then press 'Set As Active Region'.",
     "bluetooth_title": "Enable Bluetooth",
-    "bluetooth_body": "To activate Exposure Notifications, you must first turn on Bluetooth in your Settings app."
+    "bluetooth_body": "To activate Exposure Notifications, you must first turn on Bluetooth in your Settings app.",
+    "unhandled_error_body": "Something unexpected happened. Please close and reopen the app and try again.",
+    "unhandled_error_title": "Something Went Wrong"
   }
 }


### PR DESCRIPTION
Why:
Currently we are handling the case where the gaen api returns a rate
limit error when a user is checking for exposures on the exposure
history screen by rendering a 'Something Went Wrong' flash message. This
is not a great user experience. We would like to improve it. Given that
the rate limit is an implementation detail from the perspective of the
user, we would like to show a 'Success' response here as the user did
successfully check for exposures even despite the rate limit.

Furthermore, we would like to better factor this flow to handle error
messages better in general.

This commit:
- Refactors the error handling of the checkForExposures function.
- Renames the checkForExposures function to `detectExposures`.
- Shows a success flash message when the user hits the rate limit on
detectExposures.

Co-Authored-By: Matt Buckely <matt@nicethings.io>
Co-Authored-By: Devin Jameson <devin@thoughtbot.com>