### PR TITLE
Update callback form styling

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -6,9 +6,9 @@
     "version": "Version:"
   },
   "callback": {
-    "firstname": "First name",
+    "firstname": "First name (optional)",
     "if_you_prefer": "If you prefer; call directly at",
-    "lastname": "Last name",
+    "lastname": "Last name (optional)",
     "phone_number_required": "Phone number (required)",
     "request_a_call": "Request a call from our support team",
     "success_body": "Our support team is working hard to keep you and your community safe. The {{healthAuthorityName}} has received your request for a call back. An expert will contact you within 24 hours.",


### PR DESCRIPTION
Why:
We would like to use a better phone input styling for the callback form

|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 12 Pro Max - 2021-01-13 at 13 34 42](https://user-images.githubusercontent.com/16049495/104513216-247b7400-55a4-11eb-8cce-77ce75c6642a.png)|![Simulator Screen Shot - iPhone 12 Pro Max - 2021-01-13 at 13 30 19](https://user-images.githubusercontent.com/16049495/104513224-27766480-55a4-11eb-8ca9-9a7f0232ec90.png)|
