### PR TITLE
Prevent long navigation titles from colliding with back button

### DIFF
--- a/src/styles/headers.ts
+++ b/src/styles/headers.ts
@@ -31,4 +31,8 @@ export const headerMinimalOptions: StackNavigationOptions = {
   title: "",
   headerShown: true,
   headerStyle: { shadowColor: Colors.transparent.invisible },
+  headerTitleContainerStyle: {
+    width: "60%",
+    alignItems: "center",
+  },
 }


### PR DESCRIPTION
#### Why:
We'd like long navigation titles to be handled by an ellipsis rather than having them overlap with the back button text on small devices

#### This commit:
This commit caps the title area width at 60% of the total screen width, ensuring that no collisions will occur

#### Screenshots:

Before:
![LA 1 11 1 - Overlapping - Do you have your verification code 3](https://user-images.githubusercontent.com/2637355/111641709-65be1900-87cb-11eb-9358-912ec00d11cc.jpg)


After:
![Simulator Screen Shot - iPhone 8 - 2021-03-18 at 09 16 45](https://user-images.githubusercontent.com/2637355/111641743-6e165400-87cb-11eb-9726-27561a20fbcc.png)
