### PR TITLE
Fetch custom copy from remote endpoint

### DIFF
--- a/example.env.bt
+++ b/example.env.bt
@@ -4,9 +4,9 @@ MEASUREMENT_SYSTEM=imperial
 MINIMUM_PHONE_DIGITS=0
 SUPPORTED_LOCALES=en,es_PR
 QUARANTINE_LENGTH=14
+REMOTE_CONTENT_URL=https://cdn.pathcheck.app
 
 // Deep Linking
-DEEP_LINK_PREFIXES=https://app.associateddomain.org/
 ENX_APPLINKS_DOMAIN=xx-xx.en.express
 
 // Module Flags

--- a/src/ConfigurationContext.tsx
+++ b/src/ConfigurationContext.tsx
@@ -31,6 +31,7 @@ export interface Configuration {
   minimumAge: string
   minimumPhoneDigits: number
   regionCodes: string[]
+  remoteContentUrl: string | null
   stateAbbreviation: string | null
   verificationStrategy: VerificationStrategy
 }
@@ -62,6 +63,7 @@ const initialState: Configuration = {
   minimumAge: "18",
   minimumPhoneDigits: 0,
   regionCodes: [],
+  remoteContentUrl: null,
   stateAbbreviation: "",
   verificationStrategy: "Simple",
 }
@@ -98,6 +100,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
     env.LEGAL_PRIVACY_POLICY_URL || null
   const healthAuthorityVerificationCodeInfoUrl =
     env.VERIFICATION_CODE_INFO_URL || null
+  const remoteContentUrl = env.REMOTE_CONTENT_URL || null
 
   const displayAcceptTermsOfService =
     env.DISPLAY_ACCEPT_TERMS_OF_SERVICE === "true"
@@ -162,6 +165,7 @@ const ConfigurationProvider: FunctionComponent = ({ children }) => {
         minimumAge,
         minimumPhoneDigits,
         regionCodes,
+        remoteContentUrl,
         stateAbbreviation,
         verificationStrategy,
       }}

--- a/src/Settings/index.tsx
+++ b/src/Settings/index.tsx
@@ -161,6 +161,7 @@ const Settings: FunctionComponent = () => {
         )}
         <View style={style.bottomContainer}>
           <Text style={style.aboutContent}>{aboutContent}</Text>
+
           {authorityLinks?.map(({ url, label }) => {
             return <ExternalLink key={label} url={url} label={label} />
           })}

--- a/src/configuration/remoteContentAPI.ts
+++ b/src/configuration/remoteContentAPI.ts
@@ -1,0 +1,120 @@
+import { JsonDecoder } from "ts-data-json"
+
+import * as Locale from "../locales/locale"
+import Logger from "../logger"
+
+const requestHeaders = {
+  "content-type": "application/json",
+  accept: "application/json",
+}
+
+export type Resource = Partial<Record<Locale.Locale, CustomCopy>> & {
+  en: CustomCopy
+}
+
+export interface CustomCopy {
+  healthAuthorityName: string
+  welcomeMessage?: string
+  about?: string
+  legal?: string
+  verificationCodeInfo?: string
+  verificationCodeHowDoIGet?: string
+  appTransition?: {
+    header: string
+    body1: string
+    body2: string
+  }
+}
+
+const AppTransitionCopyDecoder = JsonDecoder.object(
+  {
+    header: JsonDecoder.string,
+    body1: JsonDecoder.string,
+    body2: JsonDecoder.string,
+  },
+  "AppTransition",
+)
+
+const CustomCopyDecoder = JsonDecoder.object<CustomCopy>(
+  {
+    healthAuthorityName: JsonDecoder.string,
+    welcomeMessage: JsonDecoder.optional(JsonDecoder.string),
+    about: JsonDecoder.optional(JsonDecoder.string),
+    legal: JsonDecoder.optional(JsonDecoder.string),
+    verificationCodeInfo: JsonDecoder.optional(JsonDecoder.string),
+    verificationCodeHowDoIGet: JsonDecoder.optional(JsonDecoder.string),
+    appTransition: JsonDecoder.optional(AppTransitionCopyDecoder),
+  },
+  "CustomCopy",
+)
+
+const ResourceDecoder = JsonDecoder.object<Resource>(
+  {
+    en: CustomCopyDecoder,
+    ar: JsonDecoder.optional(CustomCopyDecoder),
+    ch: JsonDecoder.optional(CustomCopyDecoder),
+    da: JsonDecoder.optional(CustomCopyDecoder),
+    el: JsonDecoder.optional(CustomCopyDecoder),
+    es_419: JsonDecoder.optional(CustomCopyDecoder),
+    es_PR: JsonDecoder.optional(CustomCopyDecoder),
+    es: JsonDecoder.optional(CustomCopyDecoder),
+    fil: JsonDecoder.optional(CustomCopyDecoder),
+    fr: JsonDecoder.optional(CustomCopyDecoder),
+    hmn: JsonDecoder.optional(CustomCopyDecoder),
+    ht: JsonDecoder.optional(CustomCopyDecoder),
+    id: JsonDecoder.optional(CustomCopyDecoder),
+    it: JsonDecoder.optional(CustomCopyDecoder),
+    ja: JsonDecoder.optional(CustomCopyDecoder),
+    ko: JsonDecoder.optional(CustomCopyDecoder),
+    ml: JsonDecoder.optional(CustomCopyDecoder),
+    nl: JsonDecoder.optional(CustomCopyDecoder),
+    pl: JsonDecoder.optional(CustomCopyDecoder),
+    pt_BR: JsonDecoder.optional(CustomCopyDecoder),
+    ro: JsonDecoder.optional(CustomCopyDecoder),
+    ru: JsonDecoder.optional(CustomCopyDecoder),
+    sk: JsonDecoder.optional(CustomCopyDecoder),
+    so: JsonDecoder.optional(CustomCopyDecoder),
+    tl: JsonDecoder.optional(CustomCopyDecoder),
+    tr: JsonDecoder.optional(CustomCopyDecoder),
+    ur: JsonDecoder.optional(CustomCopyDecoder),
+    vi: JsonDecoder.optional(CustomCopyDecoder),
+    zh_Hant: JsonDecoder.optional(CustomCopyDecoder),
+  },
+  "ResourceDecoder",
+)
+
+export type NetworkResponse<T, U> = NetworkSuccess<T> | NetworkFailure<U>
+
+type NetworkSuccess<T> = {
+  kind: "success"
+  data: T
+}
+
+type NetworkFailure<Error> = {
+  kind: "failure"
+  error: Error
+}
+
+type RemoteCopyError = "Unknown"
+
+export const fetchCustomCopy = async (
+  baseUrl: string,
+): Promise<NetworkResponse<Resource, RemoteCopyError>> => {
+  const copyEndpoint = baseUrl + "content/v1/copy.json"
+
+  try {
+    const response = await fetch(copyEndpoint, {
+      method: "GET",
+      headers: requestHeaders,
+    })
+    const json = await response.json()
+    const data = await ResourceDecoder.decodePromise(json)
+    return { kind: "success", data }
+  } catch (e) {
+    switch (e.message) {
+      default:
+        Logger.error("Failed to fetch remote copy", e)
+        return { kind: "failure", error: "Unknown" }
+    }
+  }
+}

