### PR TITLE
Update fastlane-plugin-appcenter (Android)

### DIFF
--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-appcenter (1.9.0)
+    fastlane-plugin-appcenter (1.11.0)
     fastlane-plugin-increment_version_code (0.4.3)
     fastlane-plugin-load_json (0.0.1)
     gh_inspector (1.1.3)


### PR DESCRIPTION
#### Why:
Our builds are currently failing on CI due to an out-of-date fastlane plugin

#### This commit:
This commit updates `fastlane-plugin-appcenter` for android
