### PR TITLE
Accessibility updates

### DIFF
--- a/src/ExposureHistory/History/ExposureSummary.tsx
+++ b/src/ExposureHistory/History/ExposureSummary.tsx
@@ -127,6 +127,8 @@ const style = StyleSheet.create({
     borderRadius: Outlines.baseBorderRadius,
     paddingVertical: Spacing.xSmall,
     paddingHorizontal: Spacing.xSmall,
+    borderColor: Colors.primary.shade100,
+    borderWidth: Outlines.thin,
   },
   headerContainer: {
     paddingBottom: Spacing.xxSmall,


### PR DESCRIPTION
### Accessibility defect: "Contrast of the en indicator card is not 4.5"

#### This commit: 
This commit adds a high contrast border around the `EN` card. After the update, the contrast between the white background and the border is > 4.5, as is the contrast between the black text and the card's background.
<img width="1131" alt="Screen Shot 2021-02-02 at 1 25 13 PM" src="https://user-images.githubusercontent.com/2637355/106652446-185b5480-655b-11eb-8cc5-44cac4e94f78.png">
<img width="1158" alt="Screen Shot 2021-02-02 at 1 24 24 PM" src="https://user-images.githubusercontent.com/2637355/106652452-198c8180-655b-11eb-8a5d-e2f9acbda645.png">
