### PR TITLE
Jts update quarantine summary

### DIFF
--- a/src/ExposureHistory/History/ExposureSummary.spec.tsx
+++ b/src/ExposureHistory/History/ExposureSummary.spec.tsx
@@ -46,9 +46,9 @@ describe("determineRemainingQuarantine", () => {
 
       expect(result1).toEqual(0)
       expect(result2).toEqual(0)
-      expect(result3).toEqual(1)
-      expect(result4).toEqual(4)
-      expect(result5).toEqual(14)
+      expect(result3).toEqual(0)
+      expect(result4).toEqual(3)
+      expect(result5).toEqual(13)
       expect(result6).toEqual(14)
     })
   })

--- a/src/ExposureHistory/History/ExposureSummary.tsx
+++ b/src/ExposureHistory/History/ExposureSummary.tsx
@@ -18,10 +18,10 @@ interface ExposureSummaryProps {
 export const determineRemainingQuarantine = (
   quarantineLength: number,
   today: Posix,
-  date: Posix,
+  startDate: Posix,
 ): number => {
-  const dayOfExposure = dayjs(date).add(1, "day")
-  const daysSinceExposure = dayjs(today).diff(dayOfExposure, "day")
+  const firstDay = dayjs(startDate)
+  const daysSinceExposure = dayjs(today).diff(firstDay, "day")
   const daysRemaining = quarantineLength - daysSinceExposure
 
   const maxDays = Math.min(quarantineLength, daysRemaining)
@@ -45,13 +45,21 @@ const ExposureSummary: FunctionComponent<ExposureSummaryProps> = ({
   const exposureStartDateText = formatDate(exposureStartDate)
   const exposureEndDateText = formatDate(exposureEndDate)
 
+  const quarantineStartDate = dayjs(exposureEndDate)
+    .add(1, "day")
+    .startOf("day")
+    .valueOf()
+  const quarantineEndDate = dayjs(quarantineStartDate)
+    .add(quarantineLength - 1, "day")
+    .startOf("day")
+    .valueOf()
+  const quarantineEndDateText = formatDate(quarantineEndDate)
+
   const daysOfQuarantineLeft = determineRemainingQuarantine(
     quarantineLength,
     Date.now(),
-    exposure.date,
+    quarantineStartDate,
   )
-  const quarantineEndDate = dayjs().add(daysOfQuarantineLeft, "day").valueOf()
-  const quarantineEndDateText = formatDate(quarantineEndDate)
 
   const quarantineInEffect = daysOfQuarantineLeft > 0
 
@@ -63,35 +71,48 @@ const ExposureSummary: FunctionComponent<ExposureSummaryProps> = ({
           endDate: exposureEndDateText,
         })}
       </Text>
-      {quarantineInEffect ? (
-        <View style={style.recommendationContainer}>
-          <View style={style.daysRemainingContainer}>
-            <View style={style.daysRemainingTextContainer}>
-              <Text style={style.recommendationText}>
-                {t("exposure_history.days_remaining")}
-              </Text>
-            </View>
-            <View style={style.dayNumberContainer}>
-              <Text style={style.dayNumberText}>{daysOfQuarantineLeft}</Text>
-            </View>
-          </View>
-
-          <View style={style.quarantineEndDateContainer}>
-            <Text style={style.recommendationText}>
-              {t("exposure_history.stay_quarantined_through")}
-            </Text>
-            <Text style={style.recommendationText}>
-              {quarantineEndDateText}
-            </Text>
-          </View>
-        </View>
-      ) : (
-        <View style={style.recommendationContainer}>
-          <Text style={style.recommendationText}>
-            {t("exposure_history.your_recommended_quarantine_is_over")}
+      <View style={style.recommendationContainer}>
+        <View style={style.headerContainer}>
+          <Text style={style.headerText}>
+            {t("exposure_history.recommended_quarantine")}
           </Text>
         </View>
-      )}
+        <View style={style.recommendationContentContainer}>
+          {quarantineInEffect ? (
+            <View>
+              <View style={style.daysRemainingContainer}>
+                <View style={style.recommendationLabelContainer}>
+                  <Text style={style.recommendationLabelText}>
+                    {t("exposure_history.days_remaining")}
+                  </Text>
+                </View>
+                <View style={style.recommendationValueContainer}>
+                  <Text style={style.recommendationText}>
+                    {daysOfQuarantineLeft}
+                  </Text>
+                </View>
+              </View>
+
+              <View style={style.daysRemainingContainer}>
+                <View style={style.recommendationLabelContainer}>
+                  <Text style={style.recommendationLabelText}>
+                    {t("exposure_history.stay_quarantined_through")}
+                  </Text>
+                </View>
+                <View style={style.recommendationValueContainer}>
+                  <Text style={style.recommendationText}>
+                    {quarantineEndDateText}
+                  </Text>
+                </View>
+              </View>
+            </View>
+          ) : (
+            <Text style={style.recommendationLabelText}>
+              {t("exposure_history.your_recommended_quarantine_is_over")}
+            </Text>
+          )}
+        </View>
+      </View>
     </View>
   )
 }
@@ -107,35 +128,37 @@ const style = StyleSheet.create({
     paddingVertical: Spacing.xSmall,
     paddingHorizontal: Spacing.xSmall,
   },
-  recommendationText: {
+  headerContainer: {
+    paddingBottom: Spacing.xxSmall,
+    borderBottomWidth: Outlines.hairline,
+    borderColor: Colors.neutral.shade30,
+  },
+  headerText: {
+    ...Typography.header.x20,
+  },
+  recommendationContentContainer: {
+    marginTop: Spacing.xxxSmall,
+  },
+  recommendationLabelText: {
     ...Typography.body.x20,
-    color: Colors.neutral.black,
   },
   daysRemainingContainer: {
+    marginTop: Spacing.xxSmall,
     flexDirection: "row",
     alignItems: "center",
   },
-  quarantineEndDateContainer: {
-    marginTop: Spacing.xSmall,
-    paddingTop: Spacing.xxSmall,
-    borderTopWidth: Outlines.hairline,
-    borderColor: Colors.neutral.shade30,
+  recommendationLabelContainer: {
+    flex: 1,
   },
-  daysRemainingTextContainer: {
-    flex: 3,
-  },
-  dayNumberContainer: {
-    justifyContent: "center",
-    alignItems: "center",
-    backgroundColor: Colors.neutral.white,
-    paddingVertical: Spacing.xSmall,
-    paddingHorizontal: Spacing.medium,
-    borderRadius: Outlines.baseBorderRadius,
+  recommendationValueContainer: {
+    flex: 2,
+    alignItems: "flex-start",
     marginLeft: Spacing.xSmall,
   },
-  dayNumberText: {
-    ...Typography.base.x50,
-    ...Typography.style.bold,
+  recommendationText: {
+    ...Typography.base.x40,
+    ...Typography.style.semibold,
+    ...Typography.style.monospace,
   },
 })
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,7 +35,6 @@
     "select_language": "Select language",
     "settings": "Open Settings",
     "skip": "Skip",
-    "something_went_wrong": "Something went wrong",
     "start": "Start",
     "submit": "Submit",
     "success": "Success"
@@ -53,7 +52,6 @@
     "source": "source: {{source}}"
   },
   "covid_recommendation": {
-    "and_other_covid": "- And other other COVID-19 symptoms have improved.",
     "find_a_test_center": "Find a test center",
     "for_more_information": "For more information on how to prevent spreading the illness to others, see the CDC guidance on what to do when you are sick: ",
     "from_others_at": "from others at all times and ",
@@ -65,11 +63,9 @@
     "physically_separate": "Physically separate yourself from others, ",
     "review_cdc_guidance": "Review CDC guidance",
     "review_symptoms": "Review CDC symptoms",
-    "stay_home": "Stay home and isolate, until:",
     "stay_home_except_to_get_medical_care": "Stay home except to get medical care.",
     "to_prevent_the_spread": "To prevent the spread of COVID-19 if you are sick you should:",
-    "wear_a_face_covering": "wear a face covering.",
-    "you_have_not_had_a": "- You have not had a fever for a least 24 hour,"
+    "wear_a_face_covering": "wear a face covering."
   },
   "errors": {
     "description": "An error has occurred. Please reload the app.",
@@ -103,9 +99,6 @@
   },
   "export": {
     "code": "Code",
-    "code_input_body_bluetooth": "Enter your verification code",
-    "code_input_button_cancel": "Cancel",
-    "code_input_title_bluetooth": "Verify your diagnosis",
     "complete_body_bluetooth": "You’re helping contain the spread of the virus and protect others in your community.",
     "complete_title": "Thanks for keeping your community safe!",
     "consent_body_0": "Sharing your positive diagnosis is optional and can only be done with your consent.",
@@ -118,11 +111,9 @@
     "enable_exposure_notifications_title": "Enable exposure notifications to continue",
     "enter_verification_code": "Enter verification code",
     "error": {
-      "invalid_code": "Try a different code",
       "invalid_format": "Codes may only contain numbers and letters",
       "network_connection_error": "There is no internet connection",
-      "unknown_code_verification_error": "Try a different code",
-      "verification_code_used": "Verification code has already been used"
+      "unknown_code_verification_error": "Try a different code"
     },
     "intro": {
       "body1": "If you have received a verification code from {{healthAuthorityName}} for a positive COVID-19 test, you can submit the verification code on the following screen.",
@@ -167,7 +158,6 @@
   "exposure_history": {
     "check_for_exposures": "Check for exposures",
     "days_remaining": "Days remaining:",
-    "recommended_quarantine": "Recommended Quarantine",
     "exposure_detail": {
       "next_steps": "Review health guidelines",
       "personalize_my_guidance": "Personalize my guidance",
@@ -193,6 +183,7 @@
     "no_exposure_reports": "No Exposure Reports",
     "no_exposure_reports_over_past": "You haven't received any exposure reports over the past 14-days",
     "possible_exposures": "Possible Exposures",
+    "recommended_quarantine": "Recommended Quarantine",
     "review_health_guidance": "Review Health Guidance",
     "stay_quarantined_through": "Last day:",
     "updated": "Updated",
@@ -227,7 +218,6 @@
   "home": {
     "bluetooth_info_body": "Your phone detects other phones you spend time in close contact with using Bluetooth Low Energy. This allows the app to log your daily encounters anonymously, even when you don’t have the app open on your device.",
     "bluetooth": {
-      "all_services_on_subheader": "{{applicationName}} will remain active after the app has been closed",
       "location_disabled_error_message": "To activate the Exposure Notification technology, authorize Location access in the Settings app",
       "location_disabled_error_title": "Authorize in Settings",
       "location_header": "Location",
@@ -236,7 +226,6 @@
       "share": "Share {{applicationName}}",
       "share_message": "Check out this app {{applicationName}}, which can help us contain COVID-19! {{appDownloadUrl}}",
       "tracing_off_header": "Exposure Detection Off",
-      "tracing_off_subheader": "Enable Bluetooth and Proximity Tracing to get info about possible exposures",
       "tracing_on_header": "Exposure Detection On"
     },
     "call_emergency_services": "Call Emergency Services",
@@ -274,7 +263,6 @@
     "launch_get_started": "Get Started",
     "launch_screen1_header": "Welcome to ",
     "privacy_policy": "Privacy Policy",
-    "question_icon": "Question mark icon",
     "unchecked_checkbox": "Unchecked checkbox"
   },
   "navigation": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -166,7 +166,8 @@
   },
   "exposure_history": {
     "check_for_exposures": "Check for exposures",
-    "days_remaining": "Days remaining in your recommended quarantine period:",
+    "days_remaining": "Days remaining:",
+    "recommended_quarantine": "Recommended Quarantine",
     "exposure_detail": {
       "next_steps": "Review health guidelines",
       "personalize_my_guidance": "Personalize my guidance",
@@ -193,7 +194,7 @@
     "no_exposure_reports_over_past": "You haven't received any exposure reports over the past 14-days",
     "possible_exposures": "Possible Exposures",
     "review_health_guidance": "Review Health Guidance",
-    "stay_quarantined_through": "Stay quarantined through:",
+    "stay_quarantined_through": "Last day:",
     "updated": "Updated",
     "why_did_i_get_an_en": "Why did I get an exposure notification?",
     "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you have been in close contact with later uses the app to report a positive COVID-19 test.",


### PR DESCRIPTION
Why:
We would like to update the recommended quarantine section on the
exposure history screen to be more direct and to remove some ambiguity
in what 'stay quarantined through means'

This commit:
Updates the language of the recommended quarantine section to use fewer
words. We also change the notion of `quarantine through:` to `last day:`

Note:
We would like for days remaining to say 1 when the current day
is the last day shown on the card.
We would like the first day of quarantine to be the day after the
exposure range end date.
So the time line for a 14 quarantine is determined as follows:

recorded exposure date : 1/2/2021
expected exposure range : 1/1/2021 - 1/3/2021
first day of quarantine: 1/4/2021 (14 days remaining)
last day of quarantine: 1/17/2021 (1 day remaining)


|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 12 Pro Max - 2021-01-15 at 12 57 56](https://user-images.githubusercontent.com/16049495/104777968-6e459500-5731-11eb-9faf-c5e15ef20f9e.png)|![Simulator Screen Shot - iPhone 12 Pro Max - 2021-01-15 at 12 00 40](https://user-images.githubusercontent.com/16049495/104777979-7271b280-5731-11eb-8e9e-ef345bdb2235.png)|
