### PR TITLE
Changed nextsteps timestamp to be the number of days since the exposure.

### DIFF
--- a/src/ExposureHistory/History/NextSteps.tsx
+++ b/src/ExposureHistory/History/NextSteps.tsx
@@ -33,13 +33,21 @@ const NextSteps: FunctionComponent<NextStepsProps> = ({ exposureDate }) => {
   const { trackEvent } = useProductAnalyticsContext()
 
   const handleOnPressNextStep = () => {
+    const daysSince = calculateDaysSince(exposureDate)
     trackEvent(
       "product_analytics",
       "tapped_next_steps_button",
       "next_steps",
-      exposureDate,
+      daysSince,
     )
     Linking.openURL(healthAuthorityAdviceUrl)
+  }
+
+  const calculateDaysSince = (exposureDate: number) => {
+    const n = new Date()
+    const diffInTime = n.getTime() - exposureDate
+    const diffInDays = diffInTime / (1000 * 3600 * 24)
+    return diffInDays
   }
 
   const handleOnPressPersonalizeMyGuidance = () => {


### PR DESCRIPTION
#### Why:

<!-- Provide context to the reader as to why this PR is useful or needed. -->

We need to pass the number of days since an exposure rather than the timestamp to our dashboard. This is just a cheap way to do so on the client. 

<!-- Describe how this PR achieves the desired change in functionality. -->

I just compare the timestamp to the current timestamp, get the difference of days, then pass that like normal.

<!-- Provide screenshots or gif for visual changes -->

#### How to test:

<!-- Provide steps to test this PR -->

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->


---

<!-- Commits, PRs, and Code Review should follow these guidelines: -->

<!-- How to Write a Git Commit Message -->
<!-- https://chris.beams.io/posts/git-commit/ -->

<!-- The anatomy of a perfect pull request -->
<!-- https://medium.com/@hugooodias/the-anatomy-of-a-perfect-pull-request-567382bb6067 -->

<!-- Implementing a Strong Code-Review Culture -->
<!-- https://www.youtube.com/watch?v=PJjmw9TRB7s -->
