### PR TITLE
GAEN-537 Upgrade WorkManager to fix a crash

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -238,7 +238,7 @@ dependencies {
     // Annotation processing
     kapt 'com.google.auto.value:auto-value:1.7.3'
     // Libraries
-    implementation 'androidx.work:work-runtime:2.5.0-beta01'
+    implementation 'androidx.work:work-runtime:2.5.0-beta02'
     implementation 'androidx.concurrent:concurrent-futures:1.1.0'
     implementation 'com.google.android.gms:play-services-base:17.4.0'
     implementation 'com.google.android.gms:play-services-basement:17.4.0'


### PR DESCRIPTION
#### Why:

<!-- Provide context to the reader as to why this PR is useful or needed. -->
We detected a crash happening on some Samsung devices.

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->
Google released a new version of WorkManager that should fix it.
This commit upgrades the WorkManager version to 2.5.0-beta02
