### PR TITLE
Add next steps tap to analytics events

### DIFF
--- a/docs/PRODUCT_ANALYTICS_EVENTS.md
+++ b/docs/PRODUCT_ANALYTICS_EVENTS.md
@@ -27,6 +27,8 @@ it.
 
 - Number of ENs preceding key submission (Category: epi_analytics, Action: ens_preceding_positive_diagnosis_count)
 
+- User tapped next steps button (Category: product_analytics, Action: tapped_next_steps_button)
+
 - Session length
 
 - Screen views

--- a/src/ExposureHistory/History/HasExposures.tsx
+++ b/src/ExposureHistory/History/HasExposures.tsx
@@ -56,7 +56,7 @@ const HasExposures: FunctionComponent<HasExposuresProps> = ({ exposures }) => {
         <Text style={style.subheaderText}>
           {t("exposure_history.next_steps")}
         </Text>
-        <NextSteps />
+        <NextSteps exposureDate={mostRecentExposure.date} />
       </View>
     </View>
   )

--- a/src/ExposureHistory/History/NextSteps.tsx
+++ b/src/ExposureHistory/History/NextSteps.tsx
@@ -8,12 +8,19 @@ import { ModalStackScreens } from "../../navigation"
 import { Text } from "../../components"
 import { useConnectionStatus } from "../../Device/useConnectionStatus"
 import { useCustomCopy } from "../../configuration/useCustomCopy"
+import { useProductAnalyticsContext } from "../../ProductAnalytics/Context"
 
 import { Buttons, Colors, Spacing, Typography } from "../../styles"
 import { Icons } from "../../assets"
 import { useConfigurationContext } from "../../ConfigurationContext"
 
-const NextSteps: FunctionComponent = () => {
+type Posix = number
+
+interface NextStepsProps {
+  exposureDate: Posix
+}
+
+const NextSteps: FunctionComponent<NextStepsProps> = ({ exposureDate }) => {
   const { t } = useTranslation()
   const isInternetReachable = useConnectionStatus()
   const navigation = useNavigation()
@@ -23,8 +30,15 @@ const NextSteps: FunctionComponent = () => {
     healthAuthorityAdviceUrl,
   } = useConfigurationContext()
   const { healthAuthorityName } = useCustomCopy()
+  const { trackEvent } = useProductAnalyticsContext()
 
   const handleOnPressNextStep = () => {
+    trackEvent(
+      "product_analytics",
+      "tapped_next_steps_button",
+      "next_steps",
+      exposureDate,
+    )
     Linking.openURL(healthAuthorityAdviceUrl)
   }
 


### PR DESCRIPTION
Why:
When a user that has opted into product analytics we would like to
record the tap event of going to 'NextSteps' from the exposure history
screen.

This commit:
Adds a call to trackEvent for the NextSteps button tap.