### PR TITLE
Gaen 798

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/MainApplication.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/MainApplication.java
@@ -17,9 +17,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.pathcheck.covidsafepaths.bridge.ExposureNotificationsPackage;
+import org.pathcheck.covidsafepaths.exposurenotifications.storage.RealmSecureStorageBte;
 
 public class MainApplication extends Application implements ReactApplication {
 
+  private static final long EXPOSURE_KEY_LIFESPAN = 14L;
   private static Context context;
 
   private final ReactNativeHost reactNativeHost =
@@ -55,9 +57,17 @@ public class MainApplication extends Application implements ReactApplication {
     MainApplication.context = getApplicationContext();
     AndroidThreeTen.init(this);
     SoLoader.init(this, /* native exopackage */ false);
-    Realm.init(this);
+    initializeRealm();
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());    
     initializeBugsnag();
+  }
+
+  /**
+   * Sets up the realm database and prunes off exposures that are beyond the 14 day expiration date.
+   */
+  private void initializeRealm() {
+    Realm.init(this);
+    RealmSecureStorageBte.INSTANCE.deleteExposureEntityOlderThan(EXPOSURE_KEY_LIFESPAN);
   }
 
   @SuppressWarnings("ConstantConditions")

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
@@ -56,7 +56,7 @@ public class DebugMenuModule extends ReactContextBaseJavaModule {
           RNDiagnosisKey diagnosisKey = new RNDiagnosisKey(key.getRollingStartIntervalNumber());
           diagnosisKeys.add(diagnosisKey);
         }
-
+ 
         promise.resolve(Util.convertListToWritableArray(diagnosisKeys));
       }
 
@@ -127,7 +127,7 @@ public class DebugMenuModule extends ReactContextBaseJavaModule {
                 promise.reject(exception);
               }
             };
