### PR TITLE
Adjust Layout for Onboarding Images to Accommodate Smaller Devices

### DIFF
--- a/src/HowItWorks/HowItWorksScreen.tsx
+++ b/src/HowItWorks/HowItWorksScreen.tsx
@@ -16,7 +16,7 @@ import { SvgXml } from "react-native-svg"
 import { ModalStackScreens, useStatusBarEffect } from "../navigation"
 import { Text } from "../components"
 
-import { Colors, Spacing, Typography, Buttons } from "../styles"
+import { Colors, Spacing, Typography, Buttons, Layout } from "../styles"
 import { Icons } from "../assets"
 
 type HowItWorksScreenContent = {
@@ -97,7 +97,7 @@ const createStyle = (insets: EdgeInsets) => {
   const androidPaddingTop = 90
   const headerHeight = Platform.select({
     ios: iosPaddingTop,
-    android: androidPaddingTop,
+    android: Layout.screenHeight > 650 ? androidPaddingTop : 0,
     default: iosPaddingTop,
   })
 


### PR DESCRIPTION
#### Why:
On smaller displays, onboarding images will have blank space at the top above images.

#### This commit:
This commit adjusts the relevant spacing for devices with smaller displays (iPhone SE and small Android devices).

Before:
![Screenshot_1609359447](https://user-images.githubusercontent.com/2637355/103379302-d4cc8100-4aaa-11eb-84fb-cc2257882ae4.png)

After:
![Screenshot_1609359517](https://user-images.githubusercontent.com/2637355/103379307-d8f89e80-4aaa-11eb-844f-bfa054cc43af.png)

