### PR TITLE
Remove "Force App Crash" Button from Debug Menu

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
@@ -39,11 +39,6 @@ public class DebugMenuModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void forceAppCrash(Promise promise) throws Exception {
-    throw new Exception("Force crash");
-  }
-
-  @ReactMethod
   public void fetchDiagnosisKeys(Promise promise) {
     ExposureNotificationClientWrapper client = ExposureNotificationClientWrapper.get(getReactApplicationContext());
     ReactContext reactContext = getReactApplicationContext();

--- a/ios/BT/bridge/DebugMenuModule.m
+++ b/ios/BT/bridge/DebugMenuModule.m
@@ -16,11 +16,6 @@ RCT_REMAP_METHOD(fetchDiagnosisKeys,
   [[ExposureManager shared] handleDebugAction:DebugActionFetchDiagnosisKeys resolve:resolve reject:reject];
 }
 
-RCT_EXPORT_METHOD(forceAppCrash)
-{
-  @throw [NSException exceptionWithName:NSGenericException reason:@"Forced Crash (Debug)" userInfo:nil];
-}
-
 RCT_REMAP_METHOD(simulateExposureDetectionError,
                  simulateExposureDetectionErrorWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)

--- a/src/Settings/ENDebugMenu.tsx
+++ b/src/Settings/ENDebugMenu.tsx
@@ -127,12 +127,6 @@ const ENDebugMenu: FunctionComponent<ENDebugMenuProps> = ({ navigation }) => {
               }}
             />
             <DebugMenuListItem
-              label="Force App Crash"
-              onPress={() => {
-                NativeModule.forceAppCrash()
-              }}
-            />
-            <DebugMenuListItem
               label="Restart Onboarding"
               onPress={handleOnPressRestartOnboarding}
             />

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -264,10 +264,6 @@ export const getRevisionToken = async (): Promise<string> => {
 // Debug Module
 const debugModule = NativeModules.DebugMenuModule
 
-export const forceAppCrash = async (): Promise<void> => {
-  return debugModule.forceAppCrash()
-}
-
 export const fetchDiagnosisKeys = async (): Promise<ENDiagnosisKey[]> => {
   return debugModule.fetchDiagnosisKeys()
 }


### PR DESCRIPTION
#### Why:
We'd like to remove unused UI from the debug menus to avoid confusion while testing

#### This commit:
This commit removes the "force app crash" button from the debug menu