### PR TITLE
add 10s timeout to checking exposures notification

### DIFF
--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/common/NotificationHelper.java
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/exposurenotifications/common/NotificationHelper.java
@@ -63,6 +63,7 @@ public final class NotificationHelper {
     NotificationCompat.Builder builder =
         new Builder(context, BACKGROUND_WORKER_NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification)
+            .setTimeoutAfter(10000)
             .setColor(context.getResources().getColor(R.color.colorPrimary, context.getTheme()))
             .setContentTitle(context.getString(R.string.background_worker_notification_title));
     NotificationManagerCompat notificationManager = NotificationManagerCompat
@@ -75,6 +76,7 @@ public final class NotificationHelper {
     NotificationCompat.Builder builder =
             new Builder(context, BACKGROUND_WORKER_NOTIFICATION_CHANNEL_ID)
                     .setSmallIcon(R.drawable.ic_notification)
+                    .setTimeoutAfter(10000)
                     .setColor(context.getResources().getColor(R.color.colorPrimary, context.getTheme()))
                     .setContentTitle(context.getString(R.string.background_worker_notification_title))
                     .setOngoing(true);


### PR DESCRIPTION
#### Why:

<!-- Provide context to the reader as to why this PR is useful or needed. -->
The checking exposures notification on android would never vanish for some users

#### This commit:

<!-- Describe how this PR achieves the desired change in functionality. -->
Adds a 10s timeout to the notitication

#### Screenshots:

<!-- Provide screenshots or gif for visual changes -->

#### How to test:

<!-- Provide steps to test this PR -->

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->


---

<!-- Commits, PRs, and Code Review should follow these guidelines: -->

<!-- How to Write a Git Commit Message -->
<!-- https://chris.beams.io/posts/git-commit/ -->

<!-- The anatomy of a perfect pull request -->
<!-- https://medium.com/@hugooodias/the-anatomy-of-a-perfect-pull-request-567382bb6067 -->

<!-- Implementing a Strong Code-Review Culture -->
<!-- https://www.youtube.com/watch?v=PJjmw9TRB7s -->
