### PR TITLE
Update code input form for accessibility.

### DIFF
--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -104,7 +104,7 @@ export const text: Record<Text, string> = {
   primary: neutral.shade140,
   anchorLink: primary.shade100,
   error: accent.danger100,
-  placeholder: neutral.shade75,
+  placeholder: neutral.shade100,
 }
 
 type RiskLevel = "low" | "medium" | "high" | "critical" | "unknown" | "extreme"

--- a/src/styles/forms.ts
+++ b/src/styles/forms.ts
@@ -29,7 +29,7 @@ export const required: TextStyle = {
 export const textInput: TextStyle = {
   ...Typography.form.inputText,
   borderRadius: Outlines.baseBorderRadius,
-  borderColor: Colors.neutral.shade10,
+  borderColor: Colors.neutral.shade100,
   borderWidth: Outlines.hairline,
   paddingTop: Spacing.small - 1,
   paddingBottom: Spacing.small,


### PR DESCRIPTION
#### Why:
Contrast of the placeholder does not meet 4.5 to 1 minium

#### This commit:
This commit uses higher contrast colors for the `textinput` border and placeholder to bring it in line with `WCAG`

### Before
![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 15 14 03](https://user-images.githubusercontent.com/2637355/107430190-72739100-6aea-11eb-8a09-01a9628b178d.png)


### After
![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 15 15 40](https://user-images.githubusercontent.com/2637355/107430212-77384500-6aea-11eb-95c8-5ace3c88b775.png)
