### PR TITLE
Add escrow verification flow screens

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -334,8 +334,8 @@ PODS:
     - React
   - RNCPushNotificationIOS (1.4.0):
     - React
-  - RNDateTimePicker (2.3.2):
-    - React
+  - RNDateTimePicker (3.0.8):
+    - React-Core
   - RNGestureHandler (1.6.1):
     - React
   - RNPermissions (2.1.4):
@@ -589,7 +589,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 6d99641f8e6f15d169d695d8ef184bf187903f11
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPushNotificationIOS: dc1c0c6aa18a128df123598149f42e848d26a4ac
-  RNDateTimePicker: 4bd49e09f91ca73d69119a9e1173b0d43b82f5e5
+  RNDateTimePicker: 8eba76de1afd556bc00c874f4d0c0616e30e32f1
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8
   RNScreens: 62211832af51e0aebcf6e8c36bcf7dd65592f244

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@bugsnag/react-native": "^7.3.4",
     "@react-native-community/async-storage": "^1.8.1",
-    "@react-native-community/datetimepicker": "^2.3.2",
+    "@react-native-community/datetimepicker": "^3.0.8",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "^5.9.4",
     "@react-native-community/push-notification-ios": "^1.4.0",
@@ -59,6 +59,7 @@
     "react-native-config": "^1.2.1",
     "react-native-flash-message": "^0.1.16",
     "react-native-gesture-handler": "^1.6.1",
+    "react-native-keyboard-aware-scroll-view": "^0.9.3",
     "react-native-matomo-sdk": "^0.4.0",
     "react-native-permissions": "^2.0.10",
     "react-native-safe-area-context": "^3.0.5",

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -263,7 +263,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
         <TouchableOpacity
           style={style.secondaryButton}
           onPress={handleOnPressSecondaryButton}
-          accessibilityLabel={t("common.start")}
+          accessibilityLabel={t("export.intro.what_is_a")}
         >
           <View style={style.secondaryButtonIconContainer}>
             <SvgXml

--- a/src/EscrowVerification/API.ts
+++ b/src/EscrowVerification/API.ts
@@ -1,0 +1,63 @@
+import { NativeModules } from "react-native"
+
+type Posix = number
+
+// Key Submission Module
+const escrowVerificationKeySubmissionModule =
+  NativeModules.EscrowVerificationKeySubmissionModule
+
+type PhoneNumberResponse = PhoneNumberSuccess | PhoneNumberFailure
+
+interface PhoneNumberSuccess {
+  kind: "success"
+}
+interface PhoneNumberFailure {
+  kind: "failure"
+  error: PhoneNumberError
+}
+
+export type PhoneNumberError = "Unknown"
+
+export const submitPhoneNumber = async (
+  phoneNumber: string,
+): Promise<PhoneNumberResponse> => {
+  try {
+    escrowVerificationKeySubmissionModule.submitPhoneNumber(phoneNumber)
+    return { kind: "success" }
+  } catch (e) {
+    switch (e.message) {
+      default:
+        return { kind: "failure", error: "Unknown" }
+    }
+  }
+}
+
+export type SubmitKeysResponse = SubmitKeysSuccess | SubmitKeysFailure
+
+interface SubmitKeysSuccess {
+  kind: "success"
+}
+interface SubmitKeysFailure {
+  kind: "failure"
+  error: SubmitKeysError
+}
+
+export type SubmitKeysError = "Unknown"
+
+export const submitDiagnosisKeys = async (
+  verificationCode: string,
+  date: Posix,
+): Promise<SubmitKeysResponse> => {
+  try {
+    escrowVerificationKeySubmissionModule.submitDiagnosisKeys(
+      verificationCode,
+      date,
+    )
+    return { kind: "success" }
+  } catch (e) {
+    switch (e.mssage) {
+      default:
+        return { kind: "failure", error: "Unknown" }
+    }
+  }
+}

