### PR TITLE
Treat `BluetoothOff` as Error when requesting to enable Exposure Notifications (iOS)

### DIFF
--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -296,7 +296,7 @@ class ExposureManagerUnitTests: XCTestCase {
     
     let notificationCenterMock = NotificationCenterMock()
     notificationCenterMock.addObserverHandler = { (_, _, name, _) in
-      if name == Notification.Name.AuthorizationStatusDidChange {
+      if name == Notification.Name.ExposureNotificationStatusDidChange {
         registerNotificationExpectation.fulfill()
       }
     }
@@ -335,7 +335,7 @@ class ExposureManagerUnitTests: XCTestCase {
     let broadcastAuthorizationStateExpectation = self.expectation(description: "A notification is post with the current authorization and enabled stated")
     let notificationCenterMock = NotificationCenterMock()
     notificationCenterMock.postHandler = { notification in
-      if notification.name == .AuthorizationStatusDidChange {
+      if notification.name == .ExposureNotificationStatusDidChange {
         broadcastAuthorizationStateExpectation.fulfill()
       }
     }
@@ -380,7 +380,7 @@ class ExposureManagerUnitTests: XCTestCase {
     let notificationCenterMock = NotificationCenterMock()
 
     notificationCenterMock.postHandler = { notification in
-      if notification.name == .AuthorizationStatusDidChange {
+      if notification.name == .ExposureNotificationStatusDidChange {
         broadcastAuthorizationStateExpectation.fulfill()
       }
     }
@@ -414,7 +414,7 @@ class ExposureManagerUnitTests: XCTestCase {
     }
     let notificationCenterMock = NotificationCenterMock()
     notificationCenterMock.postHandler = { notification in
-      if notification.name == .AuthorizationStatusDidChange {
+      if notification.name == .ExposureNotificationStatusDidChange {
         broadcastAuthorizationStateExpectation.fulfill()
       }
     }

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -88,6 +88,7 @@ export type RequestAuthorizationError =
   | "Unsupported"
   | "Invalidated"
   | "BluetoothOff"
+  | "LocationOff"
   | "InsufficientStorage"
   | "NotEnabled"
   | "APIMisuse"

--- a/src/useRequestExposureNotifications.tsx
+++ b/src/useRequestExposureNotifications.tsx
@@ -16,17 +16,17 @@ export const useRequestExposureNotifications = (): (() => void) => {
       switch (response.status) {
         case "Active":
           break
+        default:
+          showBaseExposureNotificationsAlert()
+      }
+    } else if (response.kind === "failure") {
+      switch (response.error) {
         case "BluetoothOff":
           showEnableBluetoothAlert()
           break
         case "LocationOff":
           showEnableLocationAlert()
           break
-        default:
-          showBaseExposureNotificationsAlert()
-      }
-    } else if (response.kind === "failure") {
-      switch (response.error) {
         case "Restricted":
           showSetToActiveRegionAlert()
           break


### PR DESCRIPTION
#### Why:
When requesting to enable exposure notifications from the JS layer, we'd like to treat responses other than an `Active` status as errors.

#### This commit:
This commit updates the iOS exposure enablement call to vend a `success` to the JS layer only if the `exposureNotificationStatus` is `Active` after the request, and vends and error otherwise