### PR TITLE
Handle SMS long code verification links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,18 @@
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize">
+            <intent-filter >
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Accepts URIs that begin with "https://app.associateddomain.org/” -->
+                <!-- Change android:host field to a registered domain -->
+                <data 
+                    android:scheme="https"
+                    android:host="app.associateddomain.org"
+                    android:pathPrefix="/" 
+                  />
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/example.env.bt
+++ b/example.env.bt
@@ -70,3 +70,6 @@ ANDROID_APPLICATION_ID='org.pathcheck.pc.bt'
 ANDROID_PLAY_STORE_URL=
 IOS_APP_STORE_URL=
 IOS_BUNDLE_ID='org.pathcheck.bt'
+
+// Deep Linking
+DEEP_LINK_PREFIXES=["pathcheck://", "https://app.associateddomain.org"]

--- a/ios/AppDelegate.m
+++ b/ios/AppDelegate.m
@@ -158,6 +158,13 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
   return [RCTLinkingManager application:application openURL:url options:options];
 }
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity
+ restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
+{
+ return [RCTLinkingManager application:application
+                  continueUserActivity:userActivity
+                    restorationHandler:restorationHandler];
+}
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
 didReceiveNotificationResponse:(UNNotificationResponse *)response
          withCompletionHandler:(void (^)(void))completionHandler

--- a/ios/BT/BT-Development.entitlements
+++ b/ios/BT/BT-Development.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>Development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:app.associateddomain.org</string>
+	</array>
 	<key>com.apple.developer.exposure-notification</key>
 	<true/>
 </dict>

--- a/ios/BT/BT-Production.entitlements
+++ b/ios/BT/BT-Production.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>Production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:app.associateddomain.org</string>
+	</array>
 	<key>com.apple.developer.exposure-notification</key>
 	<true/>
 </dict>

--- a/src/AffectedUserFlow/AffectedUserContext.tsx
+++ b/src/AffectedUserFlow/AffectedUserContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useContext,
 } from "react"
+import { CommonActions } from "@react-navigation/native"
 
 import { ExposureKey } from "../exposureKey"
 
@@ -16,6 +17,7 @@ interface AffectedUserContextState {
   exposureKeys: ExposureKey[]
   setExposureKeys: (keys: ExposureKey[]) => void
   setExposureSubmissionCredentials: (certificate: Token, hmacKey: Key) => void
+  toHome: (homeRouteName: string, navigation: Readonly<any>) => void
 }
 
 export const AffectedUserContext = createContext<
