### PR TITLE
Added await to tracking events to ensure Matomo logs correctly.

### DIFF
--- a/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
+++ b/src/AffectedUserFlow/PublishConsent/PublishConsentForm.tsx
@@ -100,6 +100,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
       undefined,
       currentExposures.length,
     )
+    return
   }
 
   const noOpAlertContent = ({ reason, newKeysInserted }: PostKeysNoOp) => {
@@ -171,7 +172,7 @@ const PublishConsentForm: FunctionComponent<PublishConsentFormProps> = ({
     setIsLoading(false)
     if (response.kind === "success") {
       storeRevisionToken(response.revisionToken)
-      trackEvents()
+      await trackEvents()
       navigation.navigate(AffectedUserFlowStackScreens.AffectedUserComplete)
     } else if (response.kind === "no-op") {
       handleNoOpResponse(response)

--- a/src/EscrowVerification/VerificationCodeForm.tsx
+++ b/src/EscrowVerification/VerificationCodeForm.tsx
@@ -75,12 +75,13 @@ const VerificationCodeForm: FunctionComponent = () => {
       undefined,
       currentExposures.length,
     )
+    return
   }
 
   const handleOnPressSubmit = async () => {
     setIsLoading(true)
     setErrorMessage(defaultErrorMessage)
-    trackEvents()
+    await trackEvents()
     try {
       const response = await API.submitDiagnosisKeys(code, testDate)
 


### PR DESCRIPTION
#### Why:

Matomo tracking events (specifically ens_preceding_positive_diagnosis_count) aren't firing off correctly. By adding some async/await logic. We can ensure that the track event has time to fire off.

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->

#### Screenshots:

<!-- Provide screenshots or gif for visual changes -->

#### How to test:

<!-- Provide steps to test this PR -->

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->


---

<!-- Commits, PRs, and Code Review should follow these guidelines: -->

<!-- How to Write a Git Commit Message -->
<!-- https://chris.beams.io/posts/git-commit/ -->

<!-- The anatomy of a perfect pull request -->
<!-- https://medium.com/@hugooodias/the-anatomy-of-a-perfect-pull-request-567382bb6067 -->

<!-- Implementing a Strong Code-Review Culture -->
<!-- https://www.youtube.com/watch?v=PJjmw9TRB7s -->
