### PR TITLE
Handle 429 rate limit code

### DIFF
--- a/src/EscrowVerification/API.ts
+++ b/src/EscrowVerification/API.ts
@@ -19,10 +19,11 @@ interface PhoneNumberFailure {
 }
 
 export type PhoneNumberError =
-  | "RateLimit"
-  | "Unknown"
   | "NoKeysOnDevice"
   | "NotAuthorized"
+  | "Forbidden"
+  | "RateLimit"
+  | "Unknown"
 
 export const submitPhoneNumber = async (
   phoneNumber: string,
@@ -79,7 +80,10 @@ const handlePhoneNetworkError = (error: any): PhoneNumberError => {
 
     switch (error.code) {
       case "403":
-        Logger.error("Hit rate limit")
+        Logger.error("Escrow server returned 403: Forbidden")
+        return "Forbidden"
+      case "429":
+        Logger.error("Escrow server returned 429: Hit rate limit")
         return "RateLimit"
       case "999":
         return "NoKeysOnDevice"
@@ -109,7 +113,12 @@ interface SubmitKeysFailure {
   error: SubmitKeysError
 }
 
-export type SubmitKeysError = "Unknown" | "NoKeysOnDevice" | "NotAuthorized"
+export type SubmitKeysError =
+  | "NoKeysOnDevice"
+  | "NotAuthorized"
+  | "RateLimit"
+  | "Forbidden"
+  | "Unknown"
 
 export const submitDiagnosisKeys = async (
   verificationCode: string,
@@ -172,6 +181,12 @@ const handleKeysNetworkError = (error: any): SubmitKeysError => {
     switch (error.code) {
       case "999":
         return "NoKeysOnDevice"
+      case "403":
+        Logger.error("Escrow server returned 403: Forbidden")
+        return "Forbidden"
+      case "429":
+        Logger.error("Escrow server returned 429: Hit rate limit")
+        return "RateLimit"
       default:
         Logger.error(`Unhandled error code in handleKeysNetworkError:`, {
           code: error.code,

--- a/src/EscrowVerification/UserDetailsForm.tsx
+++ b/src/EscrowVerification/UserDetailsForm.tsx
@@ -135,6 +135,8 @@ const UserDetailsForm: FunctionComponent = () => {
         return t("verification_code_alerts.not_authorized_title")
       case "NoKeysOnDevice":
         return t("verification_code_alerts.no_keys_on_device_title")
+      case "RateLimit":
+        return t("verification_code_alerts.rate_limit_title")
       default:
         return t("errors.something_went_wrong")
     }
@@ -147,7 +149,7 @@ const UserDetailsForm: FunctionComponent = () => {
       case "NoKeysOnDevice":
         return t("verification_code_alerts.no_keys_on_device_body")
       case "RateLimit":
-        return t("escrow_verification.error.rate_limit")
+        return t("verification_code_alerts.rate_limit_body")
       default:
         return t("errors.try_again_later")
     }

--- a/src/EscrowVerification/VerificationCodeForm.tsx
+++ b/src/EscrowVerification/VerificationCodeForm.tsx
@@ -105,6 +105,13 @@ const VerificationCodeForm: FunctionComponent = () => {
           [{ text: t("common.okay") }],
         )
         break
+      case "RateLimit":
+        Alert.alert(
+          t("verification_code_alerts.rate_limit_title"),
+          t("verification_code_alerts.rate_limit_body"),
+          [{ text: t("common.okay") }],
+        )
+        break
       case "Unknown":
         Alert.alert(
           t("verification_code_alerts.unknown_title"),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -530,6 +530,8 @@
     "no_keys_on_device_title": "No exposures to share from device",
     "not_authorized_body": "You did not authorize the app to share your Random IDs.",
     "not_authorized_title": "Did not authorize",
+    "rate_limit_body": "You've reach the daily submission limit. Please try again in 24 hours.",
+    "rate_limit_title": "Max submissions reached",
     "unknown_body": "An unexpected error occurred. Please try again.",
     "unknown_title": "Something Went Wrong"
   }


### PR DESCRIPTION
Why:
During the escrow verification code flow if the escrow server returns a
429 rate limit, we are only informing the user that 'something went
wrong'. We would like to explicitly let the user know they hit the rate
limit set by the server. Additionally we are treating 403's as rate
limits rather than 'Forbidden' as defined by the http status code spec.

This commit:
Adds the 429 code to the error handling flow and remaps a 403 to the
correct status.