@@ -26,6 +28,18 @@ export const AffectedUserProvider: FunctionComponent = ({ children }) => {
   const [exposureKeys, setExposureKeys] = useState<ExposureKey[]>([])
   const [hmacKey, setHmacKey] = useState<Key | null>(null)
   const [certificate, setCertificate] = useState<Token | null>(null)
+  // Clears routes so "App" route can be first and prevent strange re-render behavior.
+  // navigation object on the provider does not have params, so it requires the navigation object at the screen level.
+  const toHome = (homeRouteName: string, navigation: Readonly<any>) =>
+  navigation.dispatch((state: Readonly<any>) => {
+    if (state.routes[0].params) {
+      return CommonActions.reset({
+        index: 1,
+        routes: [{ name: "App" }],
+      })
+    }
+    return CommonActions.navigate(homeRouteName)
+  })
 
   const setExposureSubmissionCredentials = (
     certificate: Token,
@@ -43,6 +57,7 @@ export const AffectedUserProvider: FunctionComponent = ({ children }) => {
         exposureKeys,
         setExposureKeys,
         setExposureSubmissionCredentials,
+        toHome
       }}
     >
       {children}

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react"
+import React, { FunctionComponent, useState, useEffect } from "react"
 import {
   Alert,
   StyleSheet,
@@ -10,7 +10,7 @@ import {
   Platform,
   TouchableOpacity,
 } from "react-native"
-import { useNavigation } from "@react-navigation/native"
+import { useNavigation, useRoute } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 
@@ -42,6 +42,7 @@ const CodeInputForm: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()
   const navigation = useNavigation()
+  const route = useRoute()
   const strategy = useExposureContext()
   const { trackEvent } = useProductAnalyticsContext()
   const {
@@ -77,6 +78,14 @@ const CodeInputForm: FunctionComponent = () => {
   const handleOnPressSecondaryButton = () => {
     navigation.navigate(AffectedUserFlowStackScreens.VerificationCodeInfo)
   }
+  
+  useEffect(() => {
+    // Check for code in query string and set the code.
+    if (route.params && "c" in route.params) {
+      setCode(route.params.c)
+    }
+    // Prevent user from changing the code.
+  }, [code, route.params])
 
   const handleOnPressSubmit = async () => {
     setIsLoading(true)

--- a/src/AffectedUserFlow/Complete.tsx
+++ b/src/AffectedUserFlow/Complete.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next"
 
 import { StatusBar, Text } from "../components"
 import { useStatusBarEffect, Stacks } from "../navigation"
+import { useAffectedUserContext } from "./AffectedUserContext"
 
 import { Images } from "../assets"
 import { Buttons, Colors, Layout, Spacing, Typography } from "../styles"
@@ -13,10 +14,8 @@ export const AffectedUserComplete: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()
   const navigation = useNavigation()
-
-  const handleOnPressDone = () => {
-    navigation.navigate(Stacks.Home)
-  }
+  const { toHome } = useAffectedUserContext()
+  const handleOnPressDone = () => toHome(Stacks.Home, navigation)
 
   return (
     <>

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -40,6 +40,7 @@ interface PublishConsentFormProps {
   storeRevisionToken: (revisionToken: string) => Promise<void>
   appPackageName: string
   regionCodes: string[]
+  toHome: (homeKeyName: string, navigation: Readonly<any>) => void
 }
 
 const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
@@ -50,6 +51,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
   storeRevisionToken,
   appPackageName,
   regionCodes,
+  toHome,
 }) => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const navigation = useNavigation()
@@ -180,7 +182,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
         { text: t("common.cancel"), style: "cancel" },
         {
           text: t("common.confirm"),
-          onPress: () => navigation.navigate(HomeStackScreens.Home),
+          onPress: () => toHome(HomeStackScreens.Home, navigation),
           style: "destructive",
         },
       ],

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
@@ -16,7 +16,7 @@ const PublishConsentScreen: FunctionComponent = () => {
   const [revisionToken, setRevisionToken] = useState("")
   const { storeRevisionToken, getRevisionToken } = useExposureContext()
   const navigation = useNavigation()
-  const { certificate, hmacKey, exposureKeys } = useAffectedUserContext()
+  const { certificate, hmacKey, exposureKeys, toHome } = useAffectedUserContext()
   const { appPackageName, regionCodes } = useConfigurationContext()
 
   useEffect(() => {
@@ -35,6 +35,7 @@ const PublishConsentScreen: FunctionComponent = () => {
         revisionToken={revisionToken}
         appPackageName={appPackageName}
         regionCodes={regionCodes}
+        toHome={toHome}
       />
     )
   } else {

--- a/src/navigation/HeaderLeftBackButton.tsx
+++ b/src/navigation/HeaderLeftBackButton.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
 import { HeaderBackButton } from "@react-navigation/stack"
-import { useNavigation } from "@react-navigation/native"
+import { useNavigation, CommonActions } from "@react-navigation/native"
 
 import { Colors } from "../styles"
 
@@ -15,12 +15,23 @@ export const applyHeaderLeftBackButton = () => {
 const HeaderLeftBackButton = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
-
+  // Go back to the Dashboard if there are no routes to go back.
+  const handleBack = () =>
+    navigation.dispatch(() => {
+      if (navigation.canGoBack()) {
+        return CommonActions.goBack()
+      }
+      // Navigate to route "name: App" since "Home" is not the base route name.
+      return CommonActions.reset({
+        index: 1,
+        routes: [{ name: "App" }],
+      })
+    })
   return (
     <HeaderBackButton
       label={t("common.back")}
       tintColor={Colors.primary.shade150}
-      onPress={() => navigation.goBack()}
+      onPress={handleBack}
     />
   )
 }

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -5,6 +5,7 @@ import {
   HeaderStyleInterpolators,
 } from "@react-navigation/stack"
 import { Platform } from "react-native"
+import env from "react-native-config"
 import {
   LinkingOptions,
   NavigationContainer,
@@ -50,12 +51,20 @@ const settingsStackTransitionPreset = Platform.select({
   ios: TransitionPresets.SlideFromRightIOS,
   android: TransitionPresets.DefaultTransition,
 })
+// Import and use configurable link prefixes array
+const linkPrefixes = JSON.parse(env.DEEP_LINK_PREFIXES)
 
 const linking: LinkingOptions = {
-  prefixes: ["pathcheck://"],
+  prefixes: linkPrefixes,
   config: {
     screens: {
       ExposureHistory: "exposureHistory",
+      // Navigate to Code Input from linkPrefix/v?c=[longcode]
+      AffectedUserStack: {
+        screens: {
+          AffectedUserCodeInput: "v",
+        },
+      },
     },
   },
 }


### PR DESCRIPTION
Why:
Currently the code does not handle SMS links containing the verification long code (e.g., `appname://v?r=[region]&c=[longcode]`, `https://app.associateddomain.org/v?c=[longcode]`, etc.)

This commit:
- Opens the app when following a link from an associated domain.
- Navigates to the code input form if path is `/v`, and auto populates the code field if `c=[longcode]` parameter exists. The long code cannot be modified, so the user must continue or go back. Long code will not persist if the user goes back.
- Resets routes and navigates to `App` route if `Home` route does not exist. This prevents strange behavior and re-renders if `App` route is not the first route (index 0).
- Fixes back button when taken directly to code input form from link.
- Uses env variable `DEEP_LINK_PREFIXES` to make it customizable for different HAs.
- Adds basic deep link handler in `AndroidManifest.xml` and `BT-*.entitlements` files with `https://app.associateddomain.org/` as the customizable dummy field for each HA.

Additional requirements:
HAs using Universal Links/Android App Links must upload the proper files to `https://<domain>/.well-known/apple-app-site-association` and `https://<domain>/.well-known/assetlinks.json`.