### PR TITLE
Add note to src/locales/pull.sh

### DIFF
--- a/src/locales/pull.sh
+++ b/src/locales/pull.sh
@@ -13,6 +13,8 @@ function found_exe() {
   hash "$1" 2>/dev/null
 }
 
+# Check if lokalise2 is in Path and install if not
+# note the executable must be accessible from $PATH
 if ! found_exe lokalise2; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
 


### PR DESCRIPTION
Why:
If a user of the i18n:pull script doesn't have lokalise2 available the
script will fail. We would like to include a note to explain this to
readers of the script.

Reference: https://github.com/Path-Check/gaen-mobile/issues/711