### PR TITLE
Onboarding UX Fix

### DIFF
--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent, RefObject, useEffect, useRef } from "react"
 import {
   ScrollView,
   SafeAreaView,
@@ -21,12 +21,18 @@ import { Spacing, Typography, Buttons, Colors, Iconography } from "../styles"
 const ActivateExposureNotifications: FunctionComponent = () => {
   const { t } = useTranslation()
   const { exposureNotifications } = usePermissionsContext()
+  const scrollViewRef = useRef<ScrollView>() as RefObject<ScrollView>
 
   const isENActive = exposureNotifications.status === "Active"
+
+  useEffect(() => {
+    scrollViewRef.current?.scrollToEnd({ animated: false })
+  }, [])
 
   return (
     <SafeAreaView style={style.safeArea}>
       <ScrollView
+        ref={scrollViewRef}
         style={style.container}
         contentContainerStyle={style.contentContainer}
         alwaysBounceVertical={false}


### PR DESCRIPTION
### Why:
When onboarding to the app on an iPhone 7 form factor after hitting "enable exposure notifications" the user needs to scroll down in order to "continue".

### This Commit
This commit programmatically scrolls to the bottom of the screen so that the "continue" button is visible when the user first arrives.

![Mar-11-2021 21-07-37](https://user-images.githubusercontent.com/2637355/110886708-b656e300-82ae-11eb-8341-d28e6d322842.gif)
