### PR TITLE
Add more info screen to escrow verification flow

### DIFF
--- a/src/EscrowVerification/Start.tsx
+++ b/src/EscrowVerification/Start.tsx
@@ -7,9 +7,10 @@ import {
   TouchableOpacity,
 } from "react-native"
 import { useTranslation } from "react-i18next"
+import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
-import { useStatusBarEffect } from "../navigation"
+import { useStatusBarEffect, EscrowVerificationRoutes } from "../navigation"
 import { Text } from "../components"
 
 import { Spacing, Colors, Typography, Buttons, Iconography } from "../styles"
@@ -18,10 +19,13 @@ import { Icons, Images } from "../assets"
 export const Start: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()
+  const navigation = useNavigation()
 
   const handleOnPressContinue = () => {}
 
-  const handleOnPressSecondaryButton = () => {}
+  const handleOnPressSecondaryButton = () => {
+    navigation.navigate(EscrowVerificationRoutes.EscrowVerificationMoreInfo)
+  }
 
   return (
     <ScrollView

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -11,9 +11,10 @@ import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
 import {
-  AffectedUserFlowStackScreens,
   HomeStackScreens,
   ModalStackScreens,
+  AffectedUserFlowStackScreens,
+  EscrowVerificationRoutes,
   useStatusBarEffect,
 } from "../navigation"
 import { useConfigurationContext } from "../ConfigurationContext"
@@ -113,7 +114,12 @@ const EscrowVerificationFlowButton: FunctionComponent = () => {
     navigation.navigate(HomeStackScreens.EscrowVerificationStack)
   }
 
-  const handleOnPressMoreInfo = () => {}
+  const handleOnPressMoreInfo = () => {
+    navigation.navigate(HomeStackScreens.EscrowVerificationStack, {
+      screen: EscrowVerificationRoutes.EscrowVerificationMoreInfo,
+    })
+  }
+
   const descriptionText = t(
     "home.verification_code_card.if_you_have_a_positive_test",
   )

--- a/src/navigation/EscrowVerification.tsx
+++ b/src/navigation/EscrowVerification.tsx
@@ -3,6 +3,7 @@ import { createStackNavigator } from "@react-navigation/stack"
 
 import { EscrowVerificationProvider } from "../EscrowVerification/EscrowVerificationContext"
 import Start from "../EscrowVerification/Start"
+import VerificationCodeInfo from "../AffectedUserFlow/VerificationCodeInfo"
 
 import { EscrowVerificationRoutes } from "."
 import { applyHeaderLeftBackButton } from "./HeaderLeftBackButton"
@@ -11,6 +12,7 @@ import { Headers } from "../styles"
 
 export type EscrowVerificationRouteParamList = {
   EscrowVerificationStart: undefined
+  EscrowVerificationMoreInfo: undefined
 }
 
 const Stack = createStackNavigator<EscrowVerificationRouteParamList>()
@@ -24,6 +26,14 @@ const AffectedUserStack: FunctionComponent = () => {
         <Stack.Screen
           name={EscrowVerificationRoutes.EscrowVerificationStart}
           component={Start}
+          options={{
+            ...Headers.headerMinimalOptions,
+            headerLeft: applyHeaderLeftBackButton(),
+          }}
+        />
+        <Stack.Screen
+          name={EscrowVerificationRoutes.EscrowVerificationMoreInfo}
+          component={VerificationCodeInfo}
           options={{
             ...Headers.headerMinimalOptions,
             headerLeft: applyHeaderLeftBackButton(),

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -186,13 +186,16 @@ export const AffectedUserFlowStackScreens: {
   AffectedUserComplete: "AffectedUserComplete",
 }
 
-export type EscrowVerificationRoute = "EscrowVerificationStart"
+export type EscrowVerificationRoute =
+  | "EscrowVerificationStart"
+  | "EscrowVerificationMoreInfo"
 
 export const EscrowVerificationRoutes: Record<
   EscrowVerificationRoute,
   EscrowVerificationRoute
 > = {
   EscrowVerificationStart: "EscrowVerificationStart",
+  EscrowVerificationMoreInfo: "EscrowVerificationMoreInfo",
 }
 
 export type WelcomeStackScreen = "Welcome"


### PR DESCRIPTION
Why:
We would like for users to be able to read more information about the
verification code during the escrow verification code flow.

Co-Authored-By: Devin Jameson <devin@thoughtbot.com>
Co-Authored-By: Matty Buckley <matt@nicethings.io>