### PR TITLE
Handle dont share action in escrow verification

### DIFF
--- a/ios/EscrowVerification/Manager/EscrowVerificationManager.swift
+++ b/ios/EscrowVerification/Manager/EscrowVerificationManager.swift
@@ -25,8 +25,8 @@ class EscrowVerificationManager: NSObject {
             completionHandler(nil)
           }
         }
-      default:
-        break
+      case let .failure(error):
+        completionHandler(error)
       }
     }
   }
@@ -71,8 +71,8 @@ class EscrowVerificationManager: NSObject {
             }
           }
         }
-      default:
-        break
+      case let .failure(error):
+        completionHandler(error)
       }
     }
   }

--- a/src/EscrowVerification/API.ts
+++ b/src/EscrowVerification/API.ts
@@ -18,7 +18,11 @@ interface PhoneNumberFailure {
   error: PhoneNumberError
 }
 
-export type PhoneNumberError = "RateLimit" | "Unknown" | "NoKeysOnDevice"
+export type PhoneNumberError =
+  | "RateLimit"
+  | "Unknown"
+  | "NoKeysOnDevice"
+  | "NotAuthorized"
 
 export const submitPhoneNumber = async (
   phoneNumber: string,
@@ -27,17 +31,73 @@ export const submitPhoneNumber = async (
     await escrowVerificationKeySubmissionModule.submitPhoneNumber(phoneNumber)
     return { kind: "success" }
   } catch (e) {
-    Logger.error(`failed to submit phone number: `, { ...e })
-    switch (e.code) {
-      case "403":
-        return { kind: "failure", error: "RateLimit" }
-      case "999":
-        return { kind: "failure", error: "NoKeysOnDevice" }
-      default:
-        return { kind: "failure", error: "Unknown" }
+    Logger.addMetadata(`failed to submit phone number: `, {
+      error: JSON.stringify(e),
+    })
+    if (e.code === "ENErrorDomain") {
+      return { kind: "failure", error: handlePhoneENError(e) }
+    } else {
+      return { kind: "failure", error: handlePhoneNetworkError(e) }
     }
   }
 }
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const handlePhoneENError = (error: any): PhoneNumberError => {
+  try {
+    const errorMessage = error.message
+    assertString(errorMessage)
+
+    const errorCodeRegex = /ENErrorDomain error (\d+)./
+    const match = errorMessage.match(errorCodeRegex) ?? []
+    const errorCode = match[1]
+    assertIntegerString(errorCode)
+
+    switch (errorCode) {
+      case "4":
+        return "NotAuthorized"
+      default:
+        Logger.error(`Unhandled error code in handlePhoneENError:`, {
+          code: errorCode,
+        })
+        return "Unknown"
+    }
+  } catch (e) {
+    Logger.error(`Unknown error format for handlePhoneENError:`, {
+      error: JSON.stringify(error),
+      message: e,
+    })
+    return "Unknown"
+  }
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const handlePhoneNetworkError = (error: any): PhoneNumberError => {
+  try {
+    assertIntegerString(error.code)
+
+    switch (error.code) {
+      case "403":
+        Logger.error("Hit rate limit")
+        return "RateLimit"
+      case "999":
+        return "NoKeysOnDevice"
+      default:
+        Logger.error(`Unhandled error code in handlePhoneNetworkError:`, {
+          code: error.code,
+        })
+        return "Unknown"
+    }
+  } catch (e) {
+    Logger.error(`Unknown error format for handlePhoneNetworkError:`, {
+      error: JSON.stringify(error),
+      message: e,
+    })
+    return "Unknown"
+  }
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 export type SubmitKeysResponse = SubmitKeysSuccess | SubmitKeysFailure
 
@@ -49,7 +109,7 @@ interface SubmitKeysFailure {
   error: SubmitKeysError
 }
 
-export type SubmitKeysError = "Unknown" | "NoKeysOnDevice"
+export type SubmitKeysError = "Unknown" | "NoKeysOnDevice" | "NotAuthorized"
 
 export const submitDiagnosisKeys = async (
   verificationCode: string,
@@ -62,12 +122,80 @@ export const submitDiagnosisKeys = async (
     )
     return { kind: "success" }
   } catch (e) {
-    Logger.error(`failed to submit verification code: `, { ...e })
-    switch (e.code) {
-      case "999":
-        return { kind: "failure", error: "NoKeysOnDevice" }
-      default:
-        return { kind: "failure", error: "Unknown" }
+    Logger.addMetadata(`failed to submit diagnosis keys: `, {
+      error: JSON.stringify(e),
+    })
+
+    if (e.code === "ENErrorDomain") {
+      return { kind: "failure", error: handleKeysENError(e) }
+    } else {
+      return { kind: "failure", error: handleKeysNetworkError(e) }
     }
+  }
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const handleKeysENError = (error: any): SubmitKeysError => {
+  try {
+    const errorMessage = error.message
+    assertString(errorMessage)
+
+    const errorCodeRegex = /ENErrorDomain error (\d+)./
+    const match = errorMessage.match(errorCodeRegex) ?? []
+    const errorCode = match[1]
+    assertIntegerString(errorCode)
+
+    switch (errorCode) {
+      case "4":
+        return "NotAuthorized"
+      default:
+        Logger.error(`Unhandled error code in handleKeysENError:`, {
+          code: errorCode,
+        })
+        return "Unknown"
+    }
+  } catch (e) {
+    Logger.error(`Unknown error format for handleKeysENError:`, {
+      error: JSON.stringify(error),
+      message: e,
+    })
+    return "Unknown"
+  }
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const handleKeysNetworkError = (error: any): SubmitKeysError => {
+  try {
+    assertIntegerString(error.code)
+
+    switch (error.code) {
+      case "999":
+        return "NoKeysOnDevice"
+      default:
+        Logger.error(`Unhandled error code in handleKeysNetworkError:`, {
+          code: error.code,
+        })
+        return "Unknown"
+    }
+  } catch (e) {
+    Logger.error(`Unknown error format for handleKeysNetworkError:`, {
+      error: JSON.stringify(error),
+      message: e,
+    })
+    return "Unknown"
+  }
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+function assertString(s: unknown): asserts s is string {
+  if (typeof s !== "string") {
+    throw new Error("Value was not a string: " + s)
+  }
+}
+
+function assertIntegerString(integer: unknown): asserts integer is string {
+  if (!integer || !Number.isInteger(Number(integer))) {
+    throw new Error("Value was not an String Integer: " + integer)
   }
 }

--- a/src/EscrowVerification/UserDetailsForm.tsx
+++ b/src/EscrowVerification/UserDetailsForm.tsx
@@ -122,14 +122,17 @@ const UserDetailsForm: FunctionComponent = () => {
     } catch (e) {
       Logger.error(`escrow verification error`, e.message)
       Alert.alert(showErrorDialogTitle(e), e.message)
+    } finally {
+      setIsLoading(false)
     }
-    setIsLoading(false)
   }
 
   const buttonDisabled = phoneNumber.length < 1
 
   const showErrorDialogTitle = (error: API.PhoneNumberError): string => {
     switch (error) {
+      case "NotAuthorized":
+        return t("verification_code_alerts.not_authorized_title")
       case "NoKeysOnDevice":
         return t("verification_code_alerts.no_keys_on_device_title")
       default:
@@ -139,6 +142,8 @@ const UserDetailsForm: FunctionComponent = () => {
 
   const showErrorDialogMessage = (error: API.PhoneNumberError): string => {
     switch (error) {
+      case "NotAuthorized":
+        return t("verification_code_alerts.not_authorized_body")
       case "NoKeysOnDevice":
         return t("verification_code_alerts.no_keys_on_device_body")
       case "RateLimit":

--- a/src/EscrowVerification/VerificationCodeForm.tsx
+++ b/src/EscrowVerification/VerificationCodeForm.tsx
@@ -84,11 +84,20 @@ const VerificationCodeForm: FunctionComponent = () => {
       Logger.error("Unhandled error on submit code to escrow")
       Alert.alert(t("errors.something_went_wrong"), e.message)
       setIsLoading(false)
+    } finally {
+      setIsLoading(false)
     }
   }
 
   const showError = (error: API.SubmitKeysError): void => {
     switch (error) {
+      case "NotAuthorized":
+        Alert.alert(
+          t("verification_code_alerts.not_authorized_title"),
+          t("verification_code_alerts.not_authorized_body"),
+          [{ text: t("common.okay") }],
+        )
+        break
       case "NoKeysOnDevice":
         Alert.alert(
           t("verification_code_alerts.no_keys_on_device_title"),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -519,6 +519,8 @@
     "invalid_code_title": "Invalid Code",
     "network_connection_body": "You need to be connected to WiFi to submit a verification code.",
     "network_connection_title": "No Internet Connection",
+    "not_authorized_body": "You did not authorize the app to share your Random IDs.",
+    "not_authorized_title": "Did not authorize",
     "no_keys_on_device_body": "You do not have any exposures to submit. Please continue to isolate.",
     "no_keys_on_device_title": "No exposures on device",
     "unknown_body": "An unexpected error occurred. Please try again.",


### PR DESCRIPTION
Why:
During the submit your phone number step of the Escrow Verification
flow, an OS level prompt asks if the user would like to share their
devices Random IDs. If the user chooses 'Dont Share' the os will raise
an error which we are not handling.

This commit:
- Updates the error handling for the submitPhoneNumber iOS native method
to return ENDomainErrors when the os returns them.

- Updates the javascript side error handling for the submitPhoneNumber
native method. Note that the api for the native function can return both
network error and ENDomainErrors which do not follow the same error
format. We introduced a `handleNetworkErrror()` and
`handleENDomainError()` to handle these two cases. A future refactor
might consider updating the native method to better separate the error
conditions.

|GIF|
|---|
|![RPReplay_Final1611251740](https://user-images.githubusercontent.com/16049495/105392848-85bccc00-5bd0-11eb-931b-91339c707439.gif)|
