### PR TITLE
Downgrade okhttp version to 3.14.9

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -254,7 +254,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.0.1"
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
-    implementation "com.squareup.okhttp3:logging-interceptor:4.9.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:3.14.9"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
 
     implementation "com.google.android.gms:play-services-safetynet:17.0.0"


### PR DESCRIPTION
#### Why:

There are some conflicts between the okhttp version that RN is using and the one that the native side uses.
That is causing this crash https://app.bugsnag.com/pathcheck/gaen-mobile/errors/5fe50b4618ec5000177f2861?filters[event.since][0]=30d&filters[error.status][0]=open&event_id=5ff4f7d20065958e9a020000&pivot_tab=event

#### This commit:

Downgrades the okhttp version to avoid having conflicts with RN
