### PR TITLE
Only send exposure notification received analytics event if new exposure is found

### DIFF
--- a/ios/BT/Storage/BTSecureStorage.swift
+++ b/ios/BT/Storage/BTSecureStorage.swift
@@ -166,7 +166,9 @@ class BTSecureStorage {
     try! realmInstance.write {
       userState.exposures.append(objectsIn: exposures)
       let jsonString = userState.exposures.jsonStringRepresentation()
-      notificationCenter.post(name: .ExposuresDidChange, object: jsonString)
+      if !exposures.isEmpty {
+        notificationCenter.post(name: .ExposuresDidChange, object: jsonString)
+      }
     }
   }
 


### PR DESCRIPTION
### This commit:
This commit fixes a bug whereby the `en_notification_received` event was being sent on every exposure detection cycle.