### PR TITLE
Show exposure notification error alerts before exposure check

### DIFF
--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -14,6 +14,7 @@ import { DateTimeUtils } from "../../utils"
 import { factories } from "../../factories"
 import { ExposureContext } from "../../ExposureContext"
 import * as NativeModule from "../../gaen/nativeModule"
+import { PermissionsContext } from "../../Device/PermissionsContext"
 
 import History from "./index"
 
@@ -41,122 +42,178 @@ describe("History", () => {
   })
 
   describe("when the check for exposures button is tapped", () => {
-    it("checks for new exposures", async () => {
-      const exposures: ExposureDatum[] = []
-      const checkForNewExposuresSpy = jest
-        .fn()
-        .mockResolvedValueOnce({ kind: "success" })
-
-      const { getByTestId } = render(
-        <ExposureContext.Provider
-          value={factories.exposureContext.build({
-            detectExposures: checkForNewExposuresSpy,
-          })}
-        >
-          <History exposures={exposures} lastDetectionDate={null} />
-        </ExposureContext.Provider>,
-      )
-
-      fireEvent.press(getByTestId("check-for-exposures-button"))
-
-      await waitFor(() => {
-        expect(checkForNewExposuresSpy).toHaveBeenCalled()
-      })
-    })
-
-    describe("when exposure check returns rate limiting error", () => {
-      it("displays a success message", async () => {
-        const showMessageSpy = showMessage as jest.Mock
-        const response: NativeModule.DetectExposuresResponse = {
-          kind: "failure",
-          error: "RateLimited",
-        }
-        const checkForNewExposuresSpy = jest
-          .fn()
-          .mockResolvedValueOnce(response)
-
-        const { getByTestId } = render(
-          <ExposureContext.Provider
-            value={factories.exposureContext.build({
-              detectExposures: checkForNewExposuresSpy,
-            })}
-          >
-            <History exposures={[]} lastDetectionDate={null} />
-          </ExposureContext.Provider>,
-        )
-
-        fireEvent.press(getByTestId("check-for-exposures-button"))
-
-        await waitFor(() => {
-          expect(showMessageSpy).toHaveBeenCalledWith(
-            expect.objectContaining({
-              message: "Success",
-            }),
-          )
-        })
-      })
-    })
-
-    describe("when exposure check is successful", () => {
-      it("displays a success message", async () => {
-        const checkForNewExposuresSpy = jest.fn()
-        const showMessageSpy = showMessage as jest.Mock
-        const response: NativeModule.DetectExposuresResponse = {
-          kind: "success",
-        }
-        checkForNewExposuresSpy.mockResolvedValueOnce(response)
-
-        const { getByTestId } = render(
-          <ExposureContext.Provider
-            value={factories.exposureContext.build({
-              detectExposures: checkForNewExposuresSpy,
-            })}
-          >
-            <History exposures={[]} lastDetectionDate={null} />
-          </ExposureContext.Provider>,
-        )
-
-        fireEvent.press(getByTestId("check-for-exposures-button"))
-
-        await waitFor(() => {
-          expect(showMessageSpy).toHaveBeenCalledWith(
-            expect.objectContaining({
-              message: "Success",
-            }),
-          )
-        })
-      })
-    })
-
-    describe("when exposure check is not successful", () => {
-      it("displays a failure message", async () => {
-        const checkForNewExposuresSpy = jest.fn()
-        const response: NativeModule.DetectExposuresResponse = {
-          kind: "failure",
-          error: "Unknown",
-        }
-        checkForNewExposuresSpy.mockResolvedValueOnce(response)
+    describe("and exposure notifications are not active", () => {
+      it("displays a can't check for exposures message", async () => {
         const alertSpy = jest.fn()
         Alert.alert = alertSpy
 
         const { getByTestId } = render(
-          <ExposureContext.Provider
-            value={factories.exposureContext.build({
-              detectExposures: checkForNewExposuresSpy,
+          <PermissionsContext.Provider
+            value={factories.permissionsContext.build({
+              exposureNotifications: { status: "Disabled" },
             })}
           >
             <History exposures={[]} lastDetectionDate={null} />
-          </ExposureContext.Provider>,
+          </PermissionsContext.Provider>,
         )
 
         fireEvent.press(getByTestId("check-for-exposures-button"))
 
         await waitFor(() => {
           expect(alertSpy).toHaveBeenCalledWith(
-            "Something Went Wrong",
-            "Something unexpected happened. Please close and reopen the app and try again.",
-            [{ text: "Okay" }],
+            "Can't Check for Exposures",
+            "You must enable Exposure Notifications to check for exposures.",
+            [
+              expect.objectContaining({ text: "Back" }),
+              expect.objectContaining({ text: "Tell Me How" }),
+            ],
           )
+        })
+      })
+    })
+
+    describe("and exposure notifications are active", () => {
+      it("checks for new exposures", async () => {
+        const exposures: ExposureDatum[] = []
+        const checkForNewExposuresSpy = jest
+          .fn()
+          .mockResolvedValueOnce({ kind: "success" })
+
+        const { getByTestId } = render(
+          <PermissionsContext.Provider
+            value={factories.permissionsContext.build({
+              exposureNotifications: { status: "Active" },
+            })}
+          >
+            <ExposureContext.Provider
+              value={factories.exposureContext.build({
+                detectExposures: checkForNewExposuresSpy,
+              })}
+            >
+              <History exposures={exposures} lastDetectionDate={null} />
+            </ExposureContext.Provider>
+          </PermissionsContext.Provider>,
+        )
+
+        fireEvent.press(getByTestId("check-for-exposures-button"))
+
+        await waitFor(() => {
+          expect(checkForNewExposuresSpy).toHaveBeenCalled()
+        })
+      })
+
+      describe("when exposure check returns rate limiting error", () => {
+        it("displays a success message", async () => {
+          const showMessageSpy = showMessage as jest.Mock
+          const response: NativeModule.DetectExposuresResponse = {
+            kind: "failure",
+            error: "RateLimited",
+          }
+          const checkForNewExposuresSpy = jest
+            .fn()
+            .mockResolvedValueOnce(response)
+
+          const { getByTestId } = render(
+            <PermissionsContext.Provider
+              value={factories.permissionsContext.build({
+                exposureNotifications: { status: "Active" },
+              })}
+            >
+              <ExposureContext.Provider
+                value={factories.exposureContext.build({
+                  detectExposures: checkForNewExposuresSpy,
+                })}
+              >
+                <History exposures={[]} lastDetectionDate={null} />
+              </ExposureContext.Provider>
+            </PermissionsContext.Provider>,
+          )
+
+          fireEvent.press(getByTestId("check-for-exposures-button"))
+
+          await waitFor(() => {
+            expect(showMessageSpy).toHaveBeenCalledWith(
+              expect.objectContaining({
+                message: "Success",
+              }),
+            )
+          })
+        })
+      })
+
+      describe("when exposure check is successful", () => {
+        it("displays a success message", async () => {
+          const checkForNewExposuresSpy = jest.fn()
+          const showMessageSpy = showMessage as jest.Mock
+          const response: NativeModule.DetectExposuresResponse = {
+            kind: "success",
+          }
+          checkForNewExposuresSpy.mockResolvedValueOnce(response)
+
+          const { getByTestId } = render(
+            <PermissionsContext.Provider
+              value={factories.permissionsContext.build({
+                exposureNotifications: { status: "Active" },
+              })}
+            >
+              <ExposureContext.Provider
+                value={factories.exposureContext.build({
+                  detectExposures: checkForNewExposuresSpy,
+                })}
+              >
+                <History exposures={[]} lastDetectionDate={null} />
+              </ExposureContext.Provider>
+            </PermissionsContext.Provider>,
+          )
+
+          fireEvent.press(getByTestId("check-for-exposures-button"))
+
+          await waitFor(() => {
+            expect(showMessageSpy).toHaveBeenCalledWith(
+              expect.objectContaining({
+                message: "Success",
+              }),
+            )
+          })
+        })
+      })
+
+      describe("when exposure check is not successful", () => {
+        it("displays a failure message", async () => {
+          const checkForNewExposuresSpy = jest.fn()
+          const response: NativeModule.DetectExposuresResponse = {
+            kind: "failure",
+            error: "Unknown",
+          }
+          checkForNewExposuresSpy.mockResolvedValueOnce(response)
+          const alertSpy = jest.fn()
+          Alert.alert = alertSpy
+
+          const { getByTestId } = render(
+            <PermissionsContext.Provider
+              value={factories.permissionsContext.build({
+                exposureNotifications: { status: "Active" },
+              })}
+            >
+              <ExposureContext.Provider
+                value={factories.exposureContext.build({
+                  detectExposures: checkForNewExposuresSpy,
+                })}
+              >
+                <History exposures={[]} lastDetectionDate={null} />
+              </ExposureContext.Provider>
+            </PermissionsContext.Provider>,
+          )
+
+          fireEvent.press(getByTestId("check-for-exposures-button"))
+
+          await waitFor(() => {
+            expect(alertSpy).toHaveBeenCalledWith(
+              "Something Went Wrong",
+              "Something unexpected happened. Please close and reopen the app and try again.",
+              [{ text: "Okay" }],
+            )
+          })
         })
       })
     })

--- a/src/ExposureHistory/History/index.spec.tsx
+++ b/src/ExposureHistory/History/index.spec.tsx
@@ -65,7 +65,9 @@ describe("History", () => {
             "You must enable Exposure Notifications to check for exposures.",
             [
               expect.objectContaining({ text: "Back" }),
-              expect.objectContaining({ text: "Tell Me How" }),
+              expect.objectContaining({
+                text: "Enable Exposure Notifications",
+              }),
             ],
           )
         })

--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -29,6 +29,8 @@ import {
   Affordances,
   Iconography,
 } from "../../styles"
+import { usePermissionsContext } from "../../Device/PermissionsContext"
+import { useRequestExposureNotifications } from "../../useRequestExposureNotifications"
 
 type Posix = number
 
@@ -47,6 +49,10 @@ const History: FunctionComponent<HistoryProps> = ({
   const navigation = useNavigation()
   const { detectExposures } = useExposureContext()
   const { successFlashMessageOptions } = Affordances.useFlashMessageOptions()
+  const {
+    exposureNotifications: { status },
+  } = usePermissionsContext()
+  const requestExposureNotifications = useRequestExposureNotifications()
 
   const [checkingForExposures, setCheckingForExposures] = useState<boolean>(
     false,
@@ -54,6 +60,25 @@ const History: FunctionComponent<HistoryProps> = ({
 
   const handleOnPressMoreInfo = () => {
     navigation.navigate(ExposureHistoryStackScreens.MoreInfo)
+  }
+
+  const showEnableExposureNotificationsAlert = () => {
+    Alert.alert(
+      t("exposure_notification_alerts.cant_check_for_exposures_title"),
+      t("exposure_notification_alerts.cant_check_for_exposures_body"),
+      [
+        {
+          text: t("common.back"),
+          style: "cancel",
+        },
+        {
+          text: t(
+            "exposure_notification_alerts.cant_check_for_exposures_button",
+          ),
+          onPress: () => requestExposureNotifications(),
+        },
+      ],
+    )
   }
 
   const checkForExposures = async () => {
@@ -101,7 +126,11 @@ const History: FunctionComponent<HistoryProps> = ({
   }
 
   const handleOnPressCheckForExposures = async () => {
-    await checkForExposures()
+    if (status !== "Active") {
+      showEnableExposureNotificationsAlert()
+    } else {
+      await checkForExposures()
+    }
   }
 
   const showExposureHistory = exposures.length > 0

--- a/src/factories/permissionsContext.ts
+++ b/src/factories/permissionsContext.ts
@@ -11,7 +11,5 @@ export default Factory.define<PermissionsContextState>(() => ({
   },
   exposureNotifications: {
     status: "Active",
-    check: jest.fn(),
-    request: jest.fn(),
   },
 }))

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -113,7 +113,7 @@ export const requestAuthorization = async (): Promise<
       status: toStatus(enStatus),
     }
   } catch (e) {
-    switch (e) {
+    switch (e.code) {
       case "NotEntitled":
         return { kind: "failure", error: "NotEntitled" }
       case "NotAuthorized":

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,6 +24,7 @@
     "continue": "Continue",
     "done": "Done",
     "edit": "Edit",
+    "enable": "Enable",
     "learn_more": "Learn more",
     "maybe_later": "Maybe later",
     "more": "More",
@@ -505,6 +506,9 @@
     "timeout_title": "Submission Took Too Long",
     "timeout_body": "It took to long to submit the verificaiton code. Please try again later.",
     "unknown_title": "Something Went Wrong",
-    "unknown_body": "An unexpected error occured. Please try again."
+    "unknown_body": "An unexpected error occured. Please try again.",
+    "cant_check_for_exposures_title": "Can't Check for Exposures",
+    "cant_check_for_exposures_body": "You must enable Exposure Notifications to check for exposures.",
+    "cant_check_for_exposures_button": "Tell Me How"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -494,7 +494,10 @@
     "bluetooth_title": "Enable Bluetooth",
     "bluetooth_body": "To activate Exposure Notifications, you must first turn on Bluetooth in your Settings app.",
     "unhandled_error_body": "Something unexpected happened. Please close and reopen the app and try again.",
-    "unhandled_error_title": "Something Went Wrong"
+    "unhandled_error_title": "Something Went Wrong",
+    "cant_check_for_exposures_title": "Can't Check for Exposures",
+    "cant_check_for_exposures_body": "You must enable Exposure Notifications to check for exposures.",
+    "cant_check_for_exposures_button": "Enable Exposure Notifications"
   },
   "verification_code_alerts": {
     "invalid_code_title": "Invalid Code",
@@ -506,9 +509,6 @@
     "timeout_title": "Submission Took Too Long",
     "timeout_body": "It took to long to submit the verificaiton code. Please try again later.",
     "unknown_title": "Something Went Wrong",
-    "unknown_body": "An unexpected error occured. Please try again.",
-    "cant_check_for_exposures_title": "Can't Check for Exposures",
-    "cant_check_for_exposures_body": "You must enable Exposure Notifications to check for exposures.",
-    "cant_check_for_exposures_button": "Enable Exposure Notifications"
+    "unknown_body": "An unexpected error occured. Please try again."
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -509,6 +509,6 @@
     "unknown_body": "An unexpected error occured. Please try again.",
     "cant_check_for_exposures_title": "Can't Check for Exposures",
     "cant_check_for_exposures_body": "You must enable Exposure Notifications to check for exposures.",
-    "cant_check_for_exposures_button": "Tell Me How"
+    "cant_check_for_exposures_button": "Enable Exposure Notifications"
   }
 }


### PR DESCRIPTION
Why: if the user does *not* have exposure notifications enabled, the check for exposures will fail. So, before checking for exposures, we would like to ensure the user has exposure notifications enabled.

This commit:
- Checks whether the user has exposure notifications enabled before checking for exposures
- If the user does not have exposure notifications enabled, we tell them that we can't check for exposures unless that have exposure notifications enabled and provide a "Tell Me How" button
- If the user presses the "Tell Me How" button, we give them guidance on how to enable exposure notifications

Co-Authored-By: Matt Buckley <matt@nicethings.io>


![2020-12-01 17-39-56 2020-12-01 17_47_11](https://user-images.githubusercontent.com/39350030/100805759-427a8400-33fd-11eb-9f35-2a9c64798697.gif)