### PR TITLE
Gaen 319

### DIFF
--- a/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.spec.ts
@@ -120,7 +120,7 @@ describe("postDiagnosisKeys", () => {
     it("returns a no-op EmptyExposureKeys response if the error corresponds", async () => {
       const newKeysInserted = 0
       const message =
-        "unable to validate diagnosis verification: calculating expected HMAC: cannot calculate hmac on empty exposure keys"
+        "Looks like you have no exposure keys, this means that your device hasn't generated any yet. Please wait an hour for them to be generated."
       const jsonResponse = {
         error: message,
         insertedExposures: newKeysInserted,

--- a/src/AffectedUserFlow/exposureNotificationAPI.ts
+++ b/src/AffectedUserFlow/exposureNotificationAPI.ts
@@ -78,7 +78,7 @@ class PostDiagnosisKeysRequest {
   private static RETRY_STATUS_CODES = [429, 503]
   private static INTERNAL_ERROR = "internal_error"
   private static EMPTY_EXPOSURE_KEYS =
-    "unable to validate diagnosis verification: calculating expected HMAC: cannot calculate hmac on empty exposure keys"
+    "Looks like you have no exposure keys, this means that your device hasn't generated any yet. Please wait an hour for them to be generated."
   private static EXISTING_KEYS_SENT_RESPONSE =
     "no revision token, but sent existing keys"
   private static TIMEOUT = 5000


### PR DESCRIPTION
#### Why:

This just makes the text of our empty-key error more user-friendly.

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->

#### Screenshots:

I couldn't actually reproduce this on a physical android. No error showed up when following the ticket steps.
But essentially:
This:  "unable to validate diagnosis verification: calculating expected HMAC: cannot calculate hmac on empty exposure keys."
Is now this: "Looks like you have no exposure keys, this means that your device hasn't generated any yet. Please wait an hour for them to be generated."


#### How to test:

<!-- Provide steps to test this PR -->

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->


---

<!-- Commits, PRs, and Code Review should follow these guidelines: -->

<!-- How to Write a Git Commit Message -->
<!-- https://chris.beams.io/posts/git-commit/ -->

<!-- The anatomy of a perfect pull request -->
<!-- https://medium.com/@hugooodias/the-anatomy-of-a-perfect-pull-request-567382bb6067 -->

<!-- Implementing a Strong Code-Review Culture -->
<!-- https://www.youtube.com/watch?v=PJjmw9TRB7s -->
