### PR TITLE
Re-add how it works to onboarding

### DIFF
--- a/src/Onboarding/useOnboardingNavigation.tsx
+++ b/src/Onboarding/useOnboardingNavigation.tsx
@@ -87,6 +87,7 @@ export const determineOnboardingSteps = ({
 
   displayAppTransition && onboardingSteps.push("AppTransition")
   displayAgeVerification && onboardingSteps.push("AgeVerification")
+  onboardingSteps.push("HowItWorks")
 
   return onboardingSteps
 }


### PR DESCRIPTION
Why:
A recent commit refactored the onboarding navigation logic and
erroneously removed the 'HowItWorks' screens from the onboarding flow.

This commit:
Puts the how it works screens back into the onboarding flow.

Co-Authored-By: Matt Buckley <matt@nicethings.io>