### PR TITLE
Add Realm Migration to Account for New Stored Property

### DIFF
--- a/ios/BT/Storage/BTSecureStorage.swift
+++ b/ios/BT/Storage/BTSecureStorage.swift
@@ -118,12 +118,12 @@ class BTSecureStorage {
   func getRealmConfig() -> Realm.Configuration? {
     if let key = getEncryptionKey() {
       if (inMemory) {
-        return Realm.Configuration(inMemoryIdentifier: identifier, encryptionKey: key as Data, schemaVersion: 11,
+        return Realm.Configuration(inMemoryIdentifier: identifier, encryptionKey: key as Data, schemaVersion: 12,
                                    migrationBlock: { _, _ in }, objectTypes: [UserState.self,
                                                                               Exposure.self,
                                                                               SymptomLogEntry.self])
       } else {
-        return Realm.Configuration(encryptionKey: key as Data, schemaVersion: 11,
+        return Realm.Configuration(encryptionKey: key as Data, schemaVersion: 12,
                                    migrationBlock: { _, _ in }, objectTypes: [UserState.self,
                                                                               Exposure.self,
                                                                               SymptomLogEntry.self])


### PR DESCRIPTION
#### Why:
Without migrating realm to account for the new `weightedDurationSum` property, the local database will be reset when users update the the new version

#### This commit:
This commit updates the `schemaVersion` to trigger the necessary realm migration