### PR TITLE
Fix bug with quarantine end date

### DIFF
--- a/src/ExposureHistory/History/ExposureSummary.tsx
+++ b/src/ExposureHistory/History/ExposureSummary.tsx
@@ -50,10 +50,10 @@ const ExposureSummary: FunctionComponent<ExposureSummaryProps> = ({
     Date.now(),
     exposure.date,
   )
-  const quarantineEndDate = dayjs(exposureEndDate)
-    .add(daysOfQuarantineLeft, "day")
-    .valueOf()
+  const quarantineEndDate = dayjs().add(daysOfQuarantineLeft, "day").valueOf()
   const quarantineEndDateText = formatDate(quarantineEndDate)
+
+  const quarantineInEffect = daysOfQuarantineLeft > 0
 
   return (
     <View>
@@ -63,27 +63,35 @@ const ExposureSummary: FunctionComponent<ExposureSummaryProps> = ({
           endDate: exposureEndDateText,
         })}
       </Text>
-      <View style={style.recommendationContainer}>
-        <View style={style.daysRemainingContainer}>
-          <View style={style.daysRemainingTextContainer}>
-            <Text style={style.labelText}>
-              {t("exposure_history.days_remaining")}
+      {quarantineInEffect ? (
+        <View style={style.recommendationContainer}>
+          <View style={style.daysRemainingContainer}>
+            <View style={style.daysRemainingTextContainer}>
+              <Text style={style.recommendationText}>
+                {t("exposure_history.days_remaining")}
+              </Text>
+            </View>
+            <View style={style.dayNumberContainer}>
+              <Text style={style.dayNumberText}>{daysOfQuarantineLeft}</Text>
+            </View>
+          </View>
+
+          <View style={style.quarantineEndDateContainer}>
+            <Text style={style.recommendationText}>
+              {t("exposure_history.stay_quarantined_through")}
+            </Text>
+            <Text style={style.recommendationText}>
+              {quarantineEndDateText}
             </Text>
           </View>
-          <View style={style.dayNumberContainer}>
-            <Text style={style.dayNumberText}>{daysOfQuarantineLeft}</Text>
-          </View>
         </View>
-
-        <View style={style.quarantineEndDateContainer}>
-          <Text style={style.labelText}>
-            {t("exposure_history.stay_quarantined_through")}
-          </Text>
-          <Text style={style.quarantineEndDateText}>
-            {quarantineEndDateText}
+      ) : (
+        <View style={style.recommendationContainer}>
+          <Text style={style.recommendationText}>
+            {t("exposure_history.your_recommended_quarantine_is_over")}
           </Text>
         </View>
-      </View>
+      )}
     </View>
   )
 }
@@ -99,13 +107,9 @@ const style = StyleSheet.create({
     paddingVertical: Spacing.xSmall,
     paddingHorizontal: Spacing.xSmall,
   },
-  labelText: {
+  recommendationText: {
     ...Typography.body.x20,
     color: Colors.neutral.black,
-  },
-  quarantineEndDateText: {
-    ...Typography.body.x20,
-    letterSpacing: Typography.letterSpacing.x20,
   },
   daysRemainingContainer: {
     flexDirection: "row",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -185,7 +185,8 @@
     "updated": "Updated",
     "why_did_i_get_an_en": "Why did I get an exposure notification?",
     "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you have been in close contact with later uses the app to report a positive COVID-19 test.",
-    "your_device_exchanged": "Within each date range below, your device exchanged keys with another device that later received a verified positive test result."
+    "your_device_exchanged": "Within each date range below, your device exchanged keys with another device that later received a verified positive test result.",
+    "your_recommended_quarantine_is_over": "Your recommended quarantine is over. Please continue to follow the health guidelines."
   },
   "exposure_notification_alerts": {
     "bluetooth_body": "To activate Exposure Notifications, you must first turn on Bluetooth in your Settings app.",


### PR DESCRIPTION
Why:
Currently we have a bug where we incorrectly calculate the end date of
a recommended quarantine for users that have received an exposure
notification.

This commit:
Determines the last day of quarantine by adding quarantine days
remaining to the current day instead of the date of the exposure itself.