### PR TITLE
Fix ios warnings

### DIFF
--- a/ios/BT/bridge/UtilsModule.swift
+++ b/ios/BT/bridge/UtilsModule.swift
@@ -2,6 +2,10 @@ import Foundation
 
 @objc(UtilsModule)
 class UtilsModule: NSObject {
+  @objc static func requiresMainQueueSetup() -> Bool {
+    return true
+  }
+  
   @objc func openAppSettings() -> Void {
     let appSettingsUrl = URL(string: UIApplication.openSettingsURLString)!
     DispatchQueue.main.async {

--- a/src/SymptomHistory/Share/SymptomHistoryFormatter.ts
+++ b/src/SymptomHistory/Share/SymptomHistoryFormatter.ts
@@ -1,7 +1,7 @@
 import { TFunction } from "i18next"
 
 import { posixToDayjs } from "../../utils/dateTime"
-import { DATE_FORMAT } from "../index"
+import { DATE_FORMAT } from "../SymptomEntryListItem"
 import { SymptomHistory, SymptomEntry } from "../symptomHistory"
 import * as Symptom from "../symptom"
 

--- a/src/SymptomHistory/SymptomEntryListItem.tsx
+++ b/src/SymptomHistory/SymptomEntryListItem.tsx
@@ -9,7 +9,6 @@ import { SymptomHistoryStackParams } from "../navigation/SymptomHistoryStack"
 import { SymptomHistoryStackScreens } from "../navigation"
 import { Text } from "../components"
 import { posixToDayjs } from "../utils/dateTime"
-import { DATE_FORMAT } from "./index"
 import * as Symptom from "./symptom"
 import { SymptomEntry } from "./symptomHistory"
 
@@ -23,6 +22,8 @@ import {
   Iconography,
   Layout,
 } from "../styles"
+
+export const DATE_FORMAT = "ddd MMM D, YYYY"
 
 type SymptomEntryListItemProps = {
   entry: SymptomEntry

--- a/src/SymptomHistory/index.spec.tsx
+++ b/src/SymptomHistory/index.spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from "@testing-library/react-native"
 import { Share } from "react-native"
 import dayjs from "dayjs"
 
-import { DATE_FORMAT } from "./index"
+import { DATE_FORMAT } from "./SymptomEntryListItem"
 import { SymptomHistoryContext } from "./SymptomHistoryContext"
 import { SymptomHistory } from "./symptomHistory"
 import { Symptom } from "./symptom"

--- a/src/SymptomHistory/index.tsx
+++ b/src/SymptomHistory/index.tsx
@@ -20,8 +20,6 @@ import SymptomHistoryFormatter from "./Share/SymptomHistoryFormatter"
 
 import { Buttons, Colors, Spacing, Typography } from "../styles"
 
-export const DATE_FORMAT = "ddd MMM D, YYYY"
-
 const SymptomHistory: FunctionComponent = () => {
   useStatusBarEffect("dark-content", Colors.background.primaryLight)
   const { t } = useTranslation()


### PR DESCRIPTION
Why:
Currently we have a few warnings on start up that we would like to
address:
1. Not explicitly stating that UtilsModule requiresMainQueueSetup = true
2. An import cycle in they symptom history

This commit:
Fixes the issues that caused the warnings.