### PR TITLE
Focus verification code input when user arrives on screen (accessibility)

### DIFF
--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -1,9 +1,4 @@
-import React, {
-  createRef,
-  FunctionComponent,
-  useCallback,
-  useState,
-} from "react"
+import React, { createRef, FunctionComponent, useEffect, useState } from "react"
 import {
   Alert,
   StyleSheet,
@@ -20,7 +15,6 @@ import {
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
-import { useFocusEffect } from "@react-navigation/native"
 
 import { Text, LoadingIndicator } from "../../components"
 import { useAffectedUserContext } from "../AffectedUserContext"
@@ -69,15 +63,15 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
   const [errorMessage, setErrorMessage] = useState(defaultErrorMessage)
   const [isFocused, setIsFocused] = useState(false)
 
-  useFocusEffect(
-    useCallback(() => {
+  useEffect(() => {
+    setTimeout(() => {
       codeInputRef.current?.focus()
       const reactTag = findNodeHandle(codeInputRef.current)
       if (reactTag) {
         AccessibilityInfo.setAccessibilityFocus(reactTag)
       }
-    }, [isFocused]),
-  )
+    }, 200)
+  }, [])
 
   const handleOnChangeText = (newCode: string) => {
     setCode(newCode)
@@ -249,6 +243,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
         <TextInput
           editable={isEditable}
           ref={codeInputRef}
+          accessible
           testID="code-input"
           value={code}
           placeholder={t("export.code").toUpperCase()}

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -51,7 +51,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
   const navigation = useNavigation()
   const strategy = useExposureContext()
   const { trackEvent } = useProductAnalyticsContext()
-  const codeInputRef = useRef<TextInput>()
+  const codeInputRef = useRef<TextInput>(null)
   const {
     setExposureSubmissionCredentials,
     setExposureKeys,

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, FunctionComponent, useEffect, useState } from "react"
+import React, { useRef, FunctionComponent, useEffect, useState } from "react"
 import {
   Alert,
   StyleSheet,
@@ -51,7 +51,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
   const navigation = useNavigation()
   const strategy = useExposureContext()
   const { trackEvent } = useProductAnalyticsContext()
-  const codeInputRef = createRef<TextInput>()
+  const codeInputRef = useRef<TextInput>()
   const {
     setExposureSubmissionCredentials,
     setExposureKeys,
@@ -65,10 +65,12 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
 
   useEffect(() => {
     setTimeout(() => {
-      codeInputRef.current?.focus()
-      const reactTag = findNodeHandle(codeInputRef.current)
-      if (reactTag) {
-        AccessibilityInfo.setAccessibilityFocus(reactTag)
+      if (codeInputRef.current) {
+        codeInputRef.current?.focus()
+        const reactTag = findNodeHandle(codeInputRef.current)
+        if (reactTag) {
+          AccessibilityInfo.setAccessibilityFocus(reactTag)
+        }
       }
     }, 200)
   }, [])

--- a/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
+++ b/src/AffectedUserFlow/CodeInput/CodeInputForm.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, useState } from "react"
+import React, {
+  createRef,
+  FunctionComponent,
+  useCallback,
+  useState,
+} from "react"
 import {
   Alert,
   StyleSheet,
@@ -9,10 +14,13 @@ import {
   KeyboardAvoidingView,
   Platform,
   TouchableOpacity,
+  findNodeHandle,
+  AccessibilityInfo,
 } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTranslation } from "react-i18next"
 import { SvgXml } from "react-native-svg"
+import { useFocusEffect } from "@react-navigation/native"
 
 import { Text, LoadingIndicator } from "../../components"
 import { useAffectedUserContext } from "../AffectedUserContext"
@@ -49,6 +57,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
   const navigation = useNavigation()
   const strategy = useExposureContext()
   const { trackEvent } = useProductAnalyticsContext()
+  const codeInputRef = createRef<TextInput>()
   const {
     setExposureSubmissionCredentials,
     setExposureKeys,
@@ -59,6 +68,16 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState(defaultErrorMessage)
   const [isFocused, setIsFocused] = useState(false)
+
+  useFocusEffect(
+    useCallback(() => {
+      codeInputRef.current?.focus()
+      const reactTag = findNodeHandle(codeInputRef.current)
+      if (reactTag) {
+        AccessibilityInfo.setAccessibilityFocus(reactTag)
+      }
+    }, [isFocused]),
+  )
 
   const handleOnChangeText = (newCode: string) => {
     setCode(newCode)
@@ -229,6 +248,7 @@ const CodeInputForm: FunctionComponent<CodeInputFormProps> = ({ linkCode }) => {
         </View>
         <TextInput
           editable={isEditable}
+          ref={codeInputRef}
           testID="code-input"
           value={code}
           placeholder={t("export.code").toUpperCase()}


### PR DESCRIPTION
#### Why:
Screen reader does not know there is a Code textbox because the initial page focus is on the Next Button (WCAG 2.4.3)

#### This commit:
This commit shifts focus to the verification code input field when the user first arrives on screen. The timeout is necessary to avoid announcing the back button first each time the user arrives on this screen.