--- a/src/EscrowVerification/Complete.tsx
+++ b/src/EscrowVerification/Complete.tsx
@@ -1,0 +1,82 @@
+import React, { FunctionComponent } from "react"
+import { ScrollView, Image, StyleSheet, TouchableOpacity } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { useTranslation } from "react-i18next"
+
+import { StatusBar, Text } from "../components"
+import { useStatusBarEffect, Stacks } from "../navigation"
+
+import { Images } from "../assets"
+import { Buttons, Colors, Layout, Spacing, Typography } from "../styles"
+
+export const Complete: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.background.primaryLight)
+  const navigation = useNavigation()
+  const { t } = useTranslation()
+
+  const handleOnPressDone = () => {
+    navigation.navigate("App", { screen: Stacks.Home })
+  }
+
+  return (
+    <>
+      <StatusBar backgroundColor={Colors.background.primaryLight} />
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+        alwaysBounceVertical={false}
+      >
+        <Image source={Images.CheckInCircle} style={style.image} />
+        <Text style={style.header}>{t("export.complete_title")}</Text>
+        <Text style={style.contentText}>
+          {t("export.complete_body_bluetooth")}
+        </Text>
+        <TouchableOpacity
+          style={style.button}
+          onPress={handleOnPressDone}
+          accessibilityLabel={t("common.done")}
+        >
+          <Text style={style.buttonText}>{t("common.done")}</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </>
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background.primaryLight,
+  },
+  contentContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+    paddingTop: Layout.oneTwentiethHeight,
+    paddingBottom: Spacing.xxHuge,
+    paddingHorizontal: Spacing.large,
+  },
+  image: {
+    width: 230,
+    height: 150,
+    marginBottom: Spacing.medium,
+    resizeMode: "cover",
+  },
+  header: {
+    ...Typography.header.x60,
+    textAlign: "center",
+    marginBottom: Spacing.medium,
+  },
+  contentText: {
+    ...Typography.body.x30,
+    textAlign: "center",
+    marginBottom: Spacing.xxxLarge,
+  },
+  button: {
+    ...Buttons.primary.base,
+  },
+  buttonText: {
+    ...Typography.button.primary,
+  },
+})
+
+export default Complete

--- a/src/EscrowVerification/EscrowVerificationContext.tsx
+++ b/src/EscrowVerification/EscrowVerificationContext.tsx
@@ -5,17 +5,11 @@ import React, {
   useContext,
 } from "react"
 
-import { ExposureKey } from "../exposureKey"
-
-type Token = string
-type Key = string
+type Posix = number
 
 export interface EscrowVerificationContextState {
-  certificate: Token | null
-  hmacKey: Key | null
-  exposureKeys: ExposureKey[]
-  setExposureKeys: (keys: ExposureKey[]) => void
-  setExposureSubmissionCredentials: (certificate: Token, hmacKey: Key) => void
+  testDate: Posix
+  setTestDate: (testDate: Posix) => void
 }
 
 export const EscrowVerificationContext = createContext<
