### PR TITLE
Improve Error Logging for Escrow Verification Server Failures

### DIFF
--- a/src/EscrowVerification/API.ts
+++ b/src/EscrowVerification/API.ts
@@ -27,7 +27,7 @@ export const submitPhoneNumber = async (
     await escrowVerificationKeySubmissionModule.submitPhoneNumber(phoneNumber)
     return { kind: "success" }
   } catch (e) {
-    Logger.error(`failed to submit phone number: `, e.toString())
+    Logger.error(`failed to submit phone number: `, { ...e })
     switch (e.code) {
       case "403":
         return { kind: "failure", error: "RateLimit" }
@@ -60,7 +60,7 @@ export const submitDiagnosisKeys = async (
     )
     return { kind: "success" }
   } catch (e) {
-    Logger.error(`failed to submit verification code: `, e.toString())
+    Logger.error(`failed to submit verification code: `, { ...e })
     return { kind: "failure", error: "Unknown" }
   }
 }


### PR DESCRIPTION
#### Why:
We'd like to have better insight into errors from requests to the escrow verification server during development.

** Note that logging is only present in staging and debug builds, and is not present in release builds

Before:
`failed to submit phone number:  [Error]`

After:
`failed to submit phone number:  {"code": "403", "message": "", "nativeStackAndroid": [], "userInfo": null}`