### PR TITLE
Gaen add scroll view sympton onset date

### DIFF
--- a/src/AffectedUserFlow/SymptomOnsetDate.tsx
+++ b/src/AffectedUserFlow/SymptomOnsetDate.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, useState } from "react"
 import {
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -79,7 +80,7 @@ const SymptomOnsetDate: FunctionComponent = () => {
   const noSymptomsContainerStyle = localSymptomOnsetDate ? { opacity: 0.5 } : {}
 
   return (
-    <View style={style.container}>
+    <ScrollView style={style.container}>
       <View>
         <Text style={style.headerText}>
           {t("export.symptom_onset.symptoms")}
@@ -138,7 +139,7 @@ const SymptomOnsetDate: FunctionComponent = () => {
         <Text style={style.buttonText}>{t("common.continue")}</Text>
         <SvgXml xml={Icons.Arrow} fill={Colors.background.primaryLight} />
       </TouchableOpacity>
-    </View>
+    </ScrollView>
   )
 }
 

--- a/src/AffectedUserFlow/SymptomOnsetDate.tsx
+++ b/src/AffectedUserFlow/SymptomOnsetDate.tsx
@@ -80,7 +80,7 @@ const SymptomOnsetDate: FunctionComponent = () => {
   const noSymptomsContainerStyle = localSymptomOnsetDate ? { opacity: 0.5 } : {}
 
   return (
-    <ScrollView style={style.container}>
+    <ScrollView contentContainerStyle={style.container}>
       <View>
         <Text style={style.headerText}>
           {t("export.symptom_onset.symptoms")}


### PR DESCRIPTION
#### Why:

Some devices cannot see the proceed button after submitting an exposure and sharing.

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->

#### Screenshots:

<!-- Provide screenshots or gif for visual changes -->

#### How to test:

Submit an exposure code, share keys, and see the scrolling functionality on the Symptom Onset Date screen.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->


---

<!-- Commits, PRs, and Code Review should follow these guidelines: -->

<!-- How to Write a Git Commit Message -->
<!-- https://chris.beams.io/posts/git-commit/ -->

<!-- The anatomy of a perfect pull request -->
<!-- https://medium.com/@hugooodias/the-anatomy-of-a-perfect-pull-request-567382bb6067 -->

<!-- Implementing a Strong Code-Review Culture -->
<!-- https://www.youtube.com/watch?v=PJjmw9TRB7s -->