@@ -23,26 +17,13 @@ export const EscrowVerificationContext = createContext<
 >(undefined)
 
 export const EscrowVerificationProvider: FunctionComponent = ({ children }) => {
-  const [exposureKeys, setExposureKeys] = useState<ExposureKey[]>([])
-  const [hmacKey, setHmacKey] = useState<Key | null>(null)
-  const [certificate, setCertificate] = useState<Token | null>(null)
-
-  const setExposureSubmissionCredentials = (
-    certificate: Token,
-    hmacKey: Key,
-  ) => {
-    setCertificate(certificate)
-    setHmacKey(hmacKey)
-  }
+  const [testDate, setTestDate] = useState(Date.now)
 
   return (
     <EscrowVerificationContext.Provider
       value={{
-        hmacKey,
-        certificate,
-        exposureKeys,
-        setExposureKeys,
-        setExposureSubmissionCredentials,
+        testDate,
+        setTestDate,
       }}
     >
       {children}

--- a/src/EscrowVerification/MoreInfo.tsx
+++ b/src/EscrowVerification/MoreInfo.tsx
@@ -1,0 +1,111 @@
+import React, { FunctionComponent } from "react"
+import {
+  View,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  Linking,
+} from "react-native"
+import { useTranslation } from "react-i18next"
+import { useStatusBarEffect } from "../navigation/index"
+import { useCustomCopy } from "../configuration/useCustomCopy"
+import { SvgXml } from "react-native-svg"
+
+import { Text } from "../components"
+import { useConfigurationContext } from "../ConfigurationContext"
+
+import { Spacing, Typography, Colors, Buttons } from "../styles"
+import { Icons } from "../assets"
+
+const MoreInfo: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.background.primaryLight)
+  const { t } = useTranslation()
+  const {
+    healthAuthorityName,
+    verificationCodeInfo,
+    verificationCodeHowDoIGet,
+  } = useCustomCopy()
+  const { healthAuthorityVerificationCodeInfoUrl } = useConfigurationContext()
+
+  const verificationCodeInfoText =
+    verificationCodeInfo ||
+    t("export.verification_code_info.info_body", { healthAuthorityName })
+  const verificationCodeHowDoIGetText =
+    verificationCodeHowDoIGet ||
+    t("export.verification_code_info.how_do_i_get_body", {
+      healthAuthorityName,
+    })
+
+  const handleOnPressLink = () => {
+    const url = healthAuthorityVerificationCodeInfoUrl
+    if (url) {
+      Linking.openURL(url)
+    }
+  }
+
+  return (
+    <>
+      <ScrollView
+        style={style.container}
+        contentContainerStyle={style.contentContainer}
+      >
+        <View style={style.section}>
+          <Text style={style.headerText}>
+            {t("export.verification_code_info.info_header")}
+          </Text>
+          <Text style={style.contentText}>{verificationCodeInfoText}</Text>
+        </View>
+        <View style={style.section}>
+          <Text style={style.headerText}>
+            {t("export.verification_code_info.how_do_i_get_header")}
+          </Text>
+          <Text style={style.contentText}>{verificationCodeHowDoIGetText}</Text>
+          {Boolean(healthAuthorityVerificationCodeInfoUrl) && (
+            <TouchableOpacity style={style.button} onPress={handleOnPressLink}>
+              <Text style={style.buttonText}>{t("common.learn_more")}</Text>
+              <SvgXml xml={Icons.Arrow} fill={Colors.primary.shade100} />
+            </TouchableOpacity>
+          )}
+        </View>
+        <View style={style.section}>
+          <Text style={style.headerText}>
+            {t("export.verification_code_info.what_happens_header")}
+          </Text>
+          <Text style={style.contentText}>
+            {t("export.verification_code_info.what_happens_body")}
+          </Text>
+        </View>
+      </ScrollView>
+    </>
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.background.primaryLight,
+    padding: Spacing.medium,
+  },
+  contentContainer: {
+    paddingBottom: Spacing.xLarge,
+  },
+  headerText: {
+    ...Typography.header.x20,
+  },
+  section: {
+    paddingBottom: Spacing.xLarge,
+  },
+  contentText: {
+    ...Typography.body.x30,
+    paddingTop: Spacing.small,
+  },
+  button: {
+    ...Buttons.outlined.base,
+    marginBottom: Spacing.small,
+  },
+  buttonText: {
+    ...Typography.button.outlined,
+    marginRight: Spacing.small,
+  },
+})
+
+export default MoreInfo

--- a/src/EscrowVerification/Start.tsx
+++ b/src/EscrowVerification/Start.tsx
@@ -21,7 +21,11 @@ export const Start: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
 
