### PR TITLE
GAEN-CheckForExposureError

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ProvideDiagnosisKeyService.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/nearby/ProvideDiagnosisKeyService.kt
@@ -81,7 +81,6 @@ class ProvideDiagnosisKeyService private constructor(context: Context) {
         }
     }
 
-    // ToDo Make sure the notification displays
     private fun sendNotification() {
         Observable.fromCallable {
             weakContext.get()?.run weakContext@{

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/reactmodules/ExposureHistoryModule.java
@@ -68,12 +68,21 @@ public class ExposureHistoryModule extends ReactContextBaseJavaModule {
           if (enabled) {
             ProvideDiagnosisKeyService service =
                 ProvideDiagnosisKeyService.getInstance(getReactApplicationContext().getApplicationContext());
+            addServiceSetupTime();
             service.downloadKeys(new DetectExposureCallback(promise, service));
           } else {
             promise.reject(new Exception(CallbackMessages.DEBUG_DETECT_EXPOSURES_ERROR_EN_NOT_ENABLED));
           }
         })
         .addOnFailureListener(promise::reject);
+  }
+
+  private void addServiceSetupTime() {
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   private final class DetectExposureCallback implements ProvideDiagnosisKeyService.DownloadDiagnosisKeyListener {


### PR DESCRIPTION
#### Why:

Upon clicking the "Check for Exposures" button on Android, the following message was being displayed to the user...

<img width="313" alt="Screen Shot 2021-09-02 at 2 00 08 AM" src="https://user-images.githubusercontent.com/81425648/131790419-f4a97976-da62-4257-b61b-c7c506eabee6.png">


#### This commit:

It was discovered that there was a race condition happening when setting up the `ProvideDiagnosisKeyService`. To allow a buffer window for the service to be setup properly, a short delay was added. 

Additionally, an old comment was removed because it was no longer relevant.

#### How to test:

1. Start up application
2. Navigate to "Exposures"
3. Click "Check for Exposures"
    - Expected result: There should be a message that prompts the user by saying "Exposure check complete".