### PR TITLE
Provide better error message for verification code

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.spec.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Alert } from "react-native"
 import { render, fireEvent, waitFor } from "@testing-library/react-native"
 import "@testing-library/jest-native/extend-expect"
 import { useNavigation } from "@react-navigation/native"
@@ -132,8 +133,10 @@ describe("CodeInputForm", () => {
         error,
       }
       jest.spyOn(API, "postCode").mockResolvedValueOnce(wrongTokenResponse)
+      const alertSpy = jest.fn()
+      Alert.alert = alertSpy
 
-      const { getByTestId, getByLabelText, getByText } = render(
+      const { getByTestId, getByLabelText } = render(
         <AffectedUserProvider>
           <CodeInputForm />
         </AffectedUserProvider>,
@@ -142,7 +145,11 @@ describe("CodeInputForm", () => {
       fireEvent.press(getByLabelText("Next"))
 
       await waitFor(() => {
-        expect(getByText("Try a different code")).toBeDefined()
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Invalid Code",
+          "The verification code you submitted is invalid.\n\nThe code must be a valid verification code provided to you by your health authority.\n\nIt is also possible that your code has expired. If so, you will need to request a new code from your health authority.",
+          [{ text: "Okay" }],
+        )
       })
     })
 
@@ -153,8 +160,10 @@ describe("CodeInputForm", () => {
         error,
       }
       jest.spyOn(API, "postCode").mockResolvedValueOnce(wrongTokenResponse)
+      const alertSpy = jest.fn()
+      Alert.alert = alertSpy
 
-      const { getByTestId, getByLabelText, getByText } = render(
+      const { getByTestId, getByLabelText } = render(
         <AffectedUserProvider>
           <CodeInputForm />
         </AffectedUserProvider>,
@@ -163,9 +172,11 @@ describe("CodeInputForm", () => {
       fireEvent.press(getByLabelText("Next"))
 
       await waitFor(() => {
-        expect(
-          getByText("Verification code has already been used"),
-        ).toBeDefined()
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Verification Code Already Used",
+          "The verification code provided has already been used.",
+          [{ text: "Okay" }],
+        )
       })
     })
 
@@ -176,8 +187,10 @@ describe("CodeInputForm", () => {
         error,
       }
       jest.spyOn(API, "postCode").mockResolvedValueOnce(wrongTokenResponse)
+      const alertSpy = jest.fn()
+      Alert.alert = alertSpy
 
-      const { getByTestId, getByLabelText, getByText } = render(
+      const { getByTestId, getByLabelText } = render(
         <AffectedUserProvider>
           <CodeInputForm />
         </AffectedUserProvider>,
@@ -186,7 +199,11 @@ describe("CodeInputForm", () => {
       fireEvent.press(getByLabelText("Next"))
 
       await waitFor(() => {
-        expect(getByText("Try a different code")).toBeDefined()
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Something Went Wrong",
+          "An unexpected error occured. Please try again.",
+          [{ text: "Okay" }],
+        )
       })
     })
 

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -114,14 +114,8 @@ const CodeInputForm: FunctionComponent = () => {
           )
           setErrorMessage(errorMessage)
         }
-      } else {
-        const errorMessage = showError(response.error)
-        if (response.message) {
-          Logger.error(
-            `FailedCodeValidation${errorMessage}, ${response.message}`,
-          )
-        }
-        setErrorMessage(errorMessage)
+      } else if (response.kind === "failure") {
+        showError(response.error)
       }
       setIsLoading(false)
     } catch (e) {
@@ -130,22 +124,50 @@ const CodeInputForm: FunctionComponent = () => {
     }
   }
 
-  const showError = (error: API.CodeVerificationError): string => {
+  const showError = (error: API.CodeVerificationError): void => {
     switch (error) {
-      case "InvalidCode": {
-        return t("export.error.invalid_code")
-      }
-      case "VerificationCodeUsed": {
-        return t("export.error.verification_code_used")
-      }
-      case "NetworkConnection": {
-        return t("export.error.network_connection_error")
-      }
-      case "Timeout": {
-        return t("export.error.timeout_error")
-      }
+      case "InvalidCode":
+        {
+          Alert.alert(
+            t("verification_code_alerts.invalid_code_title"),
+            t("verification_code_alerts.invalid_code_body"),
+            [{ text: t("common.okay") }],
+          )
+        }
+        break
+      case "VerificationCodeUsed":
+        {
+          Alert.alert(
+            t("verification_code_alerts.code_used_title"),
+            t("verification_code_alerts.code_used_body"),
+            [{ text: t("common.okay") }],
+          )
+        }
+        break
+      case "NetworkConnection":
+        {
+          Alert.alert(
+            t("verification_code_alerts.network_connection_title"),
+            t("verification_code_alerts.network_connection_body"),
+            [{ text: t("common.okay") }],
+          )
+        }
+        break
+      case "Timeout":
+        {
+          Alert.alert(
+            t("verification_code_alerts.invalid_code_title"),
+            t("verification_code_alerts.invalid_code_body"),
+            [{ text: t("common.okay") }],
+          )
+        }
+        break
       default: {
-        return t("export.error.unknown_code_verification_error")
+        Alert.alert(
+          t("verification_code_alerts.unknown_title"),
+          t("verification_code_alerts.unknown_body"),
+          [{ text: t("common.okay") }],
+        )
       }
     }
   }

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -163,6 +163,7 @@ class PostDiagnosisKeysRequest {
         }
       }
       default: {
+        Logger.error("Unhandled Post DiagnosisKeys Error", { error })
         return {
           kind: "failure" as const,
           nature: PostKeysError.Unknown,

--- a/src/AffectedUserFlow/verificationAPI.ts
+++ b/src/AffectedUserFlow/verificationAPI.ts
@@ -1,6 +1,7 @@
 import env from "react-native-config"
 
 import { fetchWithTimeout, TIMEOUT_ERROR } from "./fetchWithTimeout"
+import Logger from "../logger"
 
 const baseUrl = env.GAEN_VERIFY_URL
 const verifyUrl = `${baseUrl}/api/verify`
@@ -71,11 +72,14 @@ export const postCode = async (
       return { kind: "success", body }
     } else {
       switch (json.error) {
-        case "internal server error":
+        case "verification code invalid":
           return { kind: "failure", error: "InvalidCode" }
         case "verification code used":
           return { kind: "failure", error: "VerificationCodeUsed" }
         default:
+          Logger.error("Unhandled Verification Code Submission Error", {
+            error: json.error,
+          })
           return { kind: "failure", error: "Unknown", message: json.error }
       }
     }
@@ -86,6 +90,9 @@ export const postCode = async (
       case TIMEOUT_ERROR:
         return { kind: "failure", error: "Timeout" }
       default:
+        Logger.error("Unhandled Verification Code Submission Error", {
+          errorMessage: e.message,
+        })
         return { kind: "failure", error: "Unknown" }
     }
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -494,5 +494,17 @@
     "bluetooth_body": "To activate Exposure Notifications, you must first turn on Bluetooth in your Settings app.",
     "unhandled_error_body": "Something unexpected happened. Please close and reopen the app and try again.",
     "unhandled_error_title": "Something Went Wrong"
+  },
+  "verification_code_alerts": {
+    "invalid_code_title": "Invalid Code",
+    "invalid_code_body": "The verification code you submitted is invalid.\n\nThe code must be a valid verification code provided to you by your health authority.\n\nIt is also possible that your code has expired. If so, you will need to request a new code from your health authority.",
+    "code_used_title": "Verification Code Already Used",
+    "code_used_body": "The verification code provided has already been used.",
+    "network_connection_title": "No Internet Connection",
+    "network_connection_body": "You need to be connected to WiFi to submit a verification code.",
+    "timeout_title": "Submission Took Too Long",
+    "timeout_body": "It took to long to submit the verificaiton code. Please try again later.",
+    "unknown_title": "Something Went Wrong",
+    "unknown_body": "An unexpected error occured. Please try again."
   }
 }


### PR DESCRIPTION
Why:
Currently if a user provides an invalid verification code we simply show
a 'Try again' validation message. This is a confusing experience and we
would like to show a more throughly explained error message.

This commit:
Updates the error messages show on the submit verification code form.


|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 12 Pro Max - 2020-12-01 at 14 20 17](https://user-images.githubusercontent.com/16049495/100803648-6085bb80-33e0-11eb-8f20-70cc05a458dd.png)|![Simulator Screen Shot - iPhone 12 Pro Max - 2020-12-01 at 13 37 31](https://user-images.githubusercontent.com/16049495/100803663-6380ac00-33e0-11eb-96e8-632a9821b481.png)|