-  const handleOnPressContinue = () => {}
+  const handleOnPressContinue = () => {
+    navigation.navigate(
+      EscrowVerificationRoutes.EscrowVerificationUserDetailsForm,
+    )
+  }
 
   const handleOnPressSecondaryButton = () => {
     navigation.navigate(EscrowVerificationRoutes.EscrowVerificationMoreInfo)

--- a/src/EscrowVerification/UserDetailsForm.tsx
+++ b/src/EscrowVerification/UserDetailsForm.tsx
@@ -1,0 +1,200 @@
+import React, { useState, FunctionComponent } from "react"
+import {
+  Keyboard,
+  TextInput,
+  Alert,
+  View,
+  StyleSheet,
+  TouchableOpacity,
+} from "react-native"
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view"
+import DateTimePicker from "@react-native-community/datetimepicker"
+import { useTranslation } from "react-i18next"
+import { SvgXml } from "react-native-svg"
+import { showMessage } from "react-native-flash-message"
+import { useNavigation } from "@react-navigation/native"
+import dayjs from "dayjs"
+
+import { useConfigurationContext } from "../ConfigurationContext"
+import { useEscrowVerificationContext } from "./EscrowVerificationContext"
+import { LoadingIndicator, Text } from "../components"
+import { useStatusBarEffect, EscrowVerificationRoutes } from "../navigation"
+import Logger from "../logger"
+import * as API from "./API"
+
+import {
+  Affordances,
+  Forms,
+  Colors,
+  Spacing,
+  Buttons,
+  Typography,
+} from "../styles"
+import { Icons } from "../assets"
+
+const defaultErrorMessage = " "
+
+const UserDetailsForm: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.background.primaryLight)
+  const { t } = useTranslation()
+  const navigation = useNavigation()
+  const { minimumPhoneDigits } = useConfigurationContext()
+  const { successFlashMessageOptions } = Affordances.useFlashMessageOptions()
+
+  const { testDate, setTestDate } = useEscrowVerificationContext()
+
+  const [phoneNumber, setPhoneNumber] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState(defaultErrorMessage)
+
+  const handleOnChangeTestDate = (testDate: Date | undefined) => {
+    testDate && setTestDate(dayjs(testDate).valueOf())
+  }
+
+  const handleOnChangePhoneNumber = (phoneNumber: string) => {
+    setErrorMessage("")
+    setPhoneNumber(phoneNumber)
+  }
+
+  const handleOnPressSubmit = async () => {
+    setIsLoading(true)
+    setErrorMessage(defaultErrorMessage)
+
+    try {
+      const response = await API.submitPhoneNumber(phoneNumber)
+
+      if (response.kind === "success") {
+        showMessage({
+          message: t("common.success"),
+          ...successFlashMessageOptions,
+        })
+        navigation.navigate(EscrowVerificationRoutes.EscrowVerificationCodeForm)
+      } else {
+        Alert.alert(showError(response.error))
+      }
+      setIsLoading(false)
+    } catch (e) {
+      Logger.error(`escrow verification error`, e.message)
+      Alert.alert(showError("Unknown"), e.message)
+      setIsLoading(false)
+    }
+  }
+
+  const buttonDisabled = phoneNumber.length < minimumPhoneDigits
+
+  const showError = (error: API.PhoneNumberError): string => {
+    switch (error) {
+      case "Unknown":
+        return t("common.something_went_wrong")
+    }
+  }
+
+  const errorMessageShouldBeAccessible = errorMessage !== ""
+
+  return (
+    <KeyboardAwareScrollView
+      style={style.container}
+      contentContainerStyle={style.contentContainer}
+      alwaysBounceVertical={false}
+    >
+      <View>
+        <View style={style.headerContainer}>
+          <Text style={style.header}>
+            {t("escrow_verification.user_details_form.test_details")}
+          </Text>
+        </View>
+        <View style={style.inputContainer}>
+          <Text style={style.inputLabel}>
+            {t("escrow_verification.user_details_form.phone_number")}
+          </Text>
+          <TextInput
+            value={phoneNumber}
+            style={style.textInput}
+            keyboardType="phone-pad"
+            returnKeyType="done"
+            onChangeText={handleOnChangePhoneNumber}
+            blurOnSubmit={false}
+            onSubmitEditing={Keyboard.dismiss}
+            testID="phone-number-input"
+            multiline
+          />
+        </View>
+        <DateTimePicker
+          value={dayjs(testDate).toDate()}
+          minimumDate={dayjs().subtract(4, "week").toDate()}
+          maximumDate={dayjs().toDate()}
+          onChange={(_event: Event, date?: Date) =>
+            handleOnChangeTestDate(date)
+          }
+        />
+        <View
+          accessibilityElementsHidden={!errorMessageShouldBeAccessible}
+          accessible={errorMessageShouldBeAccessible}
+        >
+          <Text style={style.errorSubtitle}>{errorMessage}</Text>
+        </View>
+        <TouchableOpacity
+          style={buttonDisabled ? style.buttonDisabled : style.button}
+          onPress={handleOnPressSubmit}
+          accessibilityLabel={t("common.submit")}
+          disabled={buttonDisabled}
+        >
+          <Text
+            style={buttonDisabled ? style.buttonDisabledText : style.buttonText}
+          >
+            {t("common.submit")}
+          </Text>
+          <SvgXml
+            xml={Icons.Arrow}
+            fill={buttonDisabled ? Colors.text.primary : Colors.neutral.white}
+          />
+        </TouchableOpacity>
+      </View>
+      {isLoading && <LoadingIndicator />}
+    </KeyboardAwareScrollView>
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.background.primaryLight,
+  },
+  contentContainer: {
+    padding: Spacing.medium,
+  },
+  headerContainer: {
+    marginBottom: Spacing.small,
+  },
+  header: {
+    ...Typography.header.x50,
+    marginBottom: Spacing.xxSmall,
+  },
+  errorSubtitle: {
+    ...Typography.utility.error,
+    height: Spacing.huge,
+  },
+  inputContainer: {
+    marginBottom: Spacing.medium,
+  },
+  inputLabel: {
+    ...Typography.form.inputLabel,
+    paddingBottom: Spacing.xxSmall,
+  },
+  textInput: {
+    ...Forms.textInput,
+  },
+  button: {
+    ...Buttons.primary.base,
+  },
+  buttonDisabled: {
+    ...Buttons.primary.disabled,
+  },
+  buttonText: {
+    ...Typography.button.primary,
+  },
+  buttonDisabledText: {
+    ...Typography.button.primaryDisabled,
+  },
+})
+
+export default UserDetailsForm

