### PR TITLE
Check for Existing Keys on Device Before Escrow Submission

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set XCode Version
-        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+        run: sudo xcode-select -s /Applications/Xcode_12.3.app
 
       - name: Cache node_modules/
         uses: actions/cache@v1

--- a/ios/BT/API/GenericResult.swift
+++ b/ios/BT/API/GenericResult.swift
@@ -56,4 +56,29 @@ public enum APIError: LocalizedError {
   }
 }
 
+
+public enum SubmissionError: CustomNSError {
+  case `default`(message: String?)
+  case noKeysOnDevice
+
+  public var errorDescription: String? {
+    switch self {
+    case .noKeysOnDevice:
+      return String.noKeysOnDevice
+    case .default(message: let message):
+      return message  ?? String.emptyMessageError
+    }
+  }
+
+  public var errorCode: Int {
+    switch self {
+    case .noKeysOnDevice:
+      return 999
+    default:
+      return 0
+    }
+  }
+
+}
+
 public let GenericSuccess = GenericResult.success(())

--- a/ios/BT/Extensions/Foundation/String+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/String+Extensions.swift
@@ -57,7 +57,8 @@ extension String {
   static let emptyMessageError = ""
   static let dailyFileProcessingLimitExceeded = "Daily exposure detection file processing limit exceeded"
   static let exposureDetectionCanceled = "Exposure Detection Cancelled"
-  
+  static let noKeysOnDevice = "No keys on device"
+
   // Computed Properties
   var gaenFilePaths: [String] {
     split(separator: "\n").map { String($0) }

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -26,7 +26,6 @@ class MockENExposureDetectionSummary: ENExposureDetectionSummary {
     return 0
   }
   
-  @available(iOS 13.7, *)
   override var daySummaries: [ENExposureDaySummary] {
     let enExposureSummary = ENExposureDaySummary()
     return [enExposureSummary]

--- a/ios/EscrowVerification/Manager/EscrowVerificationManager.swift
+++ b/ios/EscrowVerification/Manager/EscrowVerificationManager.swift
@@ -9,6 +9,14 @@ class EscrowVerificationManager: NSObject {
     getCodableKeysWithRiskLevel { result in
       switch result {
       case .success(let keys):
+
+        guard !keys.isEmpty else {
+          completionHandler(NSError(domain: "\(SubmissionError.noKeysOnDevice.errorCode)",
+                                    code: SubmissionError.noKeysOnDevice.errorCode,
+                                    userInfo: [:]))
+          return
+        }
+
         NetworkServiceController.shared.postKeysAndPhone(keyData: keys, phone: phoneNumber) { result in
           switch result {
           case let .failure(error):
@@ -28,6 +36,14 @@ class EscrowVerificationManager: NSObject {
     getCodableKeysWithRiskLevel { result in
       switch result {
       case .success(let keys):
+
+        guard !keys.isEmpty else {
+          completionHandler(NSError(domain: "\(SubmissionError.noKeysOnDevice.errorCode)",
+                                    code: SubmissionError.noKeysOnDevice.errorCode,
+                                    userInfo: [:]))
+          return
+        }
+
         NetworkServiceController.shared.generateDeviceToken { result in
           let token: Data
           switch result {

--- a/src/EscrowVerification/API.ts
+++ b/src/EscrowVerification/API.ts
@@ -18,7 +18,7 @@ interface PhoneNumberFailure {
   error: PhoneNumberError
 }
 
-export type PhoneNumberError = "RateLimit" | "Unknown"
+export type PhoneNumberError = "RateLimit" | "Unknown" | "NoKeysOnDevice"
 
 export const submitPhoneNumber = async (
   phoneNumber: string,
@@ -31,6 +31,8 @@ export const submitPhoneNumber = async (
     switch (e.code) {
       case "403":
         return { kind: "failure", error: "RateLimit" }
+      case "999":
+        return { kind: "failure", error: "NoKeysOnDevice" }
       default:
         return { kind: "failure", error: "Unknown" }
     }
@@ -47,7 +49,7 @@ interface SubmitKeysFailure {
   error: SubmitKeysError
 }
 
-export type SubmitKeysError = "Unknown"
+export type SubmitKeysError = "Unknown" | "NoKeysOnDevice"
 
 export const submitDiagnosisKeys = async (
   verificationCode: string,
@@ -61,6 +63,11 @@ export const submitDiagnosisKeys = async (
     return { kind: "success" }
   } catch (e) {
     Logger.error(`failed to submit verification code: `, { ...e })
-    return { kind: "failure", error: "Unknown" }
+    switch (e.code) {
+      case "999":
+        return { kind: "failure", error: "NoKeysOnDevice" }
+      default:
+        return { kind: "failure", error: "Unknown" }
+    }
   }
 }

--- a/src/EscrowVerification/UserDetailsForm.tsx
+++ b/src/EscrowVerification/UserDetailsForm.tsx
@@ -121,7 +121,7 @@ const UserDetailsForm: FunctionComponent = () => {
       }
     } catch (e) {
       Logger.error(`escrow verification error`, e.message)
-      Alert.alert(showErrorDialogTitle("Unknown"), e.message)
+      Alert.alert(showErrorDialogTitle(e), e.message)
     }
     setIsLoading(false)
   }
@@ -130,6 +130,8 @@ const UserDetailsForm: FunctionComponent = () => {
 
   const showErrorDialogTitle = (error: API.PhoneNumberError): string => {
     switch (error) {
+      case "NoKeysOnDevice":
+        return t("verification_code_alerts.no_keys_on_device_title")
       default:
         return t("errors.something_went_wrong")
     }
@@ -137,6 +139,8 @@ const UserDetailsForm: FunctionComponent = () => {
 
   const showErrorDialogMessage = (error: API.PhoneNumberError): string => {
     switch (error) {
+      case "NoKeysOnDevice":
+        return t("verification_code_alerts.no_keys_on_device_body")
       case "RateLimit":
         return t("escrow_verification.error.rate_limit")
       default:

--- a/src/EscrowVerification/VerificationCodeForm.tsx
+++ b/src/EscrowVerification/VerificationCodeForm.tsx
@@ -89,12 +89,20 @@ const VerificationCodeForm: FunctionComponent = () => {
 
   const showError = (error: API.SubmitKeysError): void => {
     switch (error) {
+      case "NoKeysOnDevice":
+        Alert.alert(
+          t("verification_code_alerts.no_keys_on_device_title"),
+          t("verification_code_alerts.no_keys_on_device_body"),
+          [{ text: t("common.okay") }],
+        )
+        break
       case "Unknown":
         Alert.alert(
           t("verification_code_alerts.unknown_title"),
           t("verification_code_alerts.unknown_body"),
           [{ text: t("common.okay") }],
         )
+        break
     }
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -503,6 +503,8 @@
     "code_used_title": "Verification Code Already Used",
     "invalid_code_body": "The verification code you submitted is invalid.\n\nThe code must be a valid verification code provided to you by your health authority.\n\nIt is also possible that your code has expired. If so, you will need to request a new code from your health authority.",
     "invalid_code_title": "Invalid Code",
+    "no_keys_on_device_body": "You must wait to submit your verification code until your device has generated its first keys. Please try again in a few hours.",
+    "no_keys_on_device_title": "No keys on device",
     "network_connection_body": "You need to be connected to WiFi to submit a verification code.",
     "network_connection_title": "No Internet Connection",
     "unknown_body": "An unexpected error occurred. Please try again.",


### PR DESCRIPTION
#### Why:
We'd like to avoid making requests to the escrow verification server containing empty key payloads (the server will return a 4xx).

#### This commit:
This commit short circuits POSTs to the escrow verification server if there are no existing keys on the device, and provides instructions for the user to wait until their device has had time to generate its first keys.
![IMG_2496](https://user-images.githubusercontent.com/2637355/104616205-a4124d00-564f-11eb-9c2c-796724399603.PNG)
![IMG_2495](https://user-images.githubusercontent.com/2637355/104616213-a5dc1080-564f-11eb-89ef-c630edeee53b.PNG)

