### PR TITLE
Chaff Requests Implementation (iOS)

### DIFF
--- a/ios/AppDelegate.m
+++ b/ios/AppDelegate.m
@@ -54,7 +54,8 @@
   center.delegate = self;
   
   [ExposureManager createSharedInstance];
-  [[ExposureManager shared] registerBackgroundTask];
+  [[ExposureManager shared] registerExposureDetectionBackgroundTask];
+  [[ExposureManager shared] registerChaffBackgroundTask];
 
   [RNSplashScreen showSplash:@"LaunchScreen" inRootView:rootView];
   

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -215,7 +215,7 @@ final class ExposureManager: NSObject {
     }, callback: callback)
   }
 
-  @objc func fetchChaffExposureKeys(callback: @escaping (ExposureKeysDictionaryArray?, ExposureManagerError?) -> Void) {
+  @objc func fetchChaffKeys(callback: @escaping (ExposureKeysDictionaryArray?, ExposureManagerError?) -> Void) {
     getDiagnosisKeys(transform: { (keys) -> ExposureKeysDictionaryArray in
       (keys ?? []).map { $0.chaffRepresentation }
     }, callback: callback)
@@ -636,7 +636,7 @@ private extension ExposureManager {
   }
 
   func performChaffRequest() {
-    fetchChaffExposureKeys { [weak self] (keyArray, error) in
+    fetchChaffKeys { [weak self] (keyArray, error) in
       if error != nil {
         print("error: \(error.debugDescription)")
       }

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -96,7 +96,7 @@ final class ExposureManager: NSObject {
     notificationCenter.addObserver(
       self,
       selector: #selector(scheduleChaffBackgroundTaskIfNeeded),
-      name: .ExposureNotificationStatusDidChange,
+      name: .ChaffRequestTriggered,
       object: nil
     )
   }

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -215,6 +215,12 @@ final class ExposureManager: NSObject {
     }, callback: callback)
   }
 
+  @objc func fetchChaffExposureKeys(callback: @escaping (ExposureKeysDictionaryArray?, ExposureManagerError?) -> Void) {
+    getDiagnosisKeys(transform: { (keys) -> ExposureKeysDictionaryArray in
+      (keys ?? []).map { $0.chaffRepresentation }
+    }, callback: callback)
+  }
+
 
   // MARK: == Exposure Detection ==
 
@@ -630,7 +636,7 @@ private extension ExposureManager {
   }
 
   func performChaffRequest() {
-    fetchExposureKeys { [weak self] (keyArray, error) in
+    fetchChaffExposureKeys { [weak self] (keyArray, error) in
       if error != nil {
         print("error: \(error.debugDescription)")
       }

--- a/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
+++ b/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
@@ -19,6 +19,15 @@ extension ENTemporaryExposureKey {
     ]
   }
 
+  var chaffRepresentation : [String: Any] {
+    return [
+      "key": keyData.base64EncodedString().shuffled(),
+      "rollingPeriod": rollingPeriod,
+      "rollingStartNumber": rollingStartNumber,
+      "transmissionRisk": transmissionRiskLevel
+    ]
+  }
+
   static func rollingStartNumber(_ date: Date) -> UInt32 {
     UInt32(Int(date.timeIntervalSince1970 / (24 * 60 * 60)) * Constants.intervalsPerRollingPeriod)
   }

--- a/ios/BT/Extensions/Foundation/Notification+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Notification+Extensions.swift
@@ -7,6 +7,7 @@ extension Notification.Name {
   public static let HMACKeyDidChange = Notification.Name(rawValue: "BTSecureStorageHMACKeyDidChange")
   public static let revisionTokenDidChange = Notification.Name(rawValue: "onRevisionTokenDidChange")
   public static let ExposuresDidChange = Notification.Name(rawValue: "onExposureRecordUpdated")
+  public static let ChaffRequestTriggered = Notification.Name(rawValue: "onChaffRequestTriggered")
   public static let ExposureNotificationStatusDidChange = Notification.Name(rawValue: "onEnabledStatusUpdated")
   public static let remainingDailyFileProcessingCapacityDidChange = Notification.Name(rawValue: "remainingDailyFileProcessingCapacityDidChange")
   public static let UrlOfMostRecentlyDetectedKeyFileDidChange = Notification.Name(rawValue: "UrlOfMostRecentlyDetectedKeyFileDidChange")

--- a/ios/BT/bridge/ExposureEventEmitter.m
+++ b/ios/BT/bridge/ExposureEventEmitter.m
@@ -2,6 +2,7 @@
 #import <React/RCTEventEmitter.h>
 
 // Notification/Event Names
+NSString *const onChaffRequestTriggered = @"onChaffRequestTriggered";
 NSString *const onEnabledStatusUpdated = @"onEnabledStatusUpdated";
 NSString *const onExposuresChanged = @"onExposureRecordUpdated";
 
@@ -31,6 +32,7 @@ RCT_EXPORT_MODULE();
   return @[
     onExposuresChanged,
     onEnabledStatusUpdated,
+    onChaffRequestTriggered
   ];
 }
 

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -492,7 +492,7 @@ class ExposureManagerUnitTests: XCTestCase {
     wait(for: [addNotificatiionRequestExpectation, removeNotificationsExpectation], timeout: 0)
   }
   
-  func testRegisterBackgroundTask() {
+  func testRegisterExposureDetectionBackgroundTask() {
     let registerExpectation = self.expectation(description: "A background task with the given identifier is registered")
     let bgSchedulerMock = BGTaskSchedulerMock()
     bgSchedulerMock.registerHandler = { identifier, launchHanlder in
@@ -500,11 +500,11 @@ class ExposureManagerUnitTests: XCTestCase {
       return true
     }
     let exposureManager = ExposureManager(backgroundTaskScheduler: bgSchedulerMock)
-    exposureManager.registerBackgroundTask()
+    exposureManager.registerExposureDetectionBackgroundTask()
     wait(for: [registerExpectation], timeout: 0)
   }
   
-  func testSubmitBackgroundTask() {
+  func testSubmitExposureDetectionBackgroundTask() {
     let mockEnManager = ENManagerMock()
     mockEnManager.exposureNotificationStatusHandler = {
       return .active
@@ -516,7 +516,35 @@ class ExposureManagerUnitTests: XCTestCase {
     }
     let exposureManager = ExposureManager(exposureNotificationManager: mockEnManager,
                                           backgroundTaskScheduler: bgSchedulerMock)
-    exposureManager.scheduleBackgroundTaskIfNeeded()
+    exposureManager.scheduleExposureDetectionBackgroundTaskIfNeeded()
+    wait(for: [submitExpectation], timeout: 0)
+  }
+
+  func testRegisterChaffBackgroundTask() {
+    let registerExpectation = self.expectation(description: "A background task with the given identifier is registered")
+    let bgSchedulerMock = BGTaskSchedulerMock()
+    bgSchedulerMock.registerHandler = { identifier, launchHanlder in
+      registerExpectation.fulfill()
+      return true
+    }
+    let exposureManager = ExposureManager(backgroundTaskScheduler: bgSchedulerMock)
+    exposureManager.registerChaffBackgroundTask()
+    wait(for: [registerExpectation], timeout: 0)
+  }
+
+  func testSubmitChaffBackgroundTask() {
+    let mockEnManager = ENManagerMock()
+    mockEnManager.exposureNotificationStatusHandler = {
+      return .active
+    }
+    let submitExpectation = self.expectation(description: "A background task request is submitted")
+    let bgSchedulerMock = BGTaskSchedulerMock()
+    bgSchedulerMock.submitHandler = { taskRequest in
+      submitExpectation.fulfill()
+    }
+    let exposureManager = ExposureManager(exposureNotificationManager: mockEnManager,
+                                          backgroundTaskScheduler: bgSchedulerMock)
+    exposureManager.scheduleChaffBackgroundTaskIfNeeded()
     wait(for: [submitExpectation], timeout: 0)
   }
 

--- a/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerUnitTests.swift
@@ -289,14 +289,18 @@ class ExposureManagerUnitTests: XCTestCase {
     let activateExpectation = self.expectation(description: "Activate gets called")
     let invalidateExpectation = self.expectation(description: "Invalidate gets called")
     
-    let registerNotificationExpectation = self.expectation(description: "Registers for authorization changes")
-    
+    let registerExposureNotificationsStatusNotificationExpectation = self.expectation(description: "Registers for authorization changes")
+    let registerChaffRequestNotificationExpectation = self.expectation(description: "Registers for chaff request notifications")
+
     let setExposureNotificationEnabledTrueExpectation = self.expectation(description: "When activated, if disabled, request to enable exposure notifications")
     
     let notificationCenterMock = NotificationCenterMock()
     notificationCenterMock.addObserverHandler = { (_, _, name, _) in
       if name == Notification.Name.ExposureNotificationStatusDidChange {
-        registerNotificationExpectation.fulfill()
+        registerExposureNotificationsStatusNotificationExpectation.fulfill()
+      }
+      if name == Notification.Name.ChaffRequestTriggered {
+        registerChaffRequestNotificationExpectation.fulfill()
       }
     }
     
@@ -323,7 +327,8 @@ class ExposureManagerUnitTests: XCTestCase {
                         notificationCenter: notificationCenterMock)
     wait(for: [activateExpectation,
                invalidateExpectation,
-               registerNotificationExpectation,
+               registerExposureNotificationsStatusNotificationExpectation,
+               registerChaffRequestNotificationExpectation,
                setExposureNotificationEnabledTrueExpectation], timeout: 1)
   }
 

--- a/src/AffectedUserFlow/verificationAPI.ts
+++ b/src/AffectedUserFlow/verificationAPI.ts
@@ -113,6 +113,7 @@ export type TokenVerificationError =
 export const postTokenAndHmac = async (
   token: Token,
   hmacDigest: string,
+  chaff = false,
 ): Promise<
   NetworkResponse<TokenVerificationSuccess, TokenVerificationError>
 > => {
@@ -120,11 +121,14 @@ export const postTokenAndHmac = async (
     token,
     ekeyhmac: hmacDigest,
   }
+  const headers = chaff
+    ? { ...defaultHeaders, "X-Chaff": "any" }
+    : defaultHeaders
 
   try {
     const response = await fetch(certificateUrl, {
       method: "POST",
-      headers: defaultHeaders,
+      headers,
       body: JSON.stringify(data),
     })
 

--- a/src/AffectedUserFlow/verificationAPI.ts
+++ b/src/AffectedUserFlow/verificationAPI.ts
@@ -49,15 +49,20 @@ interface VerifiedCodeResponse {
 
 export const postCode = async (
   code: string,
+  isChaffRequest = false,
 ): Promise<NetworkResponse<CodeVerificationSuccess, CodeVerificationError>> => {
   const data = {
     code,
   }
 
+  const headers = isChaffRequest
+    ? { ...defaultHeaders, "x-chaff": "1" }
+    : defaultHeaders
+
   try {
     const response = (await fetchWithTimeout(verifyUrl, {
       method: "POST",
-      headers: defaultHeaders,
+      headers: headers,
       body: JSON.stringify(data),
     })) as Response
 
@@ -113,7 +118,7 @@ export type TokenVerificationError =
 export const postTokenAndHmac = async (
   token: Token,
   hmacDigest: string,
-  chaff = false,
+  isChaffRequest = false,
 ): Promise<
   NetworkResponse<TokenVerificationSuccess, TokenVerificationError>
 > => {
@@ -121,8 +126,8 @@ export const postTokenAndHmac = async (
     token,
     ekeyhmac: hmacDigest,
   }
-  const headers = chaff
-    ? { ...defaultHeaders, "X-Chaff": "any" }
+  const headers = isChaffRequest
+    ? { ...defaultHeaders, "x-Chaff": "1" }
     : defaultHeaders
 
   try {

--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -66,7 +66,8 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
     })
   }, [])
 
-  const sendChaffRequest = async () => {
+  const sendChaffRequest = useCallback(async () => {
+    const code = Math.random().toString().substring(2, 10)
     const response = await API.postCode(code, true)
 
     if (response.kind === "success") {
@@ -84,7 +85,7 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
     } else {
       trackEvent("epi_analytics", "chaff_request_failed")
     }
-  }
+  }, [trackEvent])
 
   const refreshExposureInfo = useCallback(async () => {
     const exposureInfo = await NativeModule.getCurrentExposures()
@@ -105,18 +106,16 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
     getLastExposureDetectionDate()
 
     // Chaff subscription
-    const chaffSubscription = NativeModule.subscribeToChaffRequestEvents(
-      (exposureInfo: ExposureInfo) => {
-        sendChaffRequest()
-      },
-    )
+    const chaffSubscription = NativeModule.subscribeToChaffRequestEvents(() => {
+      sendChaffRequest()
+    })
     sendChaffRequest()
 
     return () => {
       exposuresSubscription.remove()
       chaffSubscription.remove()
     }
-  }, [getLastExposureDetectionDate])
+  }, [getLastExposureDetectionDate, sendChaffRequest])
 
   useEffect(() => {
     const subscription = NativeModule.subscribeToExposureEvents(() => {

--- a/src/ExposureContext.tsx
+++ b/src/ExposureContext.tsx
@@ -67,14 +67,20 @@ const ExposureProvider: FunctionComponent = ({ children }) => {
   }, [])
 
   const sendChaffRequest = async () => {
-    const token = "inwoeif"
-    const exposureKeys = await NativeModule.fetchChaffKeys()
-    const [hmacDigest] = await calculateHmac(exposureKeys)
+    const response = await API.postCode(code, true)
 
-    const certResponse = await API.postTokenAndHmac(token, hmacDigest)
+    if (response.kind === "success") {
+      const token = response.body.token
+      const exposureKeys = await NativeModule.fetchChaffKeys()
+      const [hmacDigest] = await calculateHmac(exposureKeys)
 
-    if (certResponse.kind === "success") {
-      trackEvent("epi_analytics", "chaff_request_sent")
+      const certResponse = await API.postTokenAndHmac(token, hmacDigest, true)
+
+      if (certResponse.kind === "success") {
+        trackEvent("epi_analytics", "chaff_request_sent")
+      } else {
+        trackEvent("epi_analytics", "chaff_request_failed")
+      }
     } else {
       trackEvent("epi_analytics", "chaff_request_failed")
     }

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -46,6 +46,18 @@ export const subscribeToEnabledStatusEvents = (
   )
 }
 
+export const subscribeToChaffRequestEvents = (
+  cb: () => void,
+): EventSubscription => {
+  const ExposureEvents = new NativeEventEmitter(
+    NativeModules.ExposureEventEmitter,
+  )
+
+  return ExposureEvents.addListener("onChaffRequestTriggered", () => {
+    cb()
+  })
+}
+
 const toStatus = (data: string): ENPermissionStatus => {
   switch (data) {
     case "Unknown":
@@ -219,6 +231,17 @@ export const getExposureKeys = async (): Promise<ExposureKey[]> => {
   } else {
     Logger.error("Invalid expousre keys from native layer", { rawKeys })
     throw new Error("Invalid exposure keys from native layer")
+  }
+}
+
+export const fetchChaffKeys = async (): Promise<ExposureKey[]> => {
+  const rawKeys: RawExposureKey[] = await exposureKeyModule.fetchChaffKeys()
+  if (rawKeys.every(validRawExposureKey)) {
+    const exposureKeys = rawKeys.map(toExposureKey)
+    return exposureKeys
+  } else {
+    Logger.error("Invalid chaff keys from native layer", { rawKeys })
+    throw new Error("Invalid chaff keys from native layer")
   }
 }
 


### PR DESCRIPTION
#### Why:

Via APHL:

Summary: To provide improved levels of security APHL is strongly recommending the implementation of chaff (fake) requests to the Multi-tenant Verification Server and National Key Server.  Chaff requests have always been recommended as part of the privacy by design inherent in the Google/Apple Exposure Notifications framework.

The Multi-Tenant Verification Server (MVS) and National Key Server (NKS) provide temporary storage and transmission of the minimum information needed for exposure notifications. The infrastructure logs for these servers do include public IP addresses. Access to the server logs where this information is stored is secured and limited to a tightly controlled group of people for debugging or denial of service attack response only. APHL has mandatory access control policies in place, following the principle of least privilege and segregation of duty.

In addition to “real” requests, these servers also accept chaff (fake) requests. These can be used to obfuscate real traffic from a network observer or server operator. Chaff requests reduce the ability for an IP address to be correlated to a positive test. Chaff requests have always been recommended as part of the privacy by design inherent in the Google/Apple Exposure Notifications framework.

#### This commit:

This commit implements a background task on iOS that periodically sends chaff requests to the verification server.