--- a/src/EscrowVerification/VerificationCodeForm.tsx
+++ b/src/EscrowVerification/VerificationCodeForm.tsx
@@ -1,0 +1,249 @@
+import React, { FunctionComponent, useState } from "react"
+import {
+  Alert,
+  StyleSheet,
+  TextInput,
+  View,
+  Keyboard,
+  TouchableOpacity,
+} from "react-native"
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view"
+import { useNavigation } from "@react-navigation/native"
+import { useTranslation } from "react-i18next"
+import { showMessage } from "react-native-flash-message"
+import { SvgXml } from "react-native-svg"
+
+import { useEscrowVerificationContext } from "./EscrowVerificationContext"
+import { useProductAnalyticsContext } from "../ProductAnalytics/Context"
+import { useStatusBarEffect, EscrowVerificationRoutes } from "../navigation"
+import { Text, LoadingIndicator } from "../components"
+import * as API from "./API"
+import Logger from "../logger"
+
+import {
+  Affordances,
+  Spacing,
+  Forms,
+  Colors,
+  Typography,
+  Buttons,
+  Iconography,
+} from "../styles"
+import { Icons } from "../assets"
+
+const defaultErrorMessage = ""
+
+const VerificationCodeForm: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.background.primaryLight)
+  const { t } = useTranslation()
+  const navigation = useNavigation()
+  const { trackEvent } = useProductAnalyticsContext()
+  const { successFlashMessageOptions } = Affordances.useFlashMessageOptions()
+
+  const { testDate } = useEscrowVerificationContext()
+  const [code, setCode] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState(defaultErrorMessage)
+  const [isFocused, setIsFocused] = useState(false)
+
+  const handleOnChangeText = (newCode: string) => {
+    setCode(newCode)
+    if (newCode && !codeContainsOnlyAlphanumericChars(newCode)) {
+      setErrorMessage(t("export.error.invalid_format"))
+    } else {
+      setErrorMessage("")
+    }
+  }
+
+  const handleOnToggleFocus = () => {
+    setIsFocused(!isFocused)
+  }
+
+  const handleOnPressSecondaryButton = () => {
+    navigation.navigate(EscrowVerificationRoutes.EscrowVerificationMoreInfo)
+  }
+
+  const handleOnPressSubmit = async () => {
+    setIsLoading(true)
+    setErrorMessage(defaultErrorMessage)
+    trackEvent("product_analytics", "verification_code_submitted")
+    try {
+      const response = await API.submitDiagnosisKeys(code, testDate)
+
+      if (response.kind === "success") {
+        showMessage({
+          message: t("common.success"),
+          ...successFlashMessageOptions,
+        })
+        navigation.navigate(EscrowVerificationRoutes.EscrowVerificationComplete)
+      } else {
+        showError(response.error)
+      }
+      setIsLoading(false)
+    } catch (e) {
+      Logger.error("Unhandled error on submit code to escrow")
+      Alert.alert(t("common.something_went_wrong"), e.message)
+      setIsLoading(false)
+    }
+  }
+
+  const showError = (error: API.SubmitKeysError): void => {
+    switch (error) {
+      case "Unknown":
+        Alert.alert(
+          t("verification_code_alerts.unknown_title"),
+          t("verification_code_alerts.unknown_body"),
+          [{ text: t("common.okay") }],
+        )
+    }
+  }
+
+  const codeLengthMin = 6
+  const codeLengthMax = 16
+  const codeContainsOnlyAlphanumericChars = (code: string) => {
+    const alphanumericRegex = /^[a-zA-Z0-9]*$/
+    return Boolean(code.match(alphanumericRegex))
+  }
+
+  const codeIsValid = (code: string): boolean => {
+    return (
+      code.length >= codeLengthMin &&
+      code.length <= codeLengthMax &&
+      codeContainsOnlyAlphanumericChars(code)
+    )
+  }
+
+  const isDisabled = !codeIsValid(code)
+
+  const codeInputFocusedStyle = isFocused && { ...style.codeInputFocused }
+  const codeInputStyle = { ...style.codeInput, ...codeInputFocusedStyle }
+
+  const errorMessageShouldBeAccessible = errorMessage !== ""
+
+  return (
+    <KeyboardAwareScrollView
+      contentContainerStyle={style.contentContainer}
+      testID={"affected-user-code-input-form"}
+      alwaysBounceVertical={false}
+    >
+      <View style={style.headerContainer}>
+        <Text style={style.header}>{t("export.enter_verification_code")}</Text>
+      </View>
+      <TextInput
+        testID="code-input"
+        value={code}
+        placeholder={t("export.code").toUpperCase()}
+        placeholderTextColor={Colors.text.placeholder}
+        maxLength={codeLengthMax}
+        style={codeInputStyle}
+        returnKeyType="done"
+        onChangeText={handleOnChangeText}
+        onFocus={handleOnToggleFocus}
+        onBlur={handleOnToggleFocus}
+        onSubmitEditing={Keyboard.dismiss}
+        blurOnSubmit={false}
+      />
+      <View
+        accessibilityElementsHidden={!errorMessageShouldBeAccessible}
+        accessible={errorMessageShouldBeAccessible}
+      >
+        <Text style={style.errorSubtitle}>{errorMessage}</Text>
+      </View>
+      <TouchableOpacity
+        style={isDisabled ? style.buttonDisabled : style.button}
+        onPress={handleOnPressSubmit}
+        accessibilityLabel={t("common.next")}
+        disabled={isDisabled}
+      >
+        <Text style={isDisabled ? style.buttonDisabledText : style.buttonText}>
+          {t("common.next")}
+        </Text>
+        <SvgXml
+          xml={Icons.Arrow}
+          fill={isDisabled ? Colors.text.primary : Colors.neutral.white}
+        />
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={style.secondaryButton}
+        onPress={handleOnPressSecondaryButton}
+        accessibilityLabel={t("common.start")}
+      >
+        <View style={style.secondaryButtonIconContainer}>
+          <SvgXml
+            xml={Icons.QuestionMark}
+            fill={Colors.primary.shade125}
+            width={Iconography.xxxSmall}
+            height={Iconography.xxxSmall}
+          />
+        </View>
+        <Text style={style.secondaryButtonText}>
+          {t("export.intro.what_is_a")}
+        </Text>
+      </TouchableOpacity>
+      {isLoading && <LoadingIndicator />}
+    </KeyboardAwareScrollView>
+  )
+}
+
+const style = StyleSheet.create({
+  contentContainer: {
+    minHeight: "100%",
+    backgroundColor: Colors.background.primaryLight,
+    paddingTop: Spacing.large,
+    paddingBottom: Spacing.xxxHuge,
+    paddingHorizontal: Spacing.medium,
+    justifyContent: "center",
+  },
+  headerContainer: {
+    marginBottom: Spacing.medium,
+  },
+  header: {
+    ...Typography.header.x60,
+  },
+  errorSubtitle: {
+    ...Typography.utility.error,
+    color: Colors.text.error,
+    marginTop: Spacing.xxSmall,
+    marginBottom: Spacing.small,
+    minHeight: Spacing.xxxHuge,
+  },
+  codeInput: {
+    ...Forms.textInput,
+    ...Typography.style.medium,
+    fontSize: Typography.size.x60,
+    textAlignVertical: "center",
+    textAlign: "center",
+    letterSpacing: 3,
+    paddingTop: Spacing.small + 2,
+  },
+  codeInputFocused: {
+    borderColor: Colors.primary.shade125,
+  },
+  button: {
+    ...Buttons.primary.base,
+    marginBottom: Spacing.small,
+  },
+  buttonDisabled: {
+    ...Buttons.primary.disabled,
+    marginBottom: Spacing.small,
+  },
+  buttonText: {
+    ...Typography.button.primary,
+    marginRight: Spacing.small,
+  },
+  buttonDisabledText: {
+    ...Typography.button.primaryDisabled,
+    marginRight: Spacing.small,
+  },
+  secondaryButton: {
+    ...Buttons.secondary.leftIcon,
+  },
+  secondaryButtonIconContainer: {
+    ...Buttons.circle.base,
+  },
+  secondaryButtonText: {
+    ...Typography.button.secondaryLeftIcon,
+  },
+})
+
+export default VerificationCodeForm

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -78,6 +78,10 @@
       "header": "Report a positive test",
       "body": "If you have tested positive for COVID-19 (not through an antibody test), you can anonymously report the test.\n\nReporting your test will help others in your community contain the spread of the virus.",
       "what_is_a_verification_code": "What is a verification code?"
