### PR TITLE
Add titles to untitled screens for accessibility 

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -126,6 +126,7 @@
       "body1": "If you have received a verification code from {{healthAuthorityName}} for a positive COVID-19 test, you can submit the verification code on the following screen.",
       "body2": "If you do not have a code, but you do have a positive test, you will need to get a verification code from {{healthAuthorityName}} before continuing.",
       "header": "Do you have your verification code?",
+      "title": "Verification Code Info",
       "what_is_a": "What is a verification code?"
     },
     "never_mind_button_title": "Never mind",
@@ -373,7 +374,12 @@
     "protect_privacy": "How we protect your privacy",
     "select_language": "Select Language",
     "select_symptoms": "Select Symptoms",
-    "settings": "Settings"
+    "settings": "Settings",
+    "my_data": "My Data",
+    "request_callback": "Request Callback",
+    "welcome": "Welcome",
+    "activation": "Activation",
+    "self_assessment": "Self Assessment"
   },
   "self_assessment": {
     "age_range": {

--- a/src/navigation/ActivationStack.tsx
+++ b/src/navigation/ActivationStack.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react"
 import { createStackNavigator } from "@react-navigation/stack"
+import { useTranslation } from "react-i18next"
 
 import { ActivationStackScreen, ActivationStackScreens } from "./index"
 import ActivateExposureNotifications from "../Activation/ActivateExposureNotifications"
@@ -52,6 +53,7 @@ const ActivationStack: FunctionComponent = () => {
     screenName: ActivationStackScreens.ActivationSummary,
     component: ActivationSummary,
   }
+  const { t } = useTranslation()
 
   const activationSteps = [
     acceptTermsOfService,
@@ -71,7 +73,7 @@ const ActivationStack: FunctionComponent = () => {
       screenOptions={{
         ...Headers.headerMinimalOptions,
         headerLeft: applyHeaderLeftBackButton(),
-        headerTitle: () => null,
+        title: t("screen_titles.activation"),
       }}
     >
       {activationSteps.map((step) => {

--- a/src/navigation/AffectedUserFlowStack.tsx
+++ b/src/navigation/AffectedUserFlowStack.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react"
 import { createStackNavigator } from "@react-navigation/stack"
+import { useTranslation } from "react-i18next"
 
 import { AffectedUserProvider } from "../AffectedUserFlow/AffectedUserContext"
 import Start from "../AffectedUserFlow/Start"
@@ -29,6 +30,7 @@ const Stack = createStackNavigator<AffectedUserFlowStackParamList>()
 
 const AffectedUserStack: FunctionComponent = () => {
   const { isOnboardingComplete } = useOnboardingContext()
+  const { t } = useTranslation()
 
   return (
     <AffectedUserProvider isOnboardingComplete={isOnboardingComplete}>
@@ -40,6 +42,7 @@ const AffectedUserStack: FunctionComponent = () => {
           component={Start}
           options={{
             ...Headers.headerMinimalOptions,
+            title: t("export.intro.title"),
             headerLeft: applyHeaderLeftBackButton(),
           }}
         />
@@ -48,6 +51,7 @@ const AffectedUserStack: FunctionComponent = () => {
           component={VerificationCodeInfo}
           options={{
             ...Headers.headerMinimalOptions,
+            title: t("export.intro.title"),
             headerLeft: applyHeaderLeftBackButton(),
           }}
         />
@@ -56,6 +60,7 @@ const AffectedUserStack: FunctionComponent = () => {
           component={CodeInput}
           options={{
             ...Headers.headerMinimalOptions,
+            title: t("export.enter_verification_code"),
             headerLeft: applyHeaderLeftBackButton(),
           }}
         />
@@ -64,6 +69,7 @@ const AffectedUserStack: FunctionComponent = () => {
           component={SymptomOnsetDate}
           options={{
             ...Headers.headerMinimalOptions,
+            title: t("export.symptom_onset.symptoms"),
             headerLeft: applyHeaderLeftBackButton(),
           }}
         />

--- a/src/navigation/CallbackStack.tsx
+++ b/src/navigation/CallbackStack.tsx
@@ -29,6 +29,7 @@ const CallbackStack: FunctionComponent = () => {
       <Stack.Navigator
         screenOptions={{
           ...Headers.headerMinimalOptions,
+          title: "screen_titles.request_callback",
           headerLeft: applyHeaderLeftBackButton(),
         }}
       >

--- a/src/navigation/ExposureHistoryStack.tsx
+++ b/src/navigation/ExposureHistoryStack.tsx
@@ -3,6 +3,7 @@ import {
   createStackNavigator,
   StackNavigationOptions,
 } from "@react-navigation/stack"
+import { useTranslation } from "react-i18next"
 
 import ExposureHistoryScreen from "../ExposureHistory/index"
 import MoreInfo from "../ExposureHistory/MoreInfo"
@@ -26,6 +27,8 @@ const defaultScreenOptions: StackNavigationOptions = {
 }
 
 const ExposureHistoryStack: FunctionComponent = () => {
+  const { t } = useTranslation()
+
   return (
     <Stack.Navigator>
       <Stack.Screen
@@ -36,7 +39,10 @@ const ExposureHistoryStack: FunctionComponent = () => {
       <Stack.Screen
         name={ExposureHistoryStackScreens.MoreInfo}
         component={MoreInfo}
-        options={defaultScreenOptions}
+        options={{
+          ...defaultScreenOptions,
+          title: t("exposure_history.more_info_header"),
+        }}
       />
     </Stack.Navigator>
   )

--- a/src/navigation/HowItWorksStack.tsx
+++ b/src/navigation/HowItWorksStack.tsx
@@ -127,7 +127,7 @@ const HowItWorksStack: FunctionComponent<HowItWorksStackProps> = ({
   return (
     <Stack.Navigator
       screenOptions={{
-        title: "",
+        title: t("screen_titles.welcome"),
         headerLeft: applyHeaderLeftBackButton(),
         headerRight: headerRight,
         headerStyleInterpolator: HeaderStyleInterpolators.forNoAnimation,

--- a/src/navigation/ModalHeader.tsx
+++ b/src/navigation/ModalHeader.tsx
@@ -52,11 +52,11 @@ const ModalHeader: FunctionComponent<ModalHeaderProps> = ({
   }
 
   return (
-    <View style={style.container}>
+    <View accessibilityLabel={"header"} style={style.container}>
       <Text
         numberOfLines={10}
         style={style.headerText}
-        accessible={headerTitle !== ""}
+        accessible
         allowFontScaling={false}
       >
         {headerTitle}

--- a/src/navigation/SelfAssessmentStack.tsx
+++ b/src/navigation/SelfAssessmentStack.tsx
@@ -21,6 +21,7 @@ import { applyHeaderLeftBackButton } from "./HeaderLeftBackButton"
 
 import { Headers } from "../styles"
 import { applyModalHeader } from "./ModalHeader"
+import { useTranslation } from "react-i18next"
 
 const Stack = createStackNavigator()
 
@@ -31,6 +32,7 @@ type SelfAssessmentStackProps = {
 const SelfAssessmentStack: FunctionComponent<SelfAssessmentStackProps> = ({
   destinationOnCancel,
 }) => {
+  const { t } = useTranslation()
   const navigationBarOptions: StackNavigationOptions = {
     headerStyleInterpolator: HeaderStyleInterpolators.forNoAnimation,
   }
@@ -38,6 +40,7 @@ const SelfAssessmentStack: FunctionComponent<SelfAssessmentStackProps> = ({
   const defaultScreenOptions = {
     ...Headers.headerMinimalOptions,
     headerLeft: applyHeaderLeftBackButton(),
+    title: t("screen_titles.self_assessment"),
     headerRight: () => null,
   }
 

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -3,6 +3,7 @@ import {
   createStackNavigator,
   StackNavigationOptions,
 } from "@react-navigation/stack"
+import { useTranslation } from "react-i18next"
 
 import Settings from "../Settings/"
 import Legal from "../Settings/Legal"
@@ -25,6 +26,8 @@ const defaultScreenOptions: StackNavigationOptions = {
 }
 
 const SettingsStack: FunctionComponent = () => {
+  const { t } = useTranslation()
+
   return (
     <Stack.Navigator screenOptions={defaultScreenOptions}>
       <Stack.Screen
@@ -35,12 +38,18 @@ const SettingsStack: FunctionComponent = () => {
       <Stack.Screen
         name={SettingsStackScreens.Legal}
         component={Legal}
-        options={defaultScreenOptions}
+        options={{
+          ...defaultScreenOptions,
+          title: t("screen_titles.legal"),
+        }}
       />
       <Stack.Screen
         name={SettingsStackScreens.DeleteConfirmation}
         component={DeleteConfirmation}
-        options={defaultScreenOptions}
+        options={{
+          ...defaultScreenOptions,
+          title: t("screen_titles.my_data"),
+        }}
       />
       <Stack.Screen
         name={SettingsStackScreens.ENDebugMenu}


### PR DESCRIPTION
## Why:
We'd like the app to be accessible for visually impaired users

### This commit:
This commit adds titles to previously untitled screens to bring the UI in line with `WCAG` guidelines.

![IMG_2635](https://user-images.githubusercontent.com/2637355/108145421-02887c00-7091-11eb-9230-e0ee9cfa01d6.PNG)
![IMG_2634](https://user-images.githubusercontent.com/2637355/108145431-087e5d00-7091-11eb-9158-db9aefc30b9b.PNG)
![IMG_2633](https://user-images.githubusercontent.com/2637355/108145436-0caa7a80-7091-11eb-91e0-1e3d7a380a8f.PNG)
![IMG_2632](https://user-images.githubusercontent.com/2637355/108145441-0e743e00-7091-11eb-8508-e357890ce0e2.PNG)
