### PR TITLE
GAEN-656 Create notification channel for background notifications

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/common/NotificationHelper.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/common/NotificationHelper.java
@@ -21,6 +21,7 @@ import org.pathcheck.covidsafepaths.R;
 public final class NotificationHelper {
 
   private static final String EXPOSURE_NOTIFICATION_CHANNEL_ID = "EXPOSURE_NOTIFICATION_CHANNEL_ID";
+  private static final String BACKGROUND_WORKER_NOTIFICATION_CHANNEL_ID = "EXPOSURE_CHECK_NOTIFICATION_CHANNEL_ID";
 
   private static final Integer EXPOSURE_NOTIFICATION_ID = 0;
   private static final Integer BACKGROUND_WORKER_NOTIFICATION_ID = 1;
@@ -58,9 +59,9 @@ public final class NotificationHelper {
    * Create notification that will be shown while we are checking exposures.
    */
   public static ForegroundInfo createWorkerNotification(Context context) {
-    createNotificationChannel(context);
+    createBackgroundWorkerNotificationChannel(context);
     NotificationCompat.Builder builder =
-        new Builder(context, EXPOSURE_NOTIFICATION_CHANNEL_ID)
+        new Builder(context, BACKGROUND_WORKER_NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification)
             .setColor(context.getResources().getColor(R.color.colorPrimary, context.getTheme()))
             .setContentTitle(context.getString(R.string.background_worker_notification_title))
@@ -78,6 +79,21 @@ public final class NotificationHelper {
               context.getString(R.string.exposure_notification_channel_name),
               NotificationManager.IMPORTANCE_HIGH);
       channel.setDescription(context.getString(R.string.exposure_notification_channel_description));
+      NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+      Objects.requireNonNull(notificationManager).createNotificationChannel(channel);
+    }
+  }
+
+  /**
+   * Creates the notification channel to show notifications when the device is checking exposures in background.
+   */
+  private static void createBackgroundWorkerNotificationChannel(Context context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      NotificationChannel channel =
+          new NotificationChannel(BACKGROUND_WORKER_NOTIFICATION_CHANNEL_ID,
+              context.getString(R.string.background_worker_channel_name),
+              NotificationManager.IMPORTANCE_HIGH);
+      channel.setDescription(context.getString(R.string.background_worker_channel_description));
       NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
       Objects.requireNonNull(notificationManager).createNotificationChannel(channel);
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
 <resources>
   <!-- Shown on app info, app switcher, etc -->
   <string name="app_name" translatable="false">PathCheck BT</string>
+  <string name="background_worker_channel_description">Indicates your device is checking for possible COVID-19 exposure.</string>
+  <string name="background_worker_channel_name">Exposure Check</string>
   <string name="background_worker_notification_title">Checking exposures…</string>
   <string name="exposure_notification_channel_description">Exposure notification alerts.</string>
   <string name="exposure_notification_channel_name">Exposure Notification</string>


### PR DESCRIPTION
#### Why:

<!-- Provide context to the reader as to why this PR is useful or needed. -->
We have multiple user requests for a way to silence the periodic “checking for exposures” message. The current configuration respects the normal notification silencing setting on phones, but people want a separate way to silence just the COVIDaware MN “checking for exposures” notification (independent from an actual “exposure notification” and the overall phone settings).

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->
Creates a new notification channel (Exposure Check) that gives the user the option to disable "Checking exposures..." notifications when the background job is running.

#### Screenshots:

<!-- Provide screenshots or gif for visual changes -->
![device-2021-01-28-123812](https://user-images.githubusercontent.com/9491378/106161738-1ada3a80-6166-11eb-8c71-1538c70f1d55.png)

#### How to test:

<!-- Provide steps to test this PR -->
- Disable "Exposure Check" notifications from `Settings > Apps & notifications > App > App Info > Notifications `
- Tap on Check for exposures in the app
- Verify the notification is not shown

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/GAEN-656