+    },
+    "user_details_form": {
+      "test_details": "Test Details",
+      "phone_number": "Phone number"
     }
   },
   "export": {

--- a/src/navigation/EscrowVerification.tsx
+++ b/src/navigation/EscrowVerification.tsx
@@ -4,6 +4,9 @@ import { createStackNavigator } from "@react-navigation/stack"
 import { EscrowVerificationProvider } from "../EscrowVerification/EscrowVerificationContext"
 import Start from "../EscrowVerification/Start"
 import VerificationCodeInfo from "../AffectedUserFlow/VerificationCodeInfo"
+import UserDetailsForm from "../EscrowVerification/UserDetailsForm"
+import VerificationCodeForm from "../EscrowVerification/VerificationCodeForm"
+import Complete from "../EscrowVerification/Complete"
 
 import { EscrowVerificationRoutes } from "."
 import { applyHeaderLeftBackButton } from "./HeaderLeftBackButton"
@@ -13,6 +16,9 @@ import { Headers } from "../styles"
 export type EscrowVerificationRouteParamList = {
   EscrowVerificationStart: undefined
   EscrowVerificationMoreInfo: undefined
+  EscrowVerificationUserDetailsForm: undefined
+  EscrowVerificationCodeForm: undefined
+  EscrowVerificationComplete: undefined
 }
 
 const Stack = createStackNavigator<EscrowVerificationRouteParamList>()
@@ -38,6 +44,26 @@ const AffectedUserStack: FunctionComponent = () => {
             ...Headers.headerMinimalOptions,
             headerLeft: applyHeaderLeftBackButton(),
           }}
