### PR TITLE
Android accessibility update

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/common/NotificationHelper.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/common/NotificationHelper.java
@@ -56,7 +56,7 @@ public final class NotificationHelper {
   }
 
   /**
-   * Create notification that will be shown when exposure check has completed successfully
+   * Create notification that will be shown when exposure check has completed successfully.
    */
   public static ForegroundInfo createSuccessWorkerNotification(Context context) {
     createBackgroundWorkerNotificationChannel(context);
@@ -70,7 +70,7 @@ public final class NotificationHelper {
   }
 
   /**
-   * Create notification that will be shown when exposure check has completed unsuccessfully
+   * Create notification that will be shown when exposure check has completed unsuccessfully.
    */
   public static ForegroundInfo createFailureWorkerNotification(Context context) {
     createBackgroundWorkerNotificationChannel(context);

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/common/NotificationHelper.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/common/NotificationHelper.java
@@ -56,15 +56,29 @@ public final class NotificationHelper {
   }
 
   /**
-   * Create notification that will be shown while we are checking exposures.
+   * Create notification that will be shown when exposure check has completed successfully
    */
-  public static ForegroundInfo createWorkerNotification(Context context) {
+  public static ForegroundInfo createSuccessWorkerNotification(Context context) {
     createBackgroundWorkerNotificationChannel(context);
     NotificationCompat.Builder builder =
         new Builder(context, BACKGROUND_WORKER_NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification)
             .setColor(context.getResources().getColor(R.color.colorPrimary, context.getTheme()))
-            .setContentTitle(context.getString(R.string.background_worker_notification_title))
+            .setContentTitle(context.getString(R.string.background_worker_notification_title_success))
+            .setOngoing(true);
+    return new ForegroundInfo(BACKGROUND_WORKER_NOTIFICATION_ID, builder.build());
+  }
+
+  /**
+   * Create notification that will be shown when exposure check has completed unsuccessfully
+   */
+  public static ForegroundInfo createFailureWorkerNotification(Context context) {
+    createBackgroundWorkerNotificationChannel(context);
+    NotificationCompat.Builder builder =
+        new Builder(context, BACKGROUND_WORKER_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setColor(context.getResources().getColor(R.color.colorPrimary, context.getTheme()))
+            .setContentTitle(context.getString(R.string.background_worker_notification_title_failure))
             .setOngoing(true);
     return new ForegroundInfo(BACKGROUND_WORKER_NOTIFICATION_ID, builder.build());
   }

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="background_worker_notification_title">Έλεγχος για εκθέσεις...</string>
-  <string name="exposure_notification_channel_description">Ειδοποιήσεις έκθεσης</string>
+    <string name="exposure_notification_channel_description">Ειδοποιήσεις έκθεσης</string>
   <string name="exposure_notification_channel_name">Ειδοποίηση έκθεσης</string>
   <string name="exposure_notification_message">Βρεθήκατε κοντά σε κάποιον που έχει διαγνωστεί θετικά με COVID-19. Πατήστε για περισσότερες πληροφορίες.</string>
   <string name="exposure_notification_title">Πιθανή έκθεση στον COVID-19</string>

--- a/android/app/src/main/res/values-es-rPR/strings.xml
+++ b/android/app/src/main/res/values-es-rPR/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="background_worker_notification_title">Comprobando si hay exposiciones...</string>
-  <string name="exposure_notification_channel_description">Alertas de Notificaciones de Exposición.</string>
+    <string name="exposure_notification_channel_description">Alertas de Notificaciones de Exposición.</string>
   <string name="exposure_notification_channel_name">Aviso de exposición</string>
   <string name="exposure_notification_message">Has estado cerca de alguien que dió positivo a COVID-19. Pulse para obtener más información.</string>
   <string name="exposure_notification_title">Posible exposición al COVID-19</string>

--- a/android/app/src/main/res/values-hmn/strings.xml
+++ b/android/app/src/main/res/values-hmn/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="background_worker_notification_title">Mus nyob ze raug tus kab mob...</string>
-  <string name="exposure_notification_channel_description">Kev ceeb toom mus raug mob </string>
+    <string name="exposure_notification_channel_description">Kev ceeb toom mus raug mob </string>
   <string name="exposure_notification_channel_name">Kev Ceeb Toom Raug Mob</string>
   <string name="exposure_notification_message">Koj tau mus ze ib tus neeg mob COVID-19.Nias kom thiaj li qhia ntxiv.</string>
   <string name="exposure_notification_title">Tej zaum tau mus kis raug COVID-19 lawm</string>

--- a/android/app/src/main/res/values-id/strings.xml
+++ b/android/app/src/main/res/values-id/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="background_worker_notification_title">Memeriksa eksposur…</string>
-  <string name="exposure_notification_channel_description">Sinyal pemberitahuan eksposur.</string>
+    <string name="exposure_notification_channel_description">Sinyal pemberitahuan eksposur.</string>
   <string name="exposure_notification_channel_name">Pemberitahuan Eksposur</string>
   <string name="exposure_notification_message">Seseorang yang dekat dengan Anda dinyatakan positif COVID-19. Klik untuk info lebih lanjut.</string>
   <string name="exposure_notification_title">Kemungkinan terekspos COVID-19</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="background_worker_notification_title">노출 확인 중…</string>
-  <string name="exposure_notification_channel_description">노출 알림 경고</string>
+    <string name="exposure_notification_channel_description">노출 알림 경고</string>
   <string name="exposure_notification_channel_name">노출 알림</string>
   <string name="exposure_notification_message">귀하의 주변에서 코로나19 감염 확진자가 발생했습니다. 자세한 정보를 보려면 해당 버튼을 누릅십시오.</string>
   <string name="exposure_notification_title">코로나19 노출 가능성</string>

--- a/android/app/src/main/res/values-so/strings.xml
+++ b/android/app/src/main/res/values-so/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="background_worker_notification_title">Hubinta dadka caabuqa qaba ee aad la joogtay...</string>
-  <string name="exposure_notification_channel_description">Digniino ogeysiis soogaaritaanno</string>
+    <string name="exposure_notification_channel_description">Digniino ogeysiis soogaaritaanno</string>
   <string name="exposure_notification_channel_name">Ogeysiinta Ufeydsanku</string>
   <string name="exposure_notification_message">Qof adiga kaa ogdhowaa ayaa laga helay COVID-19. Taabo si aad u hesho faahfaahin dheeraad ah.</string>
   <string name="exposure_notification_title">Ufeydsanaan COVID-19 suurtagal ah</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="background_worker_notification_title">Maruziyet kontrolü yapılıyor</string>
-  <string name="exposure_notification_channel_description">Maruz kalma bildirimi uyarıları</string>
+    <string name="exposure_notification_channel_description">Maruz kalma bildirimi uyarıları</string>
   <string name="exposure_notification_channel_name">Maruz Kalma Bildirimi</string>
   <string name="exposure_notification_message">Yakınında bulunmuş olduğun birinin COVID-19 testi pozitif çıktı. Daha fazla bilgi için tıkla.</string>
   <string name="exposure_notification_title">Olası COVID-19 maruziyeti</string>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="background_worker_notification_title">Đang kiểm tra các trường hợp tiếp xúc...</string>
-  <string name="exposure_notification_channel_description">Cảnh báo thông báo tiếp xúc.</string>
+    <string name="exposure_notification_channel_description">Cảnh báo thông báo tiếp xúc.</string>
   <string name="exposure_notification_channel_name">Thông Báo Tiếp Xúc</string>
   <string name="exposure_notification_message">Một người đã ở gần bạn đã có xét nghiệm dương tính với COVID-19. Chạm vào để biết thêm thông tin.</string>
   <string name="exposure_notification_title">Có thể có tiếp xúc với COVID-19</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,7 +4,8 @@
   <string name="app_name" translatable="false">PathCheck BT</string>
   <string name="background_worker_channel_description">Indicates your device is checking for possible COVID-19 exposure.</string>
   <string name="background_worker_channel_name">Exposure Check</string>
-  <string name="background_worker_notification_title">Checking exposures…</string>
+  <string name="background_worker_notification_title_success">Exposure check successful</string>
+  <string name="background_worker_notification_title_failure">Exposure check unsuccessful</string>
   <string name="exposure_notification_channel_description">Exposure notification alerts.</string>
   <string name="exposure_notification_channel_name">Exposure Notification</string>
   <string name="exposure_notification_message">Someone you were near has tested positive for COVID-19. Tap for more info.</string>


### PR DESCRIPTION
## Why:
We'd like talkback to announce the result of a manually triggered exposure detection cycle on Android. Currently on Android, talkback announces that manual exposure detection is in progress, but does not report the result

## This commit:
This commit removes the local notification announcing that exposure detection is in progress, and instead triggers a local notification when the check completes, announcing success or failure depending on the result.

* Note - we may want to implement the same functionality on iOS. iOS does not trigger a local (native) notification, and the "success" toast is likely not announced when talkback is enabled



