### PR TITLE
Conditionally render language picker

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,7 @@ module.exports = {
     "no-dupe-keys": 2, // Disallow Duplicate Keys
     "no-empty": 2, // Disallow Empty Block Statements
     "no-extra-boolean-cast": 2, // Disallow Extra Boolean Casts
+    "no-extra-semi": 0,
     "no-prototype-builtins": 2, // Disallow use of Object.prototypes builtins directly
     "no-undef": 2, // Disallow Undeclared Variables
     "no-underscore-dangle": 2, // Disallow dangling underscores in identifiers
@@ -82,6 +83,7 @@ module.exports = {
     "react/prefer-stateless-function": 2, // Use functional components vs classes
     "@typescript-eslint/no-var-requires": 0,
     "@typescript-eslint/no-empty-function": [2, { allow: ["arrowFunctions"] }],
+    "@typescript-eslint/no-extra-semi": 0,
     "@typescript-eslint/no-unused-vars": [2, { argsIgnorePattern: "^_" }],
     "@typescript-eslint/explicit-module-boundary-types": 0,
   },

--- a/src/Settings/index.spec.tsx
+++ b/src/Settings/index.spec.tsx
@@ -6,6 +6,7 @@ import { SettingsStackScreens } from "../navigation"
 import SettingsScreen from "./index"
 import { useNavigation } from "@react-navigation/native"
 import { useApplicationInfo } from "../Device/useApplicationInfo"
+import { enabledLocales, useLocaleInfo } from "../locales/languages"
 import {
   loadAuthorityLinks,
   applyTranslations,
@@ -14,6 +15,8 @@ import {
 jest.mock("@react-navigation/native")
 jest.mock("../configuration/authorityLinks")
 jest.mock("../Device/useApplicationInfo")
+jest.mock("../locales/languages.ts")
+jest.mock("@react-navigation/native")
 
 describe("Settings", () => {
   describe("when the user deletes their data", () => {
@@ -23,6 +26,11 @@ describe("Settings", () => {
       ;(useApplicationInfo as jest.Mock).mockReturnValueOnce({
         applicationName: "name",
       })
+      ;(useLocaleInfo as jest.Mock).mockReturnValue({
+        localeCode: "en",
+        languageName: "English",
+      })
+      ;(enabledLocales as jest.Mock).mockReturnValueOnce([])
 
       const { getByLabelText } = render(<SettingsScreen />)
 
@@ -42,6 +50,11 @@ describe("Settings", () => {
       applicationName: "name",
       versionInfo,
     })
+    ;(useLocaleInfo as jest.Mock).mockReturnValue({
+      localeCode: "en",
+      languageName: "English",
+    })
+    ;(enabledLocales as jest.Mock).mockReturnValueOnce([])
 
     const { getByText } = render(<SettingsScreen />)
 
@@ -59,6 +72,11 @@ describe("Settings", () => {
       applicationName: "name",
       versionInfo: "versionInfo",
     })
+    ;(useLocaleInfo as jest.Mock).mockReturnValue({
+      localeCode: "en",
+      languageName: "English",
+    })
+    ;(enabledLocales as jest.Mock).mockReturnValueOnce([])
 
     const { getByText } = render(<SettingsScreen />)
 
@@ -78,6 +96,7 @@ describe("Settings", () => {
       applicationName: "applicationName",
       versionInfo: "versionInfo",
     })
+    ;(enabledLocales as jest.Mock).mockReturnValueOnce([])
     const openURLSpy = jest.spyOn(Linking, "openURL")
 
     const { getByLabelText } = render(<SettingsScreen />)
@@ -88,6 +107,56 @@ describe("Settings", () => {
       expect(loadAuthorityLinksSpy).toHaveBeenCalledWith("about")
       expect(applyTranslationsSpy).toHaveBeenCalledWith([], "en")
       expect(openURLSpy).toHaveBeenCalledWith(url)
+    })
+  })
+
+  describe("when the app supports more than 1 locale", () => {
+    it("displays a set language button", () => {
+      ;(useApplicationInfo as jest.Mock).mockReturnValueOnce({
+        applicationName: "name",
+        versionInfo: "1",
+      })
+      ;(enabledLocales as jest.Mock).mockReturnValueOnce([
+        {
+          value: "en",
+          label: "English",
+        },
+        {
+          value: "es",
+          label: "Spanish",
+        },
+      ])
+      ;(useLocaleInfo as jest.Mock).mockReturnValue({
+        localeCode: "en",
+        languageName: "English",
+      })
+
+      const { getByTestId } = render(<SettingsScreen />)
+
+      expect(getByTestId("settings-language-picker")).toBeDefined()
+    })
+  })
+
+  describe("when the app supports only one locale", () => {
+    it("does not display a language button", () => {
+      ;(useApplicationInfo as jest.Mock).mockReturnValueOnce({
+        applicationName: "name",
+        versionInfo: "1",
+      })
+      ;(enabledLocales as jest.Mock).mockReturnValueOnce([
+        {
+          value: "en",
+          label: "English",
+        },
+      ])
+      ;(useLocaleInfo as jest.Mock).mockReturnValue({
+        localeCode: "en",
+        languageName: "English",
+      })
+
+      const { queryByTestId } = render(<SettingsScreen />)
+
+      expect(queryByTestId("settings-language-picker")).toBeNull()
     })
   })
 })

--- a/src/Settings/index.tsx
+++ b/src/Settings/index.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import env from "react-native-config"
 
-import { useLocaleInfo } from "../locales/languages"
+import ShareAnonymizedDataListItem from "./ShareAnonymizedDataListItem"
+import { enabledLocales, useLocaleInfo } from "../locales/languages"
 import {
   useStatusBarEffect,
   ModalStackScreens,
@@ -23,7 +24,6 @@ import {
 
 import { Icons } from "../assets"
 import { Colors, Spacing, Typography } from "../styles"
-import ShareAnonymizedDataListItem from "./ShareAnonymizedDataListItem"
 
 type SettingsListItem = {
   label: string
@@ -107,19 +107,23 @@ const Settings: FunctionComponent = () => {
 
   const osInfo = `${Platform.OS} v${Platform.Version}`
 
+  const showLanguagePicker = enabledLocales().length > 1
+
   return (
     <>
       <StatusBar backgroundColor={Colors.secondary.shade10} />
       <ScrollView style={style.container} alwaysBounceVertical={false}>
         <Text style={style.headerText}>{t("screen_titles.settings")}</Text>
-        <View style={style.section}>
-          <ListItem
-            label={selectLanguage.label}
-            accessibilityLabel={selectLanguage.accessibilityLabel}
-            onPress={selectLanguage.onPress}
-            icon={selectLanguage.icon}
-          />
-        </View>
+        {showLanguagePicker && (
+          <View style={style.section} testID={"settings-language-picker"}>
+            <ListItem
+              label={selectLanguage.label}
+              accessibilityLabel={selectLanguage.accessibilityLabel}
+              onPress={selectLanguage.onPress}
+              icon={selectLanguage.icon}
+            />
+          </View>
+        )}
         <View style={style.section}>
           {middleListItems.map((params, idx) => {
             const isLastItem = idx === middleListItems.length - 1

--- a/src/Welcome.spec.tsx
+++ b/src/Welcome.spec.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+import Welcome from "./Welcome"
+import { useLocaleInfo, enabledLocales } from "./locales/languages"
+
+jest.mock("./locales/languages.ts")
+jest.mock("@react-navigation/native")
+;(useLocaleInfo as jest.Mock).mockReturnValue({
+  localeCode: "en",
+  languageName: "English",
+})
+
+describe("Welcome", () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe("when the app supports more than 1 locale", () => {
+    it("displays a set language button", () => {
+      ;(enabledLocales as jest.Mock).mockReturnValueOnce([
+        {
+          value: "en",
+          label: "English",
+        },
+        {
+          value: "es",
+          label: "Spanish",
+        },
+      ])
+      ;(useLocaleInfo as jest.Mock).mockReturnValue({
+        localeCode: "en",
+        languageName: "English",
+      })
+
+      const { getByTestId } = render(<Welcome />)
+
+      expect(getByTestId("welcome-language-button")).toBeDefined()
+    })
+  })
+
+  describe("when the app supports only 1 locale", () => {
+    it("does not display a set language button", () => {
+      ;(enabledLocales as jest.Mock).mockReturnValueOnce([
+        {
+          value: "en",
+          label: "English",
+        },
+      ])
+      ;(useLocaleInfo as jest.Mock).mockReturnValue({
+        localeCode: "en",
+        languageName: "English",
+      })
+
+      const { queryByTestId } = render(<Welcome />)
+
+      expect(queryByTestId("welcome-language-button")).toBeNull()
+    })
+  })
+})

--- a/src/Welcome.tsx
+++ b/src/Welcome.tsx
@@ -1,17 +1,11 @@
 import React, { FunctionComponent } from "react"
-import {
-  Image,
-  StyleSheet,
-  View,
-  TouchableOpacity,
-  ScrollView,
-} from "react-native"
+import { Image, StyleSheet, View, Pressable, ScrollView } from "react-native"
 import { useTranslation } from "react-i18next"
 import { useNavigation } from "@react-navigation/native"
 import { SvgXml } from "react-native-svg"
 
 import { StatusBar, Text } from "./components"
-import { useLocaleInfo } from "./locales/languages"
+import { useLocaleInfo, enabledLocales } from "./locales/languages"
 import { useApplicationName } from "./Device/useApplicationInfo"
 import { useConfigurationContext } from "./ConfigurationContext"
 import { ModalStackScreens, useStatusBarEffect, Stacks } from "./navigation"
@@ -51,6 +45,8 @@ const Welcome: FunctionComponent = () => {
     }
   }
 
+  const showLanguagePicker = enabledLocales().length > 1
+
   return (
     <>
       <StatusBar backgroundColor={Colors.background.primaryLight} />
@@ -60,15 +56,20 @@ const Welcome: FunctionComponent = () => {
         alwaysBounceVertical={false}
       >
         <View style={style.mainContentContainer}>
-          <TouchableOpacity
-            onPress={handleOnPressSelectLanguage}
-            accessibilityLabel={t("common.select_language")}
-            accessibilityRole="button"
-          >
-            <View style={style.languageButtonContainer}>
-              <Text style={style.languageButtonText}>{languageName}</Text>
-            </View>
-          </TouchableOpacity>
+          <View style={style.headerContainer}>
+            {showLanguagePicker && (
+              <Pressable
+                onPress={handleOnPressSelectLanguage}
+                accessibilityLabel={t("common.select_language")}
+                accessibilityRole="button"
+                testID={"welcome-language-button"}
+              >
+                <View style={style.languageButton}>
+                  <Text style={style.languageButtonText}>{languageName}</Text>
+                </View>
+              </Pressable>
+            )}
+          </View>
           <View style={style.imageAndText}>
             <Image
               source={Images.WelcomeImage}
@@ -79,7 +80,7 @@ const Welcome: FunctionComponent = () => {
             <Text style={style.welcomeToText}>{welcomeMessage}</Text>
             <Text style={style.nameText}>{applicationName}</Text>
           </View>
-          <TouchableOpacity
+          <Pressable
             style={style.button}
             onPress={handleOnPressGetStarted}
             accessibilityLabel={t("label.launch_get_started")}
@@ -88,7 +89,7 @@ const Welcome: FunctionComponent = () => {
               {t("label.launch_get_started")}
             </Text>
             <SvgXml xml={Icons.Arrow} fill={Colors.background.primaryLight} />
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </ScrollView>
     </>
@@ -110,13 +111,15 @@ const style = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
   },
-  languageButtonContainer: {
+  headerContainer: {
     marginTop: Spacing.medium,
+    marginBottom: Spacing.xSmall,
+  },
+  languageButton: {
     backgroundColor: Colors.secondary.shade50,
     borderRadius: Outlines.borderRadiusMax,
     paddingVertical: Spacing.xxSmall,
     paddingHorizontal: Spacing.xLarge,
-    marginBottom: Spacing.xSmall,
   },
   languageButtonText: {
     ...Typography.body.x10,


### PR DESCRIPTION
Why:
If a build only supports 1 language we would like to not show the
language picker as it would be a selector with only one item.

This commit:
Adds the conditional logic to not render the location picker when the
build has only one supported locale.

||Welcome|Settings|
|-|---|---|
|1 locale |![Simulator Screen Shot - iPhone 12 Pro Max - 2020-12-08 at 14 09 19](https://user-images.githubusercontent.com/16049495/101550143-ae13a280-3963-11eb-9521-c140e22368be.png)|![Simulator Screen Shot - iPhone 12 Pro Max - 2020-12-08 at 14 09 12](https://user-images.githubusercontent.com/16049495/101550159-b370ed00-3963-11eb-9ba2-046d71b77144.png)|
|>1 locale |![Simulator Screen Shot - iPhone 12 Pro Max - 2020-12-08 at 14 13 58](https://user-images.githubusercontent.com/16049495/101550254-d1d6e880-3963-11eb-9618-c7c051632dfe.png)|![Simulator Screen Shot - iPhone 12 Pro Max - 2020-12-08 at 14 14 12](https://user-images.githubusercontent.com/16049495/101550264-d7343300-3963-11eb-9b2e-95905f9367ce.png)|




