### PR TITLE
Include symptom onset date in exposure key payload

### DIFF
--- a/src/AffectedUserFlow/AffectedUserContext.tsx
+++ b/src/AffectedUserFlow/AffectedUserContext.tsx
@@ -44,9 +44,8 @@ export const AffectedUserProvider: FunctionComponent<AffectedUserProviderProps> 
   const [hmacKey, setHmacKey] = useState<Key | null>(null)
   const [certificate, setCertificate] = useState<Token | null>(null)
   const [linkCode, setLinkCode] = useState<string | undefined>(undefined)
-  const [symptomOnsetDate, setSymptomOnsetDate] = useState<Posix | null>(
-    Date.now(),
-  )
+
+  const [symptomOnsetDate, setSymptomOnsetDate] = useState<Posix | null>(null)
 
   const setExposureSubmissionCredentials = (
     certificate: Token,

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -35,7 +35,7 @@ const CodeInputScreen: FunctionComponent = () => {
 
   return (
     <View style={style.container}>
-      {isENActive ? (
+      {true ? (
         <CodeInputForm linkCode={linkCode} />
       ) : (
         <EnableExposureNotifications />

--- a/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputScreen.tsx
@@ -35,7 +35,7 @@ const CodeInputScreen: FunctionComponent = () => {
 
   return (
     <View style={style.container}>
-      {true ? (
+      {isENActive ? (
         <CodeInputForm linkCode={linkCode} />
       ) : (
         <EnableExposureNotifications />

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.spec.tsx
@@ -31,6 +31,7 @@ describe("PublishConsentForm", () => {
           appPackageName=""
           regionCodes={[""]}
           navigateOutOfStack={() => {}}
+          symptomOnsetDate={null}
         />
       </ExposureContext.Provider>,
     )
@@ -85,6 +86,7 @@ describe("PublishConsentForm", () => {
           appPackageName={appPackageName}
           regionCodes={regionCodes}
           navigateOutOfStack={() => {}}
+          symptomOnsetDate={null}
         />,
       )
 
@@ -98,6 +100,7 @@ describe("PublishConsentForm", () => {
           hmacKey,
           appPackageName,
           revisionToken,
+          null,
         )
         expect(storeRevisionTokenSpy).toHaveBeenCalledWith(newRevisionToken)
         expect(navigateSpy).toHaveBeenCalledWith(
@@ -136,6 +139,7 @@ describe("PublishConsentForm", () => {
             appPackageName=""
             regionCodes={[""]}
             navigateOutOfStack={() => {}}
+            symptomOnsetDate={null}
           />,
         )
 
@@ -180,6 +184,7 @@ describe("PublishConsentForm", () => {
             appPackageName=""
             regionCodes={[""]}
             navigateOutOfStack={() => {}}
+            symptomOnsetDate={null}
           />,
         )
 
@@ -224,6 +229,7 @@ describe("PublishConsentForm", () => {
             appPackageName=""
             regionCodes={[""]}
             navigateOutOfStack={() => {}}
+            symptomOnsetDate={null}
           />,
         )
 
@@ -266,6 +272,7 @@ describe("PublishConsentForm", () => {
             appPackageName=""
             regionCodes={[""]}
             navigateOutOfStack={() => {}}
+            symptomOnsetDate={null}
           />,
         )
 
@@ -308,6 +315,7 @@ describe("PublishConsentForm", () => {
             appPackageName=""
             regionCodes={[""]}
             navigateOutOfStack={() => {}}
+            symptomOnsetDate={null}
           />,
         )
 
@@ -351,6 +359,7 @@ describe("PublishConsentForm", () => {
             appPackageName=""
             regionCodes={[""]}
             navigateOutOfStack={() => {}}
+            symptomOnsetDate={null}
           />,
         )
 

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -31,6 +31,8 @@ import {
   PostKeysNoOpReason,
 } from "../exposureNotificationAPI"
 
+type Posix = number
+
 interface PublishConsentFormProps {
   hmacKey: string
   certificate: string
@@ -40,6 +42,7 @@ interface PublishConsentFormProps {
   appPackageName: string
   regionCodes: string[]
   navigateOutOfStack: () => void
+  symptomOnsetDate: Posix | null
 }
 
 const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
@@ -51,6 +54,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
   appPackageName,
   regionCodes,
   navigateOutOfStack,
+  symptomOnsetDate,
 }) => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const navigation = useNavigation()
@@ -162,6 +166,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
       hmacKey,
       appPackageName,
       revisionToken,
+      symptomOnsetDate,
     )
     setIsLoading(false)
     if (response.kind === "success") {

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentScreen.tsx
@@ -19,6 +19,7 @@ const PublishConsentScreen: FunctionComponent = () => {
     hmacKey,
     exposureKeys,
     navigateOutOfStack,
+    symptomOnsetDate,
   } = useAffectedUserContext()
   const { appPackageName, regionCodes } = useConfigurationContext()
 
@@ -39,6 +40,7 @@ const PublishConsentScreen: FunctionComponent = () => {
         appPackageName={appPackageName}
         regionCodes={regionCodes}
         navigateOutOfStack={navigateOutOfStack}
+        symptomOnsetDate={symptomOnsetDate}
       />
     )
   } else {

--- a/src/AffectedUserFlow/SymptomOnsetDate.tsx
+++ b/src/AffectedUserFlow/SymptomOnsetDate.tsx
@@ -28,15 +28,21 @@ const SymptomOnsetDate: FunctionComponent = () => {
   const { t } = useTranslation()
   const navigation = useNavigation()
 
-  const { symptomOnsetDate, setSymptomOnsetDate } = useAffectedUserContext()
+  const {
+    setSymptomOnsetDate: setContextSymptomOnsetDate,
+  } = useAffectedUserContext()
   const [showDatePickerAndroid, setShowDatePickerAndroid] = useState(false)
+  const [
+    localSymptomOnsetDate,
+    setLocalSymptomOnsetDate,
+  ] = useState<Posix | null>(null)
 
   const handleOnPressHasSymptoms = () => {
-    setSymptomOnsetDate(Date.now())
+    setLocalSymptomOnsetDate(Date.now())
   }
 
   const handleOnPressNoSymptoms = () => {
-    setSymptomOnsetDate(null)
+    setLocalSymptomOnsetDate(null)
   }
 
   const handleOnPressDateInput = () => {
@@ -45,29 +51,32 @@ const SymptomOnsetDate: FunctionComponent = () => {
 
   const handleOnChangeTestDate = (
     _event: Event,
-    symptomOnsetDate: Date | undefined,
+    localSymptomOnsetDate: Date | undefined,
   ) => {
     setShowDatePickerAndroid(false)
 
-    if (symptomOnsetDate) {
-      const posix = dayjs(symptomOnsetDate).valueOf()
-      setSymptomOnsetDate(posix)
+    if (localSymptomOnsetDate) {
+      const posix = dayjs(localSymptomOnsetDate).valueOf()
+      setLocalSymptomOnsetDate(posix)
     }
   }
 
   const handleOnPressContinue = () => {
+    setContextSymptomOnsetDate(localSymptomOnsetDate)
     navigation.navigate(AffectedUserFlowStackScreens.AffectedUserPublishConsent)
   }
 
-  const formattedDate = symptomOnsetDate
-    ? dayjs(symptomOnsetDate).format("MMMM DD, YYYY")
+  const formattedDate = localSymptomOnsetDate
+    ? dayjs(localSymptomOnsetDate).format("MMMM DD, YYYY")
     : ""
 
   const showDatePicker = showDatePickerAndroid || Platform.OS === "ios"
 
-  const hasSymptomsContainerStyle = symptomOnsetDate ? {} : { opacity: 0.5 }
+  const hasSymptomsContainerStyle = localSymptomOnsetDate
+    ? {}
+    : { opacity: 0.5 }
 
-  const noSymptomsContainerStyle = symptomOnsetDate ? { opacity: 0.5 } : {}
+  const noSymptomsContainerStyle = localSymptomOnsetDate ? { opacity: 0.5 } : {}
 
   return (
     <View style={style.container}>
@@ -84,19 +93,19 @@ const SymptomOnsetDate: FunctionComponent = () => {
             <Checkbox
               label={t("export.symptom_onset.no_i_didnt_have")}
               onPress={handleOnPressNoSymptoms}
-              checked={Boolean(!symptomOnsetDate)}
+              checked={Boolean(!localSymptomOnsetDate)}
             />
           </View>
           <View style={hasSymptomsContainerStyle}>
             <Checkbox
               label={t("export.symptom_onset.yes_i_did_have")}
               onPress={handleOnPressHasSymptoms}
-              checked={Boolean(symptomOnsetDate)}
+              checked={Boolean(localSymptomOnsetDate)}
             />
           </View>
         </View>
 
-        {symptomOnsetDate ? (
+        {localSymptomOnsetDate ? (
           <View>
             <Text style={style.subheaderText}>
               {t("export.symptom_onset.when_did_your_symptoms")}
@@ -112,7 +121,7 @@ const SymptomOnsetDate: FunctionComponent = () => {
               )}
               {showDatePicker && (
                 <DatePicker
-                  date={symptomOnsetDate}
+                  date={localSymptomOnsetDate}
                   handleOnChangeTestDate={handleOnChangeTestDate}
                 />
               )}

--- a/src/AffectedUserFlow/SymptomOnsetDate.tsx
+++ b/src/AffectedUserFlow/SymptomOnsetDate.tsx
@@ -147,7 +147,7 @@ const DatePicker: FunctionComponent<DatePickerProps> = ({
       mode="date"
       display={Platform.OS === "ios" ? "compact" : "calendar"}
       value={date ? dayjs(date).toDate() : dayjs().toDate()}
-      minimumDate={dayjs().subtract(2, "month").toDate()}
+      minimumDate={dayjs().subtract(14, "day").toDate()}
       maximumDate={dayjs().toDate()}
       onChange={handleOnChangeTestDate}
     />

--- a/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
@@ -21,6 +21,7 @@ describe("postDiagnosisKeys", () => {
     const hmacKey = "hmacKey"
     const appPackageName = "appPackageName"
     const revisionToken = "revisionToken"
+    const symptomOnsetDate = null
 
     const fetchWithTimeoutSpy = fetchWithTimeout as jest.Mock
     fetchWithTimeoutSpy.mockRejectedValueOnce("error")
@@ -32,6 +33,7 @@ describe("postDiagnosisKeys", () => {
       hmacKey,
       appPackageName,
       revisionToken,
+      symptomOnsetDate,
     )
 
     // The constants are taken from "__mocks__/react-native-config.js"
@@ -73,6 +75,7 @@ describe("postDiagnosisKeys", () => {
         "hmacKey",
         "appPackageName",
         "revisionToken",
+        null,
       )
 
       expect(result).toEqual({
@@ -103,6 +106,7 @@ describe("postDiagnosisKeys", () => {
         "hmacKey",
         "appPackageName",
         "revisionToken",
+        null,
       )
 
       expect(result).toEqual({
@@ -134,6 +138,7 @@ describe("postDiagnosisKeys", () => {
         "hmacKey",
         "appPackageName",
         "revisionToken",
+        null,
       )
 
       expect(result).toEqual({
@@ -171,6 +176,7 @@ describe("postDiagnosisKeys", () => {
         "hmacKey",
         "appPackageName",
         "revisionToken",
+        null,
       )
 
       expect(result).toEqual({
@@ -209,6 +215,7 @@ describe("postDiagnosisKeys", () => {
         "hmacKey",
         "appPackageName",
         "revisionToken",
+        null,
       )
 
       expect(result).toEqual({
@@ -235,6 +242,7 @@ describe("postDiagnosisKeys", () => {
           "hmacKey",
           "appPackageName",
           "revisionToken",
+          null,
         )
 
         expect(result).toEqual({
@@ -257,6 +265,7 @@ describe("postDiagnosisKeys", () => {
           "hmacKey",
           "appPackageName",
           "revisionToken",
+          null,
         )
 
         expect(result).toEqual({
@@ -283,6 +292,7 @@ describe("postDiagnosisKeys", () => {
           "hmacKey",
           "appPackageName",
           "revisionToken",
+          null,
         )
 
         expect(result).toEqual({

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -94,6 +94,7 @@ class PostDiagnosisKeysRequest {
 
   private postKeys = async () => {
     try {
+      console.log(this.requestBody())
       const response = (await fetchWithTimeout(
         exposureUrl,
         {
@@ -208,7 +209,7 @@ export const postDiagnosisKeys = async (
 ): Promise<PostKeysResponse | PostKeysFailure> => {
   const toInterval = (posix: Posix): number => {
     const minutesSinceEpoch = posix / 60000
-    const interval = minutesSinceEpoch / 10
+    const interval = Math.floor(minutesSinceEpoch / 10)
     return interval
   }
 
@@ -225,7 +226,7 @@ export const postDiagnosisKeys = async (
   const data = symptomOnsetDate
     ? {
         ...baseData,
-        symptomOnSetInterval: toInterval(symptomOnsetDate),
+        symptomOnsetInterval: toInterval(symptomOnsetDate),
       }
     : baseData
 

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -57,6 +57,8 @@ type RegionCode = string
 
 const DEFAULT_PADDING = ""
 
+type Posix = number
+
 type PostDiagnosisKeysRequestData = {
   temporaryExposureKeys: ExposureKey[]
   regions: RegionCode[]
@@ -65,6 +67,7 @@ type PostDiagnosisKeysRequestData = {
   padding: string
   appPackageName: string
   revisionToken: string
+  symptomOnsetInterval?: Posix
 }
 
 class PostDiagnosisKeysRequest {
@@ -201,8 +204,15 @@ export const postDiagnosisKeys = async (
   hmacKey: string,
   appPackageName: string,
   revisionToken: string,
+  symptomOnsetDate: Posix | null,
 ): Promise<PostKeysResponse | PostKeysFailure> => {
-  return await PostDiagnosisKeysRequest.perform({
+  const toInterval = (posix: Posix): number => {
+    const minutesSinceEpoch = posix / 60000
+    const interval = minutesSinceEpoch / 10
+    return interval
+  }
+
+  const baseData = {
     temporaryExposureKeys: exposureKeys,
     regions: regionCodes,
     appPackageName,
@@ -210,5 +220,14 @@ export const postDiagnosisKeys = async (
     hmackey: hmacKey,
     padding: DEFAULT_PADDING,
     revisionToken,
-  })
+  }
+
+  const data = symptomOnsetDate
+    ? {
+        ...baseData,
+        symptomOnSetInterval: toInterval(symptomOnsetDate),
+      }
+    : baseData
+
+  return await PostDiagnosisKeysRequest.perform(data)
 }

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -94,7 +94,6 @@ class PostDiagnosisKeysRequest {
 
   private postKeys = async () => {
     try {
-      console.log(this.requestBody())
       const response = (await fetchWithTimeout(
         exposureUrl,
         {


### PR DESCRIPTION
Why:
A previous commit introduced a form for users to provide their symptom onset date when submitting their exposure keys. We would like to include this symptom onset date in the payload to the exposure server.

This commit:
Threads through the existing symptom onset date to the post function. Note that the symptomOnsetInterval expected by the api is the number of 10 minute increments since the epoch.

Co-Authored-By: Devin Jameson <devin@thoughtbot.com>
Co-Authored-By: John Schoeman <johnschoeman1617@gmail.com>