--- a/src/configuration/useCustomCopy.ts
+++ b/src/configuration/useCustomCopy.ts
@@ -1,34 +1,43 @@
+import { useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 
 import * as Locale from "../locales/locale"
 import copy from "../../config/copy.json"
+import { useConfigurationContext } from "../ConfigurationContext"
+import * as API from "./remoteContentAPI"
 
 const DEFAULT_LOCALE = "en"
 
-type Resource = Partial<Record<Locale.Locale, CustomCopy>> & { en: CustomCopy }
+const fallbackCopyByLocale = copy as API.Resource
 
-interface CustomCopy {
-  welcomeMessage?: string
-  about?: string
-  legal?: string
-  healthAuthorityName: string
-  verificationCodeInfo?: string
-  verificationCodeHowDoIGet?: string
-  appTransition?: {
-    header: string
-    body1: string
-    body2: string
-  }
-}
-
-const customCopyByLocale = copy as Resource
-
-export const useCustomCopy = (): CustomCopy => {
+export const useCustomCopy = (): API.CustomCopy => {
+  const { remoteContentUrl } = useConfigurationContext()
   const {
     i18n: { language: localeCode },
   } = useTranslation()
+  const [remoteCustomCopy, setRemoteCustomCopy] = useState<API.Resource | null>(
+    null,
+  )
 
   const locale = Locale.fromString(localeCode)
 
-  return customCopyByLocale[locale] || customCopyByLocale[DEFAULT_LOCALE] || {}
+  useEffect(() => {
+    const fetchCopy = async () => {
+      if (remoteContentUrl) {
+        const response = await API.fetchCustomCopy(remoteContentUrl)
+
+        if (response.kind === "success") {
+          const { data } = response
+          setRemoteCustomCopy(data)
+        }
+      }
+    }
+
+    fetchCopy()
+  }, [remoteContentUrl])
+
+  const copyByLocale = remoteCustomCopy || fallbackCopyByLocale
+  const customCopy = copyByLocale[locale] || copyByLocale[DEFAULT_LOCALE] || {}
+
+  return customCopy
 }

--- a/src/factories/configurationContext.ts
+++ b/src/factories/configurationContext.ts
@@ -28,6 +28,7 @@ export default Factory.define<Configuration>(() => ({
   minimumAge: "18",
   minimumPhoneDigits: 0,
   regionCodes: ["REGION"],
+  remoteContentUrl: null,
   stateAbbreviation: null,
   verificationStrategy: "Simple",
 }))


### PR DESCRIPTION
Why:
We would like for the custom copy to be received from a remote cms and
cdn so that we may update the copy without needing to release a new
version of the app.

This commit:
Adds the networking logic to fetch the custom copy and adds it to the
useCustomCopy hook. We fallback to the static copy set at build time
if the network request fails for whatever reason.

Co-Authored-By: Matt Buckley <matt@nicethings.io>