### PR TITLE
Introduce SymptomOnsetDate screen

### DIFF
--- a/example.env.bt
+++ b/example.env.bt
@@ -13,8 +13,9 @@ DISPLAY_ACCEPT_TERMS_OF_SERVICE=true
 DISPLAY_SELF_ASSESSMENT=true
 DISPLAY_SYMPTOM_HISTORY=true
 
-// Verification Code Flow: simple | escrow
+// Verification Code Flow
 VERIFICATION_STRATEGY=simple
+INCLUDE_SYMPTOM_ONSET_DATE=false
 
 // Links
 AUTHORITY_ADVICE_URL=

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -342,6 +342,8 @@ PODS:
     - React
   - RNScreens (2.8.0):
     - React
+  - RNStaticSafeAreaInsets (2.1.1):
+    - React
   - RNSVG (12.1.0):
     - React
   - Yoga (1.14.0)
@@ -418,6 +420,7 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - RNStaticSafeAreaInsets (from `../node_modules/react-native-static-safe-area-insets`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
   - ZIPFoundation (~> 0.9.11)
@@ -528,6 +531,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-permissions"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  RNStaticSafeAreaInsets:
+    :path: "../node_modules/react-native-static-safe-area-insets"
   RNSVG:
     :path: "../node_modules/react-native-svg"
   Yoga:
@@ -593,6 +598,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8
   RNScreens: 62211832af51e0aebcf6e8c36bcf7dd65592f244
+  RNStaticSafeAreaInsets: 6103cf09647fa427186d30f67b0f5163c1ae8252
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-native-screens": "^2.8.0",
     "react-native-simple-crypto": "^0.2.12",
     "react-native-splash-screen": "^3.2.0",
+    "react-native-static-safe-area-insets": "^2.1.1",
     "react-native-svg": "^12.0.3",
     "reanimated-bottom-sheet": "^1.0.0-alpha.19",
     "regression": "^2.0.1",

--- a/src/AffectedUserFlow/AffectedUserContext.tsx
+++ b/src/AffectedUserFlow/AffectedUserContext.tsx
@@ -11,6 +11,7 @@ import { Stacks, WelcomeStackScreens } from "../navigation"
 
 type Token = string
 type Key = string
+type Posix = number
 
 export interface AffectedUserContextState {
   certificate: Token | null
@@ -21,6 +22,8 @@ export interface AffectedUserContextState {
   navigateOutOfStack: () => void
   linkCode: string | undefined
   setLinkCode: (linkCode: string | undefined) => void
+  symptomOnsetDate: Posix | null
+  setSymptomOnsetDate: (symptomOnsetDate: Posix | null) => void
 }
 
 interface AffectedUserProviderProps {
@@ -41,6 +44,9 @@ export const AffectedUserProvider: FunctionComponent<AffectedUserProviderProps> 
   const [hmacKey, setHmacKey] = useState<Key | null>(null)
   const [certificate, setCertificate] = useState<Token | null>(null)
   const [linkCode, setLinkCode] = useState<string | undefined>(undefined)
+  const [symptomOnsetDate, setSymptomOnsetDate] = useState<Posix | null>(
+    Date.now(),
+  )
 
   const setExposureSubmissionCredentials = (
     certificate: Token,
@@ -75,6 +81,8 @@ export const AffectedUserProvider: FunctionComponent<AffectedUserProviderProps> 
         navigateOutOfStack,
         linkCode,
         setLinkCode,
+        symptomOnsetDate,
+        setSymptomOnsetDate,
       }}
     >
       {children}

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -82,7 +82,6 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
     : AffectedUserFlowStackScreens.AffectedUserPublishConsent
 
   const handleOnPressSubmit = async () => {
-    navigation.navigate(AffectedUserFlowStackScreens.SymptomOnsetDate)
     setIsLoading(true)
     setErrorMessage(defaultErrorMessage)
     trackEvent("product_analytics", "verification_code_submitted")

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -76,6 +76,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
   }
 
   const handleOnPressSubmit = async () => {
+    navigation.navigate(AffectedUserFlowStackScreens.SymptomOnsetDate)
     setIsLoading(true)
     setErrorMessage(defaultErrorMessage)
     trackEvent("product_analytics", "verification_code_submitted")
@@ -101,9 +102,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
           setExposureKeys(exposureKeys)
           setExposureSubmissionCredentials(certificate, hmacKey)
           Keyboard.dismiss()
-          navigation.navigate(
-            AffectedUserFlowStackScreens.AffectedUserPublishConsent,
-          )
+          navigation.navigate(AffectedUserFlowStackScreens.SymptomOnsetDate)
         } else {
           const errorMessage = showCertificateError(certResponse.error)
           Logger.error(

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -25,6 +25,7 @@ import {
   AffectedUserFlowStackScreens,
 } from "../../navigation"
 import Logger from "../../logger"
+import { useConfigurationContext } from "../../ConfigurationContext"
 
 import {
   Spacing,
@@ -52,6 +53,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
     setExposureSubmissionCredentials,
     setExposureKeys,
   } = useAffectedUserContext()
+  const { includeSymptomOnsetDate } = useConfigurationContext()
 
   const [code, setCode] = useState(linkCode || "")
   const [isLoading, setIsLoading] = useState(false)
@@ -74,6 +76,10 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
   const handleOnPressSecondaryButton = () => {
     navigation.navigate(AffectedUserFlowStackScreens.VerificationCodeInfo)
   }
+
+  const nextScreen = includeSymptomOnsetDate
+    ? AffectedUserFlowStackScreens.SymptomOnsetDate
+    : AffectedUserFlowStackScreens.AffectedUserPublishConsent
 
   const handleOnPressSubmit = async () => {
     navigation.navigate(AffectedUserFlowStackScreens.SymptomOnsetDate)
@@ -102,7 +108,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
           setExposureKeys(exposureKeys)
           setExposureSubmissionCredentials(certificate, hmacKey)
           Keyboard.dismiss()
-          navigation.navigate(AffectedUserFlowStackScreens.SymptomOnsetDate)
+          navigation.navigate(nextScreen)
         } else {
           const errorMessage = showCertificateError(certResponse.error)
           Logger.error(

--- a/src/AffectedUserFlow/SymptomOnsetDate.tsx
+++ b/src/AffectedUserFlow/SymptomOnsetDate.tsx
@@ -18,14 +18,7 @@ import { AffectedUserFlowStackScreens, useStatusBarEffect } from "../navigation"
 import { useAffectedUserContext } from "./AffectedUserContext"
 import Checkbox from "../components/Checkbox"
 
-import {
-  Buttons,
-  Colors,
-  Forms,
-  Outlines,
-  Spacing,
-  Typography,
-} from "../styles"
+import { Buttons, Colors, Forms, Spacing, Typography } from "../styles"
 import { Icons } from "../assets"
 
 type Posix = number
@@ -38,6 +31,10 @@ const SymptomOnsetDate: FunctionComponent = () => {
   const { symptomOnsetDate, setSymptomOnsetDate } = useAffectedUserContext()
 
   const [showDatePickerAndroid, setShowDatePickerAndroid] = useState(false)
+
+  const handleOnPressHasSymptoms = () => {
+    setSymptomOnsetDate(Date.now())
+  }
 
   const handleOnPressNoSymptoms = () => {
     setSymptomOnsetDate(null)
@@ -65,48 +62,60 @@ const SymptomOnsetDate: FunctionComponent = () => {
 
   const showDatePicker = showDatePickerAndroid || Platform.OS === "ios"
 
-  const noSymptomsContainerStyle = symptomOnsetDate
-    ? { ...style.noSymptomsContainer, opacity: 0.5 }
-    : style.noSymptomsContainer
+  const hasSymptomsContainerStyle = symptomOnsetDate ? {} : { opacity: 0.5 }
 
-  const dateInputStyle = symptomOnsetDate ? {} : { opacity: 0.5 }
+  const noSymptomsContainerStyle = symptomOnsetDate ? { opacity: 0.5 } : {}
 
   return (
     <View style={style.container}>
       <View>
         <Text style={style.headerText}>
-          {t("export.symptom_onset.when_did_your")}
+          {t("export.symptom_onset.symptoms")}
         </Text>
 
-        <View style={style.inputContainer}>
-          <Text style={style.inputLabel}>
-            {t("export.symptom_onset.symptom_onset_date")}
+        <View style={style.radioButtonsContainer}>
+          <Text style={style.subheaderText}>
+            {t("export.symptom_onset.did_you_have_symptoms")}
           </Text>
-          <View style={dateInputStyle}>
-            {Platform.OS === "android" && (
-              <Pressable
-                onPress={handleOnPressDateInput}
-                style={style.dateInput}
-              >
-                <Text style={style.dateInputText}>{formattedDate}</Text>
-              </Pressable>
-            )}
-            {showDatePicker && (
-              <DatePicker
-                date={symptomOnsetDate}
-                handleOnChangeTestDate={handleOnChangeTestDate}
-              />
-            )}
+          <View style={noSymptomsContainerStyle}>
+            <Checkbox
+              label={t("export.symptom_onset.no_i_didnt_have")}
+              onPress={handleOnPressNoSymptoms}
+              checked={Boolean(!symptomOnsetDate)}
+            />
+          </View>
+          <View style={hasSymptomsContainerStyle}>
+            <Checkbox
+              label={t("export.symptom_onset.yes_i_did_have")}
+              onPress={handleOnPressHasSymptoms}
+              checked={Boolean(symptomOnsetDate)}
+            />
           </View>
         </View>
 
-        <View style={noSymptomsContainerStyle}>
-          <Checkbox
-            label={t("export.symptom_onset.i_didnt_have")}
-            onPress={handleOnPressNoSymptoms}
-            checked={Boolean(!symptomOnsetDate)}
-          />
-        </View>
+        {symptomOnsetDate ? (
+          <View>
+            <Text style={style.subheaderText}>
+              {t("export.symptom_onset.when_did_your_symptoms")}
+            </Text>
+            <View style={style.inputContainer}>
+              {Platform.OS === "android" && (
+                <Pressable
+                  onPress={handleOnPressDateInput}
+                  style={style.dateInput}
+                >
+                  <Text style={style.dateInputText}>{formattedDate}</Text>
+                </Pressable>
+              )}
+              {showDatePicker && (
+                <DatePicker
+                  date={symptomOnsetDate}
+                  handleOnChangeTestDate={handleOnChangeTestDate}
+                />
+              )}
+            </View>
+          </View>
+        ) : null}
       </View>
 
       <TouchableOpacity
@@ -135,7 +144,7 @@ const DatePicker: FunctionComponent<DatePickerProps> = ({
       mode="date"
       display={Platform.OS === "ios" ? "compact" : "calendar"}
       value={date ? dayjs(date).toDate() : dayjs().toDate()}
-      minimumDate={dayjs().subtract(4, "week").toDate()}
+      minimumDate={dayjs().subtract(2, "month").toDate()}
       maximumDate={dayjs().toDate()}
       onChange={handleOnChangeTestDate}
     />
@@ -153,26 +162,23 @@ const style = StyleSheet.create({
   },
   headerText: {
     ...Typography.header.x60,
-    marginBottom: Spacing.xxLarge,
+    marginBottom: Spacing.medium,
+  },
+  subheaderText: {
+    ...Typography.header.x30,
+    marginBottom: Spacing.small,
+  },
+  radioButtonsContainer: {
+    marginBottom: Spacing.small,
   },
   inputContainer: {
     marginBottom: Spacing.large,
-    paddingBottom: Spacing.large,
-    borderColor: Colors.neutral.shade10,
-    borderBottomWidth: Outlines.hairline,
-  },
-  inputLabel: {
-    ...Typography.form.inputLabel,
-    paddingBottom: Spacing.xxSmall,
   },
   dateInput: {
     ...Forms.textInput,
   },
   dateInputText: {
     ...Typography.body.x30,
-  },
-  noSymptomsContainer: {
-    marginBottom: Spacing.xSmall,
   },
   button: {
     ...Buttons.primary.base,

--- a/src/AffectedUserFlow/SymptomOnsetDate.tsx
+++ b/src/AffectedUserFlow/SymptomOnsetDate.tsx
@@ -48,7 +48,11 @@ const SymptomOnsetDate: FunctionComponent = () => {
     symptomOnsetDate: Date | undefined,
   ) => {
     setShowDatePickerAndroid(false)
-    symptomOnsetDate && setSymptomOnsetDate(dayjs(symptomOnsetDate).valueOf())
+
+    if (symptomOnsetDate) {
+      const posix = dayjs(symptomOnsetDate).valueOf()
+      setSymptomOnsetDate(posix)
+    }
   }
 
   const handleOnPressContinue = () => {

--- a/src/AffectedUserFlow/SymptomOnsetDate.tsx
+++ b/src/AffectedUserFlow/SymptomOnsetDate.tsx
@@ -29,7 +29,6 @@ const SymptomOnsetDate: FunctionComponent = () => {
   const navigation = useNavigation()
 
   const { symptomOnsetDate, setSymptomOnsetDate } = useAffectedUserContext()
-
   const [showDatePickerAndroid, setShowDatePickerAndroid] = useState(false)
 
   const handleOnPressHasSymptoms = () => {
@@ -58,7 +57,7 @@ const SymptomOnsetDate: FunctionComponent = () => {
 
   const formattedDate = symptomOnsetDate
     ? dayjs(symptomOnsetDate).format("MMMM DD, YYYY")
-    : t("export.symptom_onset.select_date")
+    : ""
 
   const showDatePicker = showDatePickerAndroid || Platform.OS === "ios"
 

--- a/src/AffectedUserFlow/SymptomOnsetDate.tsx
+++ b/src/AffectedUserFlow/SymptomOnsetDate.tsx
@@ -1,0 +1,123 @@
+import React, { FunctionComponent, useState } from "react"
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native"
+import { useTranslation } from "react-i18next"
+import dayjs from "dayjs"
+import DateTimePicker from "@react-native-community/datetimepicker"
+
+import { useStatusBarEffect } from "../navigation"
+import Checkbox from "../components/Checkbox"
+
+import { Colors, Forms, Outlines, Spacing, Typography } from "../styles"
+
+type Posix = number
+
+const SymptomOnsetDate: FunctionComponent = () => {
+  useStatusBarEffect("dark-content", Colors.background.primaryLight)
+  const { t } = useTranslation()
+
+  const [hasNoSymptoms, setHasNoSymptoms] = useState<boolean>(false)
+  const [date, setDate] = useState<Posix>(Date.now())
+  const [showDatePickerAndroid, setShowDatePickerAndroid] = useState(false)
+
+  const handleOnPressNoSymptoms = () => {
+    setHasNoSymptoms(!hasNoSymptoms)
+  }
+
+  const handleOnPressDateInput = () => {
+    setShowDatePickerAndroid(true)
+  }
+
+  const handleOnChangeTestDate = (_event: Event, date: Date | undefined) => {
+    setShowDatePickerAndroid(false)
+    date && setDate(dayjs(date).valueOf())
+  }
+
+  const formattedDate = dayjs(date).format("MMMM DD, YYYY")
+
+  const showDatePicker = showDatePickerAndroid || Platform.OS === "ios"
+
+  return (
+    <View style={style.container}>
+      <Text style={style.headerText}>
+        {t("export.symptom_onset.when_did_your")}
+      </Text>
+      <View style={style.noSymptomsContainer}>
+        <Checkbox
+          label={t("export.symptom_onset.i_didnt_have")}
+          onPress={handleOnPressNoSymptoms}
+          checked={hasNoSymptoms}
+        />
+      </View>
+      <View style={style.inputContainer}>
+        <Text style={style.inputLabel}>
+          {t("escrow_verification.user_details_form.test_date")}
+        </Text>
+        {Platform.OS === "android" && (
+          <Pressable onPress={handleOnPressDateInput} style={style.dateInput}>
+            <Text style={style.dateInputText}>{formattedDate}</Text>
+          </Pressable>
+        )}
+        {showDatePicker && (
+          <DatePicker
+            date={date}
+            handleOnChangeTestDate={handleOnChangeTestDate}
+          />
+        )}
+      </View>
+    </View>
+  )
+}
+
+interface DatePickerProps {
+  date: Posix
+  handleOnChangeTestDate: (_event: Event, date: Date | undefined) => void
+}
+
+const DatePicker: FunctionComponent<DatePickerProps> = ({
+  date,
+  handleOnChangeTestDate,
+}) => {
+  return (
+    <DateTimePicker
+      mode="date"
+      display={Platform.OS === "ios" ? "compact" : "calendar"}
+      value={dayjs(date).toDate()}
+      minimumDate={dayjs().subtract(4, "week").toDate()}
+      maximumDate={dayjs().toDate()}
+      onChange={handleOnChangeTestDate}
+    />
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background.primaryLight,
+    paddingHorizontal: Spacing.large,
+  },
+  headerText: {
+    ...Typography.header.x60,
+    marginBottom: Spacing.xxLarge,
+  },
+  noSymptomsContainer: {
+    paddingBottom: Spacing.xSmall,
+    marginBottom: Spacing.xSmall,
+    borderColor: Colors.neutral.shade10,
+    borderBottomWidth: Outlines.hairline,
+  },
+  inputContainer: {
+    marginBottom: Spacing.medium,
+  },
+  inputLabel: {
+    ...Typography.form.inputLabel,
+    paddingBottom: Spacing.xxSmall,
+  },
+  dateInput: {
+    ...Forms.textInput,
+  },
+  dateInputText: {
+    ...Typography.body.x30,
+  },
+})
+
+export default SymptomOnsetDate

--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -24,6 +24,7 @@ export interface Configuration {
   healthAuthorityLegalPrivacyPolicyUrl: string | null
   healthAuthorityPrivacyPolicyUrl: string
   healthAuthorityVerificationCodeInfoUrl: string | null
+  includeSymptomOnsetDate: boolean
   measurementSystem: MeasurementSystem
   minimumAge: string
   minimumPhoneDigits: number
@@ -52,6 +53,7 @@ const initialState: Configuration = {
   healthAuthorityLegalPrivacyPolicyUrl: "",
   healthAuthorityPrivacyPolicyUrl: "",
   healthAuthorityVerificationCodeInfoUrl: null,
+  includeSymptomOnsetDate: false,
   measurementSystem: "Imperial" as const,
   minimumAge: "18",
   minimumPhoneDigits: 0,
@@ -103,9 +105,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
 
   const enableProductAnalytics = env.ENABLE_PRODUCT_ANALYTICS === "true"
 
-  const verificationStrategy: VerificationStrategy = toVerificationStrategy(
-    env.VERIFICATION_STRATEGY,
-  )
+  const includeSymptomOnsetDate = env.INCLUDE_SYMPTOM_ONSET_DATE === "true"
 
   const measurementSystem =
     env.MEASUREMENT_SYSTEM === "metric" ? "Metric" : "Imperial"
@@ -122,6 +122,10 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
 
   const stateAbbreviation =
     env.STATE_ABBREVIATION?.length > 0 ? env.STATE_ABBREVIATION : null
+
+  const verificationStrategy: VerificationStrategy = toVerificationStrategy(
+    env.VERIFICATION_STRATEGY,
+  )
 
   return (
     <ConfigurationContext.Provider
@@ -145,6 +149,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         healthAuthorityLegalPrivacyPolicyUrl,
         healthAuthorityPrivacyPolicyUrl,
         healthAuthorityVerificationCodeInfoUrl,
+        includeSymptomOnsetDate,
         measurementSystem,
         minimumAge,
         minimumPhoneDigits,

--- a/src/Device/PermissionsContext.tsx
+++ b/src/Device/PermissionsContext.tsx
@@ -99,7 +99,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
           request: requestNotificationPermission,
         },
         exposureNotifications: {
-          status: enPermission,
+          status: "Active",
         },
       }}
     >

--- a/src/Device/PermissionsContext.tsx
+++ b/src/Device/PermissionsContext.tsx
@@ -99,7 +99,7 @@ const PermissionsProvider: FunctionComponent = ({ children }) => {
           request: requestNotificationPermission,
         },
         exposureNotifications: {
-          status: "Active",
+          status: enPermission,
         },
       }}
     >

--- a/src/SymptomHistory/Form/SelectSymptoms.tsx
+++ b/src/SymptomHistory/Form/SelectSymptoms.tsx
@@ -18,7 +18,7 @@ import {
   hasEmergencySymptoms,
   SymptomEntry,
 } from "../symptomHistory"
-import Checkbox from "./Checkbox"
+import Checkbox from "../../components/Checkbox"
 
 import {
   Affordances,

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -2,10 +2,10 @@ import React, { FunctionComponent, useState } from "react"
 import { View, StyleSheet, TouchableWithoutFeedback } from "react-native"
 import { SvgXml } from "react-native-svg"
 
-import { Text } from "../../components"
+import { Text } from "."
 
-import { Colors, Iconography, Forms } from "../../styles"
-import { Icons } from "../../assets"
+import { Colors, Iconography, Forms } from "../styles"
+import { Icons } from "../assets"
 
 interface CheckboxProps {
   label: string

--- a/src/factories/affectedUserFlowContext.ts
+++ b/src/factories/affectedUserFlowContext.ts
@@ -11,4 +11,6 @@ export default Factory.define<AffectedUserContextState>(() => ({
   navigateOutOfStack: () => {},
   linkCode: undefined,
   setLinkCode: () => {},
+  symptomOnsetDate: 0,
+  setSymptomOnsetDate: () => {},
 }))

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -21,6 +21,7 @@ export default Factory.define<Configuration>(() => ({
   healthAuthorityPrivacyPolicyUrl: "authorityPrivacyPolicyUrl",
   healthAuthorityLegalPrivacyPolicyUrl: "authorityLegalPrivacyPolicyUrl",
   healthAuthorityVerificationCodeInfoUrl: "authorityVerificationCodeInfoUrl",
+  includeSymptomOnsetDate: false,
   measurementSystem: "Imperial",
   minimumAge: "18",
   minimumPhoneDigits: 0,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -97,7 +97,9 @@
     },
     "symptom_onset": {
       "when_did_your": "When did your symptoms start?",
-      "i_didnt_have": "I didn't have any symptoms"
+      "i_didnt_have": "I didn't have any symptoms",
+      "symptom_onset_date": "Symptom Onset Date",
+      "select_date": "Select Date"
     },
     "intro": {
       "body1": "If you have received a verification code from {{healthAuthorityName}} for a positive COVID-19 test, you can submit the verification code on the following screen.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -95,6 +95,10 @@
       "network_connection_error": "There is no internet connection",
       "unknown_code_verification_error": "Try a different code"
     },
+    "symptom_onset": {
+      "when_did_your": "When did your symptoms start?",
+      "i_didnt_have": "I didn't have any symptoms"
+    },
     "intro": {
       "body1": "If you have received a verification code from {{healthAuthorityName}} for a positive COVID-19 test, you can submit the verification code on the following screen.",
       "body2": "If you do not have a code, but you do have a positive test, you will need to get a verification code from {{healthAuthorityName}} before continuing.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -96,10 +96,13 @@
       "unknown_code_verification_error": "Try a different code"
     },
     "symptom_onset": {
-      "when_did_your": "When did your symptoms start?",
-      "i_didnt_have": "I didn't have any symptoms",
+      "symptoms": "Symptoms",
+      "no_i_didnt_have": "No, I didn't have any symptoms",
+      "yes_i_did_have": "Yes, I did have symptoms",
       "symptom_onset_date": "Symptom Onset Date",
-      "select_date": "Select Date"
+      "select_date": "Select Date",
+      "did_you_have_symptoms": "Did you have any symptoms?",
+      "when_did_your_symptoms": "When did your symptoms begin?"
     },
     "intro": {
       "body1": "If you have received a verification code from {{healthAuthorityName}} for a positive COVID-19 test, you can submit the verification code on the following screen.",

--- a/src/navigation/AffectedUserFlowStack.tsx
+++ b/src/navigation/AffectedUserFlowStack.tsx
@@ -4,6 +4,7 @@ import { createStackNavigator } from "@react-navigation/stack"
 import { AffectedUserProvider } from "../AffectedUserFlow/AffectedUserContext"
 import Start from "../AffectedUserFlow/Start"
 import CodeInput from "../AffectedUserFlow/CodeInput/CodeInputScreen"
+import SymptomOnsetDate from "../AffectedUserFlow/SymptomOnsetDate"
 import Complete from "../AffectedUserFlow/Complete"
 import PublishConsent from "../AffectedUserFlow/PublishConsent/PublishConsentScreen"
 import VerificationCodeInfo from "../AffectedUserFlow/VerificationCodeInfo"
@@ -17,6 +18,7 @@ export type AffectedUserFlowStackParamList = {
   AffectedUserStart: undefined
   VerificationCodeInfo: undefined
   AffectedUserCodeInput: { code?: string; c?: string }
+  SymptomOnsetDate: undefined
   AffectedUserPublishConsent: undefined
   AffectedUserConfirmUpload: undefined
   AffectedUserExportDone: undefined
@@ -52,6 +54,14 @@ const AffectedUserStack: FunctionComponent = () => {
         <Stack.Screen
           name={AffectedUserFlowStackScreens.AffectedUserCodeInput}
           component={CodeInput}
+          options={{
+            ...Headers.headerMinimalOptions,
+            headerLeft: applyHeaderLeftBackButton(),
+          }}
+        />
+        <Stack.Screen
+          name={AffectedUserFlowStackScreens.SymptomOnsetDate}
+          component={SymptomOnsetDate}
           options={{
             ...Headers.headerMinimalOptions,
             headerLeft: applyHeaderLeftBackButton(),

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -165,6 +165,7 @@ export type AffectedUserFlowStackScreen =
   | "AffectedUserStart"
   | "VerificationCodeInfo"
   | "AffectedUserCodeInput"
+  | "SymptomOnsetDate"
   | "AffectedUserPublishConsent"
   | "AffectedUserConfirmUpload"
   | "AffectedUserExportDone"
@@ -176,6 +177,7 @@ export const AffectedUserFlowStackScreens: {
   AffectedUserStart: "AffectedUserStart",
   VerificationCodeInfo: "VerificationCodeInfo",
   AffectedUserCodeInput: "AffectedUserCodeInput",
+  SymptomOnsetDate: "SymptomOnsetDate",
   AffectedUserPublishConsent: "AffectedUserPublishConsent",
   AffectedUserConfirmUpload: "AffectedUserConfirmUpload",
   AffectedUserExportDone: "AffectedUserExportDone",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6700,6 +6700,11 @@ react-native-splash-screen@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"
 
+react-native-static-safe-area-insets@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-static-safe-area-insets/-/react-native-static-safe-area-insets-2.1.1.tgz#394a3510c7029288895bbaccf1dadf4fa46c4b88"
+  integrity sha512-NUSRNZp+0IJOuLeoHoU4kw/cY9g7ozUo2ApCbJAiPyYbkbv49S8gdAcZRkeR0nqwzFDA07sCZCbPI03iEV0RTQ==
+
 react-native-svg-transformer@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/react-native-svg-transformer/-/react-native-svg-transformer-0.14.3.tgz#43c8e176f5a11f16f39b87a64018e0ac090ffbdb"


### PR DESCRIPTION
Why: we would like to be have the option to include the symptom onset date in the positive test result submission.

This commit:
Adds a `SymptomOnsetDate` screen to the `AffectedUserFlow` that can be activated with a build flag
The `SymptomOnsetDate` either collects a date or null if the user was asymptomatic. This value is saved to the context. Nothing else is done with this value. A future PR will add the symptom onset date to the network request if it exists.
Adds the `react-native-static-safe-area-insets` package, which enables us to get the device's insets without using a hook.

Note: the yellow color on the iPhone simulator isn't in the actual app, there's just something off with my simulator.

![gif](https://user-images.githubusercontent.com/39350030/102252485-21716300-3ed4-11eb-9854-e4239d3a6272.gif)