### PR TITLE
Xcode 12.3 Update

### DIFF
--- a/ios/BT/Extensions/Exposure Notifications/Scoring.swift
+++ b/ios/BT/Extensions/Exposure Notifications/Scoring.swift
@@ -47,7 +47,7 @@ extension ENExposureDetectionSummary: Scoring {
 }
 
 @available(iOS 13.7, *)
-extension ENExposureDaySummary: Scoring {
+extension ENExposureDaySummary {
   typealias T = DailySummariesConfiguration
 
   func isAboveScoreThreshold(with configuration: DailySummariesConfiguration) -> Bool {


### PR DESCRIPTION
#### Why:
We'd like the app to compile on `Xcode 12.3`

#### This commit:
This commit removes a protocol conformance that causes a compilation error on `Xcode 12.3`