### PR TITLE
GAEN-645, checking for phone numbers used every 5 minutes in callbac…

### DIFF
--- a/src/Activation/ActivateExposureNotifications.tsx
+++ b/src/Activation/ActivateExposureNotifications.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, RefObject, useEffect, useRef } from "react"
+import React, { FunctionComponent } from "react"
 import {
   ScrollView,
   SafeAreaView,
@@ -21,18 +21,12 @@ import { Spacing, Typography, Buttons, Colors, Iconography } from "../styles"
 const ActivateExposureNotifications: FunctionComponent = () => {
   const { t } = useTranslation()
   const { exposureNotifications } = usePermissionsContext()
-  const scrollViewRef = useRef<ScrollView>() as RefObject<ScrollView>
 
   const isENActive = exposureNotifications.status === "Active"
-
-  useEffect(() => {
-    scrollViewRef.current?.scrollToEnd({ animated: false })
-  }, [])
 
   return (
     <SafeAreaView style={style.safeArea}>
       <ScrollView
-        ref={scrollViewRef}
         style={style.container}
         contentContainerStyle={style.contentContainer}
         alwaysBounceVertical={false}

--- a/src/Callback/Form.spec.tsx
+++ b/src/Callback/Form.spec.tsx
@@ -7,11 +7,15 @@ import Form from "./Form"
 import { CallbackStackScreens } from "../navigation"
 import Logger from "../logger"
 import { Alert } from "react-native"
+import AsyncStorage from "@react-native-community/async-storage"
 
 jest.mock("./callbackAPI")
 jest.mock("@react-navigation/native")
 jest.mock("../logger.ts")
 describe("Form", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
   describe("on a successful call back requested", () => {
     it("navigates to the success screen", async () => {
       expect.assertions(1)
@@ -43,6 +47,9 @@ describe("Form", () => {
         error: errorNature,
         message: errorMessage,
       }
+
+      // We need to reset the submission timer to test a response error.
+      AsyncStorage.setItem("LastSubmission", "1618250000")
       ;(postCallbackInfo as jest.Mock).mockResolvedValueOnce(errorResponse)
       const { getByText, getByLabelText, getByTestId } = render(<Form />)
 
@@ -61,11 +68,15 @@ describe("Form", () => {
     })
   })
 
+  // This test aims to spy on our alert and logger errors on the UI.
+  // Used for generic errors on the UI and CallbackAPI
   describe("on a error for a requested call back", () => {
     it("shows an alert to the user and logs the error", async () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const loggErrorSpy = jest.spyOn(Logger, "error")
       const errorMessage = "errorMessage"
+
+      AsyncStorage.removeItem("LastSubmission")
       ;(postCallbackInfo as jest.Mock).mockRejectedValueOnce(
         new Error(errorMessage),
       )
@@ -81,6 +92,34 @@ describe("Form", () => {
         )
         expect(loggErrorSpy).toHaveBeenCalledWith(
           `FailureToRequestCallback.exception.${errorMessage}`,
+        )
+      })
+    })
+
+    it("shows a maximum submissions alert to the user and logs the error", async () => {
+      const alertSpy = jest.spyOn(Alert, "alert")
+      const loggMetadataSpy = jest.spyOn(Logger, "addMetadata")
+      const errorMessage =
+        "You have reached the max number of submissions, please wait 5 minutes to resubmit."
+
+      // We need to reset the submission timer to test a response error.
+      const now = new Date().getTime().toString()
+      AsyncStorage.setItem("LastSubmission", now)
+      const { getByLabelText, getByTestId } = render(<Form />)
+
+      fireEvent.changeText(getByTestId("phone-number-input"), "1234567890")
+      fireEvent.press(getByLabelText("Submit"))
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Maximum submissions reached.",
+          errorMessage,
+        )
+        expect(loggMetadataSpy).toHaveBeenCalledWith(
+          "requestCallbackTooManySubmissions",
+          {
+            errorMessage: errorMessage,
+          },
         )
       })
     })

--- a/src/ExposureHistory/History/NextSteps.tsx
+++ b/src/ExposureHistory/History/NextSteps.tsx
@@ -33,21 +33,13 @@ const NextSteps: FunctionComponent<NextStepsProps> = ({ exposureDate }) => {
   const { trackEvent } = useProductAnalyticsContext()
 
   const handleOnPressNextStep = () => {
-    const daysSince = calculateDaysSince(exposureDate)
     trackEvent(
       "product_analytics",
       "tapped_next_steps_button",
       "next_steps",
-      daysSince,
+      exposureDate,
     )
     Linking.openURL(healthAuthorityAdviceUrl)
-  }
-
-  const calculateDaysSince = (exposureDate: number) => {
-    const n = new Date()
-    const diffInTime = n.getTime() - exposureDate
-    const diffInDays = diffInTime / (1000 * 3600 * 24)
-    return diffInDays
   }
 
   const handleOnPressPersonalizeMyGuidance = () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,7 +23,7 @@
     "continue": "Continue",
     "done": "Done",
     "edit": "Edit",
-    "hascode": "Already have a code? ",
+    "hascode": "Already have a code?",
     "learn_more": "Learn more",
     "maybe_later": "Maybe later",
     "more": "More",
@@ -72,6 +72,7 @@
   },
   "errors": {
     "description": "An error has occurred. Please reload the app.",
+    "maxed_submission_requests": "You have reached the max number of submissions, please wait 15 minutes to resubmit.",
     "reload": "Reload",
     "something_went_wrong": "Something went wrong",
     "title": "Unknown Error",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -71,8 +71,11 @@
     "wear_a_face_covering": "wear a face covering."
   },
   "errors": {
+    "authorization_failure": "You are not authorized to perform this action.",
     "description": "An error has occurred. Please reload the app.",
-    "maxed_submission_requests": "You have reached the max number of submissions, please wait 15 minutes to resubmit.",
+    "invalid_phone_number": "Phone number must be 10 digits",
+    "maxed_submission_header": "Maximum submissions reached.",
+    "maxed_submission_requests": "You have reached the max number of submissions, please wait 5 minutes to resubmit.",
     "reload": "Reload",
     "something_went_wrong": "Something went wrong",
     "title": "Unknown Error",


### PR DESCRIPTION
…k form

#### Why:

Users can repeatedly spam the callback form with their phone number, this solution makes a timestamp on the first submit and saves the phone number. Only after 15 minutes can that phone number be reused on the same device.

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->

#### Screenshots:

<!-- Provide screenshots or gif for visual changes -->

#### How to test:

<!-- Provide steps to test this PR -->

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->


---

<!-- Commits, PRs, and Code Review should follow these guidelines: -->

<!-- How to Write a Git Commit Message -->
<!-- https://chris.beams.io/posts/git-commit/ -->

<!-- The anatomy of a perfect pull request -->
<!-- https://medium.com/@hugooodias/the-anatomy-of-a-perfect-pull-request-567382bb6067 -->

<!-- Implementing a Strong Code-Review Culture -->
<!-- https://www.youtube.com/watch?v=PJjmw9TRB7s -->
