### PR TITLE
Add quarantine end date to exposure history

### DIFF
--- a/src/ExposureHistory/History/ExposureListItem.tsx
+++ b/src/ExposureHistory/History/ExposureListItem.tsx
@@ -1,10 +1,14 @@
 import React, { FunctionComponent } from "react"
 import { StyleSheet } from "react-native"
+import dayjs from "dayjs"
 
 import { Text } from "../../components"
 import * as Exposure from "../../exposure"
 
 import { Spacing, Typography } from "../../styles"
+
+type Posix = number
+
 interface ExposureListItemProps {
   exposureDatum: Exposure.ExposureDatum
 }
@@ -12,9 +16,18 @@ interface ExposureListItemProps {
 const ExposureListItem: FunctionComponent<ExposureListItemProps> = ({
   exposureDatum,
 }) => {
+  const formatDate = (posix: Posix) => {
+    return dayjs(posix).format("dddd, MMM Do")
+  }
+
+  const [startDate, endDate] = Exposure.toExposureRange(exposureDatum)
+  const startDateText = formatDate(startDate)
+  const endDateText = formatDate(endDate)
+  const exposureRangeText = `${startDateText} - ${endDateText}`
+
   return (
     <Text style={style.secondaryText} testID="exposure-list-item">
-      - {Exposure.toDateRangeString(exposureDatum)}
+      - {exposureRangeText}
     </Text>
   )
 }

--- a/src/ExposureHistory/History/ExposureSummary.tsx
+++ b/src/ExposureHistory/History/ExposureSummary.tsx
@@ -35,24 +35,54 @@ const ExposureSummary: FunctionComponent<ExposureSummaryProps> = ({
 }) => {
   const { t } = useTranslation()
 
+  const formatDate = (posix: Posix) => {
+    return dayjs(posix).format("dddd, MMM Do")
+  }
+
+  const [exposureStartDate, exposureEndDate] = Exposure.toExposureRange(
+    exposure,
+  )
+  const exposureStartDateText = formatDate(exposureStartDate)
+  const exposureEndDateText = formatDate(exposureEndDate)
+
   const daysOfQuarantineLeft = determineRemainingQuarantine(
     quarantineLength,
     Date.now(),
     exposure.date,
   )
-
-  const startDate = Exposure.toStartDateString(exposure)
-  const endDate = Exposure.toEndDateString(exposure)
+  const quarantineEndDate = dayjs(exposureEndDate)
+    .add(daysOfQuarantineLeft, "day")
+    .valueOf()
+  const quarantineEndDateText = formatDate(quarantineEndDate)
 
   return (
     <View>
       <Text style={style.summaryText}>
-        {t("exposure_history.exposure_summary", { startDate, endDate })}
+        {t("exposure_history.exposure_summary", {
+          startDate: exposureStartDateText,
+          endDate: exposureEndDateText,
+        })}
       </Text>
-      <View style={style.daysRemainingTextContainer}>
-        <Text style={style.daysRemainingText}>
-          {t("exposure_history.days_remaining", { daysOfQuarantineLeft })}
-        </Text>
+      <View style={style.recommendationContainer}>
+        <View style={style.daysRemainingContainer}>
+          <View style={style.daysRemainingTextContainer}>
+            <Text style={style.labelText}>
+              {t("exposure_history.days_remaining")}
+            </Text>
+          </View>
+          <View style={style.dayNumberContainer}>
+            <Text style={style.dayNumberText}>{daysOfQuarantineLeft}</Text>
+          </View>
+        </View>
+
+        <View style={style.quarantineEndDateContainer}>
+          <Text style={style.labelText}>
+            {t("exposure_history.stay_quarantined_through")}
+          </Text>
+          <Text style={style.quarantineEndDateText}>
+            {quarantineEndDateText}
+          </Text>
+        </View>
       </View>
     </View>
   )
@@ -63,15 +93,45 @@ const style = StyleSheet.create({
     ...Typography.body.x20,
     marginBottom: Spacing.small,
   },
-  daysRemainingTextContainer: {
+  recommendationContainer: {
     backgroundColor: Colors.neutral.shade10,
     borderRadius: Outlines.baseBorderRadius,
-    paddingVertical: Spacing.xxSmall,
+    paddingVertical: Spacing.xSmall,
     paddingHorizontal: Spacing.xSmall,
   },
-  daysRemainingText: {
+  labelText: {
     ...Typography.body.x20,
     color: Colors.neutral.black,
+  },
+  quarantineEndDateText: {
+    ...Typography.body.x20,
+    letterSpacing: Typography.letterSpacing.x20,
+  },
+  daysRemainingContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  quarantineEndDateContainer: {
+    marginTop: Spacing.xSmall,
+    paddingTop: Spacing.xxSmall,
+    borderTopWidth: Outlines.hairline,
+    borderColor: Colors.neutral.shade30,
+  },
+  daysRemainingTextContainer: {
+    flex: 3,
+  },
+  dayNumberContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: Colors.neutral.white,
+    paddingVertical: Spacing.xSmall,
+    paddingHorizontal: Spacing.medium,
+    borderRadius: Outlines.baseBorderRadius,
+    marginLeft: Spacing.xSmall,
+  },
+  dayNumberText: {
+    ...Typography.base.x50,
+    ...Typography.style.bold,
   },
 })
 

--- a/src/ExposureHistory/History/HasExposures.tsx
+++ b/src/ExposureHistory/History/HasExposures.tsx
@@ -21,7 +21,6 @@ const HasExposures: FunctionComponent<HasExposuresProps> = ({ exposures }) => {
   const { t } = useTranslation()
 
   const envQuarantineLength = Number(env.QUARANTINE_LENGTH)
-
   const quarantineLength = isNaN(envQuarantineLength)
     ? DEFAULT_QUARANTINE_LENGTH
     : envQuarantineLength

--- a/src/exposure.ts
+++ b/src/exposure.ts
@@ -11,28 +11,10 @@ export interface ExposureDatum {
 
 export type ExposureInfo = ExposureDatum[]
 
-type ExposureDateRangeStrings = {
-  start: string
-  end: string
-}
+type ExposureRange = [Posix, Posix]
 
-const toExposureDateRangeStrings = (date: Posix): ExposureDateRangeStrings => {
-  return {
-    start: dayjs.utc(date).subtract(1, "day").format("dddd, MMM Do"),
-    end: dayjs.utc(date).add(1, "day").format("dddd, MMM Do"),
-  }
-}
-
-export const toDateRangeString = ({ date }: ExposureDatum): string => {
-  const { start, end } = toExposureDateRangeStrings(date)
-
-  return `${start} - ${end}`
-}
-
-export const toStartDateString = ({ date }: ExposureDatum): string => {
-  return toExposureDateRangeStrings(date).start
-}
-
-export const toEndDateString = ({ date }: ExposureDatum): string => {
-  return toExposureDateRangeStrings(date).end
+export const toExposureRange = ({ date }: ExposureDatum): ExposureRange => {
+  const start = dayjs.utc(date).subtract(1, "day").valueOf()
+  const end = dayjs.utc(date).add(1, "day").valueOf()
+  return [start, end]
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -146,7 +146,7 @@
   },
   "exposure_history": {
     "check_for_exposures": "Check for exposures",
-    "days_remaining": "There are {{daysOfQuarantineLeft}} days left in your recommended quarantine period.",
+    "days_remaining": "Days remaining in your recommended quarantine period:",
     "exposure_detail": {
       "next_steps": "Review health guidelines",
       "personalize_my_guidance": "Personalize my guidance",
@@ -173,6 +173,7 @@
     "no_exposure_reports_over_past": "You haven't received any exposure reports over the past 14-days",
     "possible_exposures": "Possible Exposures",
     "review_health_guidance": "Review Health Guidance",
+    "stay_quarantined_through": "Stay quarantined through:",
     "updated": "Updated",
     "why_did_i_get_an_en": "Why did I get an exposure notification?",
     "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you have been in close contact with later uses the app to report a positive COVID-19 test.",


### PR DESCRIPTION
Why:
We would like to display to users the calendar date of the end of their
recommended quarantine.

This commit:
Adds the end date to the exposure history screen and refactors some of
the date view logic out of the Exposure module and into the view layer
components.

|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 12 - 2021-01-12 at 08 45 42](https://user-images.githubusercontent.com/16049495/104344922-983d5400-54b2-11eb-812e-6f52f965c355.png)|![Simulator Screen Shot - iPhone 12 - 2021-01-12 at 08 37 02](https://user-images.githubusercontent.com/16049495/104344944-9e333500-54b2-11eb-9582-1f6d521269f6.png)|

