### PR TITLE
Fix typo in en deep link domain

### DIFF
--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -54,7 +54,7 @@ const settingsStackTransitionPreset = Platform.select({
 })
 
 const customPrefixes = env.DEEP_LINK_PREFIXES?.split(",") || []
-const allPrefixes = ["pathcheck://", "https://*.en.express/", ...customPrefixes]
+const allPrefixes = ["pathcheck://", "https://*.en.express", ...customPrefixes]
 
 const linking: LinkingOptions = {
   prefixes: allPrefixes,


### PR DESCRIPTION
Why:
We currently have an extra `/` at the end of a the wildcard en link for
universal links to the app.

This commit:
Removes the extra '/'

Co-Authored-By: Devin Jameson <devin@thoughtbot.com>