### PR TITLE
Remove --poll flag from i18n script

### DIFF
--- a/src/locales/push.sh
+++ b/src/locales/push.sh
@@ -37,6 +37,5 @@ lokalise2 file upload \
   --detect-icu-plurals \
   --apply-tm \
   --convert-placeholders \
-  --poll \
   --config .lokalise.yml \
   --token=$LOKALISE_READ_WRITE_TOKEN


### PR DESCRIPTION
### Why:
Running `yarn i18n:push` results in an "unknown flag" error on the command line due to the `--poll` flag.

### This Commit:

This commit removes the `--poll` flag from the script.