+        />
+        <Stack.Screen
+          name={EscrowVerificationRoutes.EscrowVerificationUserDetailsForm}
+          component={UserDetailsForm}
+          options={{
+            ...Headers.headerMinimalOptions,
+            headerLeft: applyHeaderLeftBackButton(),
+          }}
+        />
+        <Stack.Screen
+          name={EscrowVerificationRoutes.EscrowVerificationCodeForm}
+          component={VerificationCodeForm}
+          options={{
+            ...Headers.headerMinimalOptions,
+            headerLeft: applyHeaderLeftBackButton(),
+          }}
+        />
+        <Stack.Screen
+          name={EscrowVerificationRoutes.EscrowVerificationComplete}
+          component={Complete}
         />
       </Stack.Navigator>
     </EscrowVerificationProvider>

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -189,6 +189,9 @@ export const AffectedUserFlowStackScreens: {
 export type EscrowVerificationRoute =
   | "EscrowVerificationStart"
   | "EscrowVerificationMoreInfo"
+  | "EscrowVerificationUserDetailsForm"
+  | "EscrowVerificationCodeForm"
+  | "EscrowVerificationComplete"
 
 export const EscrowVerificationRoutes: Record<
   EscrowVerificationRoute,
@@ -196,6 +199,9 @@ export const EscrowVerificationRoutes: Record<
 > = {
   EscrowVerificationStart: "EscrowVerificationStart",
   EscrowVerificationMoreInfo: "EscrowVerificationMoreInfo",
+  EscrowVerificationUserDetailsForm: "EscrowVerificationUserDetailsForm",
+  EscrowVerificationCodeForm: "EscrowVerificationCodeForm",
+  EscrowVerificationComplete: "EscrowVerificationComplete",
 }
 
 export type WelcomeStackScreen = "Welcome"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,9 +1224,10 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-community/datetimepicker@^2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-2.3.2.tgz#c4dfc503ed260c7c93ce838f60e707dbba179452"
+"@react-native-community/datetimepicker@^3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-3.0.8.tgz#3960b39dfeea4a0f11425e24e0852764ed9133ca"
+  integrity sha512-85pOIjRnhrUmyWFH52qGGya1MDwE7vU4fDqt21yY6EyT7TolwQvZknwId8TAmREawsMoCMchke6VFo1IqRaUOA==
   dependencies:
     invariant "^2.2.4"
 
@@ -6649,9 +6650,22 @@ react-native-gesture-handler@^1.6.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-iphone-x-helper@^1.0.3:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
+  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
+
 react-native-iphone-x-helper@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
+
+react-native-keyboard-aware-scroll-view@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.3.tgz#65ab4cab1a987b486d97924602756fa88b7fbfcc"
+  integrity sha512-EDyFp8wAJoKvi1T2pzoPRn8R0Inp3G+575jPAWEFTlXq26URMmk8760rzde2XLW+v/1+QwDyBg6d/5mz63/ZRA==
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-iphone-x-helper "^1.0.3"
 
 react-native-matomo-sdk@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Why:
We would like to support the verification code flow with the escrow
based format.

This commit:
Adds the remaining screens needed in this flow and connects to the
native module for making the network calls. Note that we still need to
finishing styling and handling the error cases.

Co-Authored-By: Devin Jameson <devin@thoughtbot.com>
Co-Authored-By: Matt Buckley <matt@nicethings.io>

|GIF|
|---|
|![escrow-flow](https://user-images.githubusercontent.com/16049495/101413165-a804bf80-3898-11eb-95d7-88bb13da6127.gif)|
