### PR TITLE
Refactor open link logic

### DIFF
--- a/src/Home/HealthCheckLink.tsx
+++ b/src/Home/HealthCheckLink.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
 
 import { Text } from "../components"
+import Logger from "../logger"
 
 import { Icons, Images } from "../assets"
 import {
@@ -32,12 +33,14 @@ const HealthCheckLink: FunctionComponent<HealthCheckLinkProps> = ({
   const { t } = useTranslation()
 
   const handleOnPress = async () => {
-    const supported = await Linking.canOpenURL(healthCheckUrl)
-
-    if (supported) {
+    try {
       await Linking.openURL(healthCheckUrl)
-    } else {
-      Alert.alert(`Don't know how to open this URL: ${healthCheckUrl}`)
+    } catch (e) {
+      Logger.error("Failed to open healthCheckUrl: ", { healthCheckUrl })
+      const alertMessage = t("home.could_not_open_link", {
+        url: healthCheckUrl,
+      })
+      Alert.alert(alertMessage)
     }
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -227,6 +227,7 @@
     },
     "call_emergency_services": "Call Emergency Services",
     "check_if_your_symptoms": "Enter your symptoms and get an instant recommendation on how to stay safe.",
+    "could_not_open_link": "Could not open link: {{url}}. Please try to open the url in your phone's browser.",
     "enter_symptoms": "Enter symptoms",
     "error": {
       "share_link_failed": "Failed to open link to share"


### PR DESCRIPTION
Why:
Currently production versions of the app will fail to open the
healthCheck url as we are using the `Linking.canOpenUrl` function which
checks against the LSApplicationQueriesSchemes value in the info.plist
on iOS which we do not have currently set. Given that we are only ever
needing to support https schemes this extra check is extraneous and can
be removed.

This commit:
Refactors the logic to open the health check link.