-
+ 
             Futures.addCallback(
                 exposureNotificationsClient.requestPermissionToStartTracing(reactContext),
                 callback,

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
@@ -14,7 +14,6 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nonnull;
 import org.jetbrains.annotations.NotNull;
 import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
@@ -142,6 +141,7 @@ public class DebugMenuModule extends ReactContextBaseJavaModule {
     promise.resolve(RealmSecureStorageBte.INSTANCE.getLastProcessedKeyZipFileName());
   }
 
+  
   @ReactMethod
   public void addOldExposure(Promise promise) {
     long expiredDate = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(EXPOSURE_KEY_LIFESPAN);

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/DebugMenuModule.java
@@ -13,6 +13,8 @@ import com.google.common.util.concurrent.Futures;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nonnull;
 import org.jetbrains.annotations.NotNull;
 import org.pathcheck.covidsafepaths.exposurenotifications.ExposureNotificationClientWrapper;
@@ -21,6 +23,7 @@ import org.pathcheck.covidsafepaths.exposurenotifications.common.DebugConstants;
 import org.pathcheck.covidsafepaths.exposurenotifications.dto.RNDiagnosisKey;
 import org.pathcheck.covidsafepaths.exposurenotifications.nearby.ExposureNotificationBroadcastReceiver;
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.RealmSecureStorageBte;
+import org.pathcheck.covidsafepaths.exposurenotifications.storage.objects.ExposureEntity;
 import org.pathcheck.covidsafepaths.exposurenotifications.utils.Util;
 import org.threeten.bp.Instant;
 
@@ -28,6 +31,7 @@ import org.threeten.bp.Instant;
 @ReactModule(name = DebugMenuModule.MODULE_NAME)
 public class DebugMenuModule extends ReactContextBaseJavaModule {
   static final String MODULE_NAME = "DebugMenuModule";
+  static final long EXPOSURE_KEY_LIFESPAN = 14;
 
   public DebugMenuModule(ReactApplicationContext context) {
     super(context);
@@ -136,5 +140,12 @@ public class DebugMenuModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void showLastProcessedFilePath(Promise promise) {
     promise.resolve(RealmSecureStorageBte.INSTANCE.getLastProcessedKeyZipFileName());
+  }
+
+  @ReactMethod
+  public void addOldExposure(Promise promise) {
+    long expiredDate = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(EXPOSURE_KEY_LIFESPAN);
+    RealmSecureStorageBte.INSTANCE.insertExposure(ExposureEntity.create(expiredDate, expiredDate));
+    promise.resolve(null);
   }
 }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
@@ -8,6 +8,7 @@ import com.google.android.gms.nearby.exposurenotification.DailySummary
 import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.RealmResults
+import java.security.SecureRandom
 import org.pathcheck.covidsafepaths.MainApplication
 import org.pathcheck.covidsafepaths.exposurenotifications.dto.RNExposureInformation
 import org.pathcheck.covidsafepaths.exposurenotifications.storage.objects.ExposureEntity
@@ -18,7 +19,6 @@ import org.pathcheck.covidsafepaths.exposurenotifications.storage.objects.Sympto
 import org.threeten.bp.Duration
 import org.threeten.bp.Instant
 import org.threeten.bp.temporal.ChronoUnit
-import java.security.SecureRandom
 
 /**
  * Modified from GPS target to support Exposure Notification on-device data

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/storage/RealmSecureStorageBte.kt
@@ -33,7 +33,6 @@ object RealmSecureStorageBte {
     private const val MANUALLY_KEYED_KEY_INDEX = 2
     private const val MANUALLY_KEYED_PRESHARED_SECRET = "" // This will not be used as we do not support < 18
     private const val KEY_REALM_ENCRYPTION_KEY = "KEY_REALM_ENCRYPTION_KEY"
-    private const val EXPOSURE_KEY_LIFESPAN: Long = 14
 
     private val realmConfig: RealmConfiguration
 
@@ -49,8 +48,6 @@ object RealmSecureStorageBte {
             .apply {
                 realmConfig = build()
             }
-
-        deleteSymptomLogsOlderThan(EXPOSURE_KEY_LIFESPAN)
     }
 
     private fun getEncryptionKey(): ByteArray {
@@ -171,6 +168,20 @@ object RealmSecureStorageBte {
         getRealmInstance().use {
             it.executeTransaction { db ->
                 db.insert(exposure)
+            }
+        }
+    }
+
+    fun deleteExposureEntityOlderThan(days: Long) {
+        getRealmInstance().use {
+            it.executeTransaction { db ->
+                db.where(ExposureEntity::class.java)
+                    .lessThan(
+                        "dateMillisSinceEpoch",
+                        daysAgo(days)
+                    )
+                    .findAll()
+                    ?.deleteAllFromRealm()
             }
         }
     }

--- a/ios/BT/DebugAction.swift
+++ b/ios/BT/DebugAction.swift
@@ -4,5 +4,6 @@
   simulateExposure,
   fetchExposures,
   resetExposures,
-  showLastProcessedFilePath
+  showLastProcessedFilePath,
+  addOldExposure
 }

--- a/ios/BT/ExposureManager+Debug.swift
+++ b/ios/BT/ExposureManager+Debug.swift
@@ -11,12 +11,12 @@ import RealmSwift
 
 protocol ExposureManagerDebuggable {
   func handleDebugAction(_ action: DebugAction,
-                               resolve: @escaping RCTPromiseResolveBlock,
-                               reject: @escaping RCTPromiseRejectBlock)
+                         resolve: @escaping RCTPromiseResolveBlock,
+                         reject: @escaping RCTPromiseRejectBlock)
 }
 
 extension ExposureManager: ExposureManagerDebuggable {
-
+  
   @objc func handleDebugAction(_ action: DebugAction,
                                resolve: @escaping RCTPromiseResolveBlock,
                                reject: @escaping RCTPromiseRejectBlock) {
@@ -48,6 +48,17 @@ extension ExposureManager: ExposureManagerDebuggable {
     case .showLastProcessedFilePath:
       let path = btSecureStorage.userState.urlOfMostRecentlyDetectedKeyFile
       resolve(path)
+    case .addOldExposure:
+      // Store an old exposure in the phone's local storage to use later.
+      let oldExposure = Exposure(id: UUID().uuidString,
+                                 date: Date().posixRepresentation - 14 * 24 * 60 * 60 * 1000, weightedDurationSum: 2000.0)
+      // Append an old exposure to our list of exposures
+      btSecureStorage.exposures.append(oldExposure)
+      
+      // OR we can just store the exposure and forget the rest
+      //      btSecureStorage.storeExposures([oldExposure])s
+      notifyUserExposureDetected()
+      resolve("Exposures: \(btSecureStorage.userState.exposures)")
     }
   }
 }

--- a/ios/BT/bridge/DebugMenuModule.m
+++ b/ios/BT/bridge/DebugMenuModule.m
@@ -53,4 +53,11 @@ RCT_REMAP_METHOD(showLastProcessedFilePath,
   [[ExposureManager shared] handleDebugAction:DebugActionShowLastProcessedFilePath resolve:resolve reject:reject];
 }
 
+RCT_REMAP_METHOD(addOldExposure,
+                 addOldExposureResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [[ExposureManager shared] handleDebugAction:DebugActionAddOldExposure resolve:resolve reject:reject];
+}
+
 @end

--- a/ios/COVIDSafePathsTests/DebugMenuUnitTests.swift
+++ b/ios/COVIDSafePathsTests/DebugMenuUnitTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import BT
 
 class DebugMenuUnitTests: XCTestCase {
-
+  
   func testDebugFetchDiagnosisKeys() {
     let debugAction = DebugAction.fetchDiagnosisKeys
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -22,7 +22,7 @@ class DebugMenuUnitTests: XCTestCase {
     }
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDebugSimulateExposureDetectionError() {
     let debugAction = DebugAction.simulateExposureDetectionError
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -36,7 +36,7 @@ class DebugMenuUnitTests: XCTestCase {
     }
     wait(for: [successExpectactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDebugSimulateExposure() {
     let debugAction = DebugAction.simulateExposure
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -50,14 +50,14 @@ class DebugMenuUnitTests: XCTestCase {
     }
     wait(for: [successExpectactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDebugFetchExposures() {
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
     let debugAction = DebugAction.fetchExposures
     let successExpetactionResolve = self.expectation(description: "resolve is called")
     let successExpectationReject = self.expectation(description: "reject is not called")
     successExpectationReject.isInverted = true
-
+    
     exposureManager.handleDebugAction(debugAction, resolve: { (success) in
       successExpetactionResolve.fulfill()
     }) { (_, _, _) in
@@ -65,7 +65,7 @@ class DebugMenuUnitTests: XCTestCase {
     }
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 2)
   }
-
+  
   func testDebugResetExposures() {
     let debugAction = DebugAction.resetExposures
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -79,7 +79,7 @@ class DebugMenuUnitTests: XCTestCase {
     }
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 0)
   }
-
+  
   func testDebugShowLastProcessedFilePath() {
     let debugAction = DebugAction.showLastProcessedFilePath
     let exposureManager = defaultExposureManager(enAPIVersion: .v1)
@@ -93,6 +93,21 @@ class DebugMenuUnitTests: XCTestCase {
     }
     wait(for: [successExpetactionResolve, successExpectationReject], timeout: 0)
   }
-
-
+  
+  //  Test for if an old exposure is added
+  func addOldExposure() {
+    let debugAction = DebugAction.addOldExposure
+    let exposureManager = defaultExposureManager(enAPIVersion: .v1)
+    let successExpectactionResolve = self.expectation(description: "resolve is called")
+    let successExpectationReject = self.expectation(description: "reject is not called")
+    successExpectationReject.isInverted = true
+    exposureManager.handleDebugAction(debugAction, resolve: { (success) in
+      successExpectactionResolve.fulfill()
+    }) { (_, _, _) in
+      successExpectationReject.fulfill()
+    }
+    wait(for: [successExpectactionResolve, successExpectationReject], timeout: 0)
+  }
+  
+  
 }

--- a/src/Settings/ENDebugMenu.tsx
+++ b/src/Settings/ENDebugMenu.tsx
@@ -149,7 +149,6 @@ const ENDebugMenu: FunctionComponent<ENDebugMenuProps> = ({ navigation }) => {
             />
             <DebugMenuListItem
               label="Reset Exposures"
-              itemStyle={style.lastListItem}
               onPress={handleOnPressSimulationButton(
                 NativeModule.resetExposures,
               )}
@@ -158,6 +157,13 @@ const ENDebugMenu: FunctionComponent<ENDebugMenuProps> = ({ navigation }) => {
               label="Simulate Exposure Detection Error"
               onPress={handleOnPressSimulationButton(
                 NativeModule.simulateExposureDetectionError,
+              )}
+            />
+            <DebugMenuListItem
+              label="Add Old Exposure"
+              itemStyle={style.lastListItem}
+              onPress={handleOnPressSimulationButton(
+                NativeModule.addOldExposure,
               )}
             />
           </View>

--- a/src/gaen/nativeModule.ts
+++ b/src/gaen/nativeModule.ts
@@ -295,3 +295,7 @@ export const simulateExposureDetectionError = async (): Promise<"success"> => {
 export const resetExposures = async (): Promise<"success"> => {
   return debugModule.resetExposures()
 }
+
+export const addOldExposure = async (): Promise<"success"> => {
+  return debugModule.addOldExposure()
+}


### PR DESCRIPTION
#### Why:

We want to build a feature in the debug menu for testing the exposure filtering where we go to the debug menu and generate an "old exposure" that should input an exposure into the apps local database that is OLDER than 14 days old. The goal is that this exposure does NOT show up on the UI of the app, because the filtering should be working properly.

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->

#### Screenshots:

<!-- Provide screenshots or gif for visual changes -->

#### How to test:

Go to the EN debug menu in the app and select "Add old exposure".

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->


---

<!-- Commits, PRs, and Code Review should follow these guidelines: -->

<!-- How to Write a Git Commit Message -->
<!-- https://chris.beams.io/posts/git-commit/ -->

<!-- The anatomy of a perfect pull request -->
<!-- https://medium.com/@hugooodias/the-anatomy-of-a-perfect-pull-request-567382bb6067 -->

<!-- Implementing a Strong Code-Review Culture -->
<!-- https://www.youtube.com/watch?v=PJjmw9TRB7s -->
