### PR TITLE
Gaen 686 - Prompt for airplane mode events

### DIFF
--- a/src/ExposureHistory/History/index.tsx
+++ b/src/ExposureHistory/History/index.tsx
@@ -95,6 +95,12 @@ const History: FunctionComponent<HistoryProps> = ({
             ),
           )
           break
+        case "DataInaccessible":
+          showAlert(
+            t("exposure_notification_alerts.requires_network_title"),
+            t("exposure_notification_alerts.requires_network_body"),
+          )
+          break
         default:
           showAlert(
             t("exposure_notification_alerts.unhandled_error_title"),

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -165,6 +165,7 @@ type DetectExposuresError =
   | "Unknown"
   | "NotEnabled"
   | "NotAuthorized"
+  | "DataInaccessible"
 
 export type DetectExposuresResponse =
   | DetectExposuresResponseSuccess
@@ -191,6 +192,8 @@ export const detectExposures = async (): Promise<DetectExposuresResponse> => {
         return { kind: "failure", error: "NotEnabled" }
       case "NotAuthorized":
         return { kind: "failure", error: "NotAuthorized" }
+      case "Unknown":
+        return { kind: "failure", error: "DataInaccessible" }
       default:
         Logger.error("Unhandled Error in detectExposures", { e })
         return { kind: "failure", error: "Unknown" }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -210,6 +210,8 @@
     "exposure_check_complete": "Exposure check complete",
     "location_body": "Google requires that devices running Android 10 or below have location services enabled to use Exposure Notifications. {{applicationName}} does NOT track or keep a record of your location.",
     "location_title": "Enable Location Services",
+    "requires_network_body": "Please disable airplane mode and enable mobile data or wifi.",
+    "requires_network_title": "Can't Connect To Network",
     "set_active_region_ios_body": "Open the Settings app, navigate to the Exposure Notifications settings for this app, then press 'Set As Active Region'.",
     "set_active_region_ios_title": "Set Active Region",
     "share_exposure_information_ios_body": "Open the Settings app, then navigate to the Exposure Notifications settings for this app. Ensure 'Share Exposure Information' is turned on, then press 'Set As Active Region'.",


### PR DESCRIPTION
Why:
GAEN-686

This commit:
If we cannot complete an exposure check due to network issues, I throw a DataInaccessible error and alert the user to turn off airplane mode and turn on wifi or data.

Screenshots:
How to test:
Open the app, navigate to "exposures" in the bottom tab bar, turn on airplane mode, and press "check for exposures" you should get a modal that prompts your to turn off airplane mode.

Linked issues:
GAEN-686