### PR TITLE
Reset locale on delete data

### DIFF
--- a/src/Settings/DeleteConfirmation.tsx
+++ b/src/Settings/DeleteConfirmation.tsx
@@ -13,12 +13,14 @@ import { showMessage } from "react-native-flash-message"
 import { useOnboardingContext } from "../OnboardingContext"
 import { useProductAnalyticsContext } from "../ProductAnalytics/Context"
 import { useSymptomHistoryContext } from "../SymptomHistory/SymptomHistoryContext"
-import { Text } from "../components"
-import { useStatusBarEffect } from "../navigation"
-import * as Storage from "../utils/storage"
 import { useConfigurationContext } from "../ConfigurationContext"
-import { OperationResponse } from "../OperationResponse"
 import { useApplicationName } from "../Device/useApplicationInfo"
+import { resetUserLocale } from "../locales/languages"
+
+import { OperationResponse } from "../OperationResponse"
+import * as Storage from "../utils/storage"
+import { useStatusBarEffect } from "../navigation"
+import { Text } from "../components"
 
 import { Spacing, Buttons, Typography, Colors, Affordances } from "../styles"
 
@@ -41,6 +43,7 @@ const DeleteConfirmation: FunctionComponent = () => {
   const deleteAllData = async (): Promise<OperationResponse> => {
     resetOnboarding()
     resetUserConsent()
+    resetUserLocale()
     Storage.removeAll()
     const deleteAllEntriesResult = await deleteAllEntries()
     return deleteAllEntriesResult

--- a/src/locales/languages.ts
+++ b/src/locales/languages.ts
@@ -119,6 +119,10 @@ export async function setUserLocaleOverride(
   await StorageUtils.setUserLocaleOverride(locale)
 }
 
+export const resetUserLocale = async (): Promise<void> => {
+  await setLocale("en")
+}
+
 async function setLocale(locale: Locale.Locale) {
   const iETFLanguageTag = Locale.toIETFLanguageTag(locale)
   dayjs.locale(iETFLanguageTag)


### PR DESCRIPTION
Why:
Currently when a user deletes their data we delete the saved locale
override token, but do not reset the in-app language setting in i18next.
This is confusing to the user as it seems like we didnt delete the
language token even though we did. We would like to reset the current
locale to the default of 'en' when the user deletes their data to avoid
this confusion.

This commit:
Adds a resetUserLocale function to the languages.ts module and calls it
the DeleteConfirmation component on deleteAllData.
