### PR TITLE
Update Error Messaging for Escrow Verification Rate Limit Error

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -120,7 +120,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
       }
       setIsLoading(false)
     } catch (e) {
-      Alert.alert(t("common.something_went_wrong"), e.message)
+      Alert.alert(t("errors.something_went_wrong"), e.message)
       setIsLoading(false)
     }
   }

--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -138,7 +138,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
         return t("export.publish_keys.errors.unknown")
       }
       case PostKeysError.RequestFailed: {
-        return t("common.something_went_wrong")
+        return t("errors.something_went_wrong")
       }
     }
   }

--- a/src/Callback/Form.tsx
+++ b/src/Callback/Form.tsx
@@ -81,7 +81,7 @@ const CallbackForm: FunctionComponent = () => {
       setIsLoading(false)
     } catch (e) {
       Logger.error(`FailureToRequestCallback.exception.${e.message}`)
-      Alert.alert(t("common.something_went_wrong"), e.message)
+      Alert.alert(t("errors.something_went_wrong"), e.message)
       setIsLoading(false)
     }
   }
@@ -91,7 +91,7 @@ const CallbackForm: FunctionComponent = () => {
   const showError = (error: string): string => {
     switch (error) {
       default: {
-        return t("common.something_went_wrong")
+        return t("errors.something_went_wrong")
       }
     }
   }

--- a/src/EscrowVerification/API.ts
+++ b/src/EscrowVerification/API.ts
@@ -16,7 +16,7 @@ interface PhoneNumberFailure {
   error: PhoneNumberError
 }
 
-export type PhoneNumberError = "Unknown"
+export type PhoneNumberError = "RateLimit" | "Unknown"
 
 export const submitPhoneNumber = async (
   phoneNumber: string,
@@ -25,7 +25,9 @@ export const submitPhoneNumber = async (
     await escrowVerificationKeySubmissionModule.submitPhoneNumber(phoneNumber)
     return { kind: "success" }
   } catch (e) {
-    switch (e.message) {
+    switch (e.code) {
+      case "403":
+        return { kind: "failure", error: "RateLimit" }
       default:
         return { kind: "failure", error: "Unknown" }
     }

--- a/src/EscrowVerification/UserDetailsForm.tsx
+++ b/src/EscrowVerification/UserDetailsForm.tsx
@@ -115,27 +115,27 @@ const UserDetailsForm: FunctionComponent = () => {
         navigation.navigate(EscrowVerificationRoutes.EscrowVerificationCodeForm)
       } else {
         Alert.alert(
-          errorDialogTitle(response.error),
-          errorDialogMessage(response.error),
+          showErrorDialogTitle(response.error),
+          showErrorDialogMessage(response.error),
         )
       }
     } catch (e) {
       Logger.error(`escrow verification error`, e.message)
-      Alert.alert(errorDialogTitle("Unknown"), e.message)
+      Alert.alert(showErrorDialogTitle("Unknown"), e.message)
     }
     setIsLoading(false)
   }
 
   const buttonDisabled = phoneNumber.length < 1
 
-  const errorDialogTitle = (error: API.PhoneNumberError): string => {
+  const showErrorDialogTitle = (error: API.PhoneNumberError): string => {
     switch (error) {
       default:
         return t("errors.something_went_wrong")
     }
   }
 
-  const errorDialogMessage = (error: API.PhoneNumberError): string => {
+  const showErrorDialogMessage = (error: API.PhoneNumberError): string => {
     switch (error) {
       case "RateLimit":
         return t("escrow_verification.error.rate_limit")

--- a/src/EscrowVerification/UserDetailsForm.tsx
+++ b/src/EscrowVerification/UserDetailsForm.tsx
@@ -114,21 +114,33 @@ const UserDetailsForm: FunctionComponent = () => {
         })
         navigation.navigate(EscrowVerificationRoutes.EscrowVerificationCodeForm)
       } else {
-        Alert.alert(showError(response.error))
+        Alert.alert(
+          errorDialogTitle(response.error),
+          errorDialogMessage(response.error),
+        )
       }
     } catch (e) {
       Logger.error(`escrow verification error`, e.message)
-      Alert.alert(showError("Unknown"), e.message)
+      Alert.alert(errorDialogTitle("Unknown"), e.message)
     }
     setIsLoading(false)
   }
 
   const buttonDisabled = phoneNumber.length < 1
 
-  const showError = (error: API.PhoneNumberError): string => {
+  const errorDialogTitle = (error: API.PhoneNumberError): string => {
     switch (error) {
-      case "Unknown":
-        return t("common.something_went_wrong")
+      default:
+        return t("errors.something_went_wrong")
+    }
+  }
+
+  const errorDialogMessage = (error: API.PhoneNumberError): string => {
+    switch (error) {
+      case "RateLimit":
+        return t("escrow_verification.error.rate_limit")
+      default:
+        return t("errors.try_again_later")
     }
   }
 

--- a/src/EscrowVerification/VerificationCodeForm.tsx
+++ b/src/EscrowVerification/VerificationCodeForm.tsx
@@ -82,7 +82,7 @@ const VerificationCodeForm: FunctionComponent = () => {
       setIsLoading(false)
     } catch (e) {
       Logger.error("Unhandled error on submit code to escrow")
-      Alert.alert(t("common.something_went_wrong"), e.message)
+      Alert.alert(t("errors.something_went_wrong"), e.message)
       setIsLoading(false)
     }
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,7 +35,6 @@
     "select_language": "Select language",
     "settings": "Open Settings",
     "skip": "Skip",
-    "something_went_wrong": "Something went wrong",
     "start": "Start",
     "submit": "Submit",
     "success": "Success"
@@ -59,11 +58,14 @@
   "errors": {
     "description": "An error has occurred. Please reload the app.",
     "reload": "Reload",
-    "title": "Unknown Error"
+    "title": "Unknown Error",
+    "something_went_wrong": "Something went wrong",
+    "try_again_later": "Try again later"
   },
   "escrow_verification": {
     "error": {
-      "invalid_phone_number": "Phone number must be 10 digits"
+      "invalid_phone_number": "Phone number must be 10 digits",
+      "rate_limit": "You've reach the daily submission limit. Please try again in 24 hours."
     },
     "person_and_health_expert": "A person talking to a health expert",
     "start": {


### PR DESCRIPTION
#### Why:
We'd like to provide specific error messaging when the user exceeds the escrow verification server's daily request limit.

#### This commit:
This commit presents a more detailed error message to the user when the escrow verification server returns a `403` status code.

co-authored by: John Schoeman <john.schoeman@thoughtbot.com>

<img width="314" alt="Screen Shot 2020-12-28 at 3 27 55 PM" src="https://user-images.githubusercontent.com/2637355/103244147-ae2f0e80-4921-11eb-935e-1d2c25ea9d40.png">
