### PR TITLE
GAEN-685 Return error when there are no keys to submit

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/escrowserver/EscrowVerificationClient.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/network/escrowserver/EscrowVerificationClient.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.pathcheck.covidsafepaths.BuildConfig
+import org.pathcheck.covidsafepaths.exposurenotifications.reactmodules.EscrowVerificationKeySubmissionModule.Companion.NO_KEYS_ERROR_CODE
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.ExposureNotificationSharedPreferences
 import org.pathcheck.covidsafepaths.exposurenotifications.utils.Error
 import org.pathcheck.covidsafepaths.exposurenotifications.utils.Result
@@ -183,7 +184,7 @@ object EscrowVerificationClient {
                     if (submission.keys!!.isEmpty()) {
                         Log.w(TAG, "There are no keys")
                         // Backend is not called, return a success
-                        return@withContext Result.Success(Unit)
+                        return@withContext Result.Failure(Error(NO_KEYS_ERROR_CODE, "NoKeysOnDevice"))
                     }
                 } catch (e: KotlinNullPointerException) {
                     Log.e(TAG, "Keys are null")

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/EscrowVerificationKeySubmissionModule.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/EscrowVerificationKeySubmissionModule.kt
@@ -8,7 +8,6 @@ import com.facebook.react.module.annotations.ReactModule
 import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
 import com.google.common.util.concurrent.FutureCallback
 import com.google.common.util.concurrent.Futures
-import java.lang.Exception
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -27,6 +26,7 @@ import org.pathcheck.covidsafepaths.exposurenotifications.utils.Result
 class EscrowVerificationKeySubmissionModule(context: ReactApplicationContext?) : ReactContextBaseJavaModule(context) {
     companion object {
         const val MODULE_NAME = "EscrowVerificationKeySubmissionModule"
+        const val NO_KEYS_ERROR_CODE = 999
     }
 
     override fun getName(): String {
@@ -104,7 +104,7 @@ class EscrowVerificationKeySubmissionModule(context: ReactApplicationContext?) :
                         return@launch
                     }
 
-                    promise.reject(Exception("No exposure keys"))
+                    promise.reject(NO_KEYS_ERROR_CODE.toString(), "NoKeysOnDevice")
                 }
             }
 


### PR DESCRIPTION
#### Why:

<!-- Provide context to the reader as to why this PR is useful or needed. -->
We user was seeing a Success message when he doesn't have keys to submit

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->
Returns a Failure instead to let the user know we didn't have anything to send to the backend

