### PR TITLE
Add formating to user details form

### DIFF
--- a/__mocks__/react-native-keyboard-aware-scroll-view.js
+++ b/__mocks__/react-native-keyboard-aware-scroll-view.js
@@ -1,0 +1,3 @@
+import { View } from "react-native"
+
+export default View

--- a/src/EscrowVerification/UserDetailsForm.spec.ts
+++ b/src/EscrowVerification/UserDetailsForm.spec.ts
@@ -1,0 +1,35 @@
+import { phoneToFormattedString } from "./UserDetailsForm"
+
+describe("phoneToFormattedString", () => {
+  describe("when given a phonenumber", () => {
+    it("adds parenteses and a dash, and pads missing digits with underscores", () => {
+      const number1 = ""
+      const number2 = "1"
+      const number3 = "123"
+      const number4 = "123456"
+      const number5 = "1234567890"
+      const number6 = "123456789012345"
+
+      const result1 = phoneToFormattedString(number1)
+      const result2 = phoneToFormattedString(number2)
+      const result3 = phoneToFormattedString(number3)
+      const result4 = phoneToFormattedString(number4)
+      const result5 = phoneToFormattedString(number5)
+      const result6 = phoneToFormattedString(number6)
+
+      const expected1 = "(___) ___-____"
+      const expected2 = "(1__) ___-____"
+      const expected3 = "(123) ___-____"
+      const expected4 = "(123) 456-____"
+      const expected5 = "(123) 456-7890"
+      const expected6 = "(123) 456-7890"
+
+      expect(result1).toEqual(expected1)
+      expect(result2).toEqual(expected2)
+      expect(result3).toEqual(expected3)
+      expect(result4).toEqual(expected4)
+      expect(result5).toEqual(expected5)
+      expect(result6).toEqual(expected6)
+    })
+  })
+})

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -73,6 +73,9 @@
     "title": "Unknown Error"
   },
   "escrow_verification": {
+    "error": {
+      "invalid_phone_number": "Phone number must be 10 digits"
+    },
     "person_and_health_expert": "A person talking to a health expert",
     "start": {
       "header": "Report a positive test",
@@ -80,7 +83,9 @@
       "what_is_a_verification_code": "What is a verification code?"
     },
     "user_details_form": {
+      "subheader": "Please provide the date of your test and phone number.",
       "test_details": "Test Details",
+      "test_date": "Test date",
       "phone_number": "Phone number"
     }
   },


### PR DESCRIPTION
Why:
We would like for the ux of the user details form to better inform the
user of valid form input.

This commit:
Updates the ux of the user details form in the escrow verification flow
by showing the phone number input with '(123) 123-1234' formatting.

Co-Authored-By: Devin Jameson <devin@thoughtbot.com>

|GIF|
|---|
|![phone-input](https://user-images.githubusercontent.com/16049495/101488069-f5724280-3913-11eb-99eb-2075f6502fc5.gif)|
