### PR TITLE
Adjust iOS scoring threshold.

### DIFF
--- a/ios/BT/Extensions/Exposure Notifications/Scoring.swift
+++ b/ios/BT/Extensions/Exposure Notifications/Scoring.swift
@@ -51,6 +51,10 @@ extension ENExposureDaySummary: Scoring {
   typealias T = DailySummariesConfiguration
 
   func isAboveScoreThreshold(with configuration: DailySummariesConfiguration) -> Bool {
-    return Int(daySummary.weightedDurationSum) >= configuration.triggerThresholdWeightedDuration
+    // Note: weightedDurationSum is measured in seconds
+    // (https://developer.apple.com/documentation/exposurenotification/enexposuresummaryitem/3644417-weighteddurationsum),
+    // while the config value is set in minutes, so it needs to be multiplied by 60 for this check.
+
+    return Int(daySummary.weightedDurationSum) >= configuration.triggerThresholdWeightedDuration * 60
   }
 }

--- a/ios/COVIDSafePathsTests/DailySummariesConfigurationUnitTests.swift
+++ b/ios/COVIDSafePathsTests/DailySummariesConfigurationUnitTests.swift
@@ -76,7 +76,7 @@ class DailySummariesConfigurationUnitTests: XCTestCase {
       return daySummaryItem
     }
     daySummaryItem.weightedDurationSumHandler = {
-      return TimeInterval(config.triggerThresholdWeightedDuration)
+      return TimeInterval(config.triggerThresholdWeightedDuration * 60) // 15 minutes
     }
     let isAboveThreshold = daySummary.isAboveScoreThreshold(with: config)
 
@@ -93,7 +93,7 @@ class DailySummariesConfigurationUnitTests: XCTestCase {
       return daySummaryItem
     }
     daySummaryItem.weightedDurationSumHandler = {
-      return TimeInterval(config.triggerThresholdWeightedDuration + 1)
+      return TimeInterval(config.triggerThresholdWeightedDuration * 60) + 1 // 15:01
     }
     let isAboveThreshold = daySummary.isAboveScoreThreshold(with: config)
 

--- a/ios/COVIDSafePathsTests/XCTestCase+Extensions.swift
+++ b/ios/COVIDSafePathsTests/XCTestCase+Extensions.swift
@@ -123,7 +123,7 @@ extension XCTestCase {
     
     let enExposureSummaryItemMock = MockENExposureSummaryItem()
     enExposureSummaryItemMock.weightedDurationSumHandler = {
-      return forceRiskScore == .aboveThreshold ? 20 : 0
+      return forceRiskScore == .aboveThreshold ? 1200 : 0 // 20 minutes : 0 minutes
     }
     
     let enExposureDaySummaryMock = MockENExposureDaySummary()


### PR DESCRIPTION
#### Why:
We'd like the scoring threshold check to reflect the original intention and be consistent across platforms.

#### This commit:
This commit brings the scoring threshold check for devices running `iOS 13.7+` in line with the Android implementation; the android implementation appropriately converts the the `weightedDurationSum` to minutes before making the comparison (https://github.com/Path-Check/gaen-mobile/blob/79e4d0091417fb71533edd3195d049b243be1fcd/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/ExposureNotificationClientWrapper.java#L229), and this commit performs the identical check in reverse, converting the `triggerThresholdWeightedDuration` value to seconds to perform the check