### PR TITLE
(iOS) Remove wildcard domain from app domains

### DIFF
--- a/ios/BT/BT-Development.entitlements
+++ b/ios/BT/BT-Development.entitlements
@@ -6,7 +6,6 @@
 	<string>Development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:*.en.express</string>
 		<string>applinks:$(ENX_APPLINKS_DOMAIN)</string>
 	</array>
 	<key>com.apple.developer.exposure-notification</key>

--- a/ios/BT/BT-Production.entitlements
+++ b/ios/BT/BT-Production.entitlements
@@ -6,7 +6,6 @@
 	<string>Production</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:*.en.express</string>
 		<string>applinks:$(ENX_APPLINKS_DOMAIN)</string>
 	</array>
 	<key>com.apple.developer.exposure-notification</key>


### PR DESCRIPTION
#### Why:

The wildcard app domain doesn’t add anything, and could cause unintended consequences

#### This commit:

Removes wildcard domain from app domains