### PR TITLE
Bugfix/Update gson from 2.8.6 to 2.8.9

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -252,7 +252,7 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "androidx.annotation:annotation:1.1.0"
     implementation 'com.bottlerocketstudios:vault:1.4.2'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.9'
 
     // Imports to support Exposure Notifications implementation based on Google sample
     // Annotation processing


### PR DESCRIPTION
#### Why:
Fixes a high severity vulnerability in gson library used

#### This commit:
Updates gson in android build to use 2.8.9

#### How to test:
Pull updated package, ensure builds and functions on android 

#### Linked issues:
Resolves